### PR TITLE
Don't require active_record.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,10 @@ group :development do
   gem 'sqlite3', '>= 1.3.3'
   gem 'mongoid', '2.0.0.rc.7'
   gem 'bson_ext', '~> 1.2'
-  if RUBY_VERSION < '1.9'
+  platforms :mri_18 do
     gem 'ruby-debug'
-  else
+  end
+  platforms :mri_19 do
     gem 'ruby-debug19'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     abstract (1.0.0)
+    archive-tar-minitar (0.5.2)
     bcrypt-ruby (2.1.4)
     bson (1.2.2)
     bson_ext (1.2.2)
@@ -89,9 +90,10 @@ GEM
       bundler (~> 1.0.0)
       git (>= 1.2.5)
       rake
-      ruby-debug
     json_pure (1.5.1)
     linecache (0.43)
+    linecache19 (0.5.11)
+      ruby_core_source (>= 0.1.4)
     mail (2.2.15)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -134,6 +136,16 @@ GEM
       ruby-debug-base (~> 0.10.4.0)
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
+    ruby-debug-base19 (0.11.24)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.4)
+      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.4)
     selenium-webdriver (0.1.3)
       childprocess (~> 0.1.5)
@@ -168,5 +180,6 @@ DEPENDENCIES
   rspec (>= 2.5.0)
   rspec-rails (>= 2.5.0)
   ruby-debug
+  ruby-debug19
   sqlite3 (>= 1.3.3)
   steak (>= 1.1.0)

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,7 +1,5 @@
 require 'rails'
-require 'action_view'
 # ensure ORMs are loaded *before* initializing Kaminari
-begin; require 'active_record'; rescue LoadError; end
 begin; require 'mongoid'; rescue LoadError; end
 
 require File.join(File.dirname(__FILE__), 'helpers')
@@ -9,7 +7,7 @@ require File.join(File.dirname(__FILE__), 'helpers')
 module Kaminari
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'kaminari' do |app|
-      if defined? ::ActiveRecord
+      ActiveSupport.on_load(:active_record) do 
         require File.join(File.dirname(__FILE__), 'active_record_extension')
         ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
       end
@@ -18,7 +16,9 @@ module Kaminari
         ::Mongoid::Document.send :include, Kaminari::MongoidExtension::Document
         ::Mongoid::Criteria.send :include, Kaminari::MongoidExtension::Criteria
       end
-      ::ActionView::Base.send :include, Kaminari::Helpers
+      ActiveSupport.on_load(:action_view) do 
+        ::ActionView::Base.send :include, Kaminari::Helpers
+      end
     end
   end
 end


### PR DESCRIPTION
ORMにmongoidのみを使用している場合、active_recordは不要なため
ActiveSupport.on_load(:active_record)を使用し、active_recordがロードされたらActiveRecord::Baseへ
のinclude処理を実施するように変更してみました。

なお、mongiidは、ActiveSupport.on_load(:mongoid)を行っても動作しなかったため
そのままにしています。
