### PR TITLE
Use Proc.new instead of lambda for scoped_options

### DIFF
--- a/lib/kaminari/active_record_extension.rb
+++ b/lib/kaminari/active_record_extension.rb
@@ -17,9 +17,7 @@ module Kaminari
         kls.class_eval do
           # Fetch the values at the specified page number
           #   Model.page(5)
-          scope :page, lambda {|*num|
-            raise ArgumentError if num.size > 1
-            num = num.first || 1
+          scope :page, Proc.new {|num|
             limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
           } do
             # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope

--- a/lib/kaminari/mongoid_extension.rb
+++ b/lib/kaminari/mongoid_extension.rb
@@ -16,7 +16,7 @@ module Kaminari
       included do
         # Fetch the values at the specified page number
         #   Model.page(5)
-        scope :page, lambda {|num|
+        scope :page, Proc.new {|num|
           limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
         } do
           # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope


### PR DESCRIPTION
Same thing, but lambda is more strict in 1.9.2. Also fixes it in the mongo_extension too!
