### PR TITLE
Refactor scope definition with Concerns

### DIFF
--- a/lib/kaminari/active_record_extension.rb
+++ b/lib/kaminari/active_record_extension.rb
@@ -1,9 +1,8 @@
+require File.join(File.dirname(__FILE__), 'active_record_relation_methods')
 module Kaminari
-  DEFAULT_PER_PAGE = 25 unless defined? ::Kaminari::DEFAULT_PER_PAGE
-
   module ActiveRecordExtension
     extend ActiveSupport::Concern
-
+    include Kaminari::ConfigurationMethods
     included do
       def self.inherited(kls) #:nodoc:
         # TERRIBLE HORRIBLE NO GOOD VERY BAD HACK: inheritable_attributes is not yet set here on AR 3.0
@@ -20,39 +19,8 @@ module Kaminari
           scope :page, Proc.new {|num|
             limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
           } do
-            # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
-            #   Model.page(3).per(10)
-            def per(num)
-              if (n = num.to_i) <= 0
-                self
-              else
-                limit(n).offset(offset_value / limit_value * n)
-              end
-            end
-
-            # Total number of pages
-            def num_pages
-              (except(:offset, :limit).count.to_f / limit_value).ceil
-            end
-
-            # Current page number
-            def current_page
-              (offset_value / limit_value) + 1
-            end
-          end
-
-          # Overrides the default per_page value per model
-          #   class Article < ActiveRecord::Base
-          #     paginates_per 10
-          #   end
-          def self.paginates_per(val)
-            @_default_per_page = val
-          end
-
-          # This model's default per_page value
-          # returns 25 unless explicitly overridden via <tt>paginates_per</tt>
-          def self.default_per_page
-            @_default_per_page || Kaminari::DEFAULT_PER_PAGE
+            include Kaminari::ActiveRecordRelationMethods
+            include Kaminari::PageScopeMethods
           end
         end
       end

--- a/lib/kaminari/active_record_relation_methods.rb
+++ b/lib/kaminari/active_record_relation_methods.rb
@@ -1,0 +1,10 @@
+module Kaminari
+  module ActiveRecordRelationMethods
+    extend ActiveSupport::Concern
+    module InstanceMethods
+      def pagination_count
+        except(:offset, :limit).count
+      end
+    end
+  end
+end

--- a/lib/kaminari/configuration_methods.rb
+++ b/lib/kaminari/configuration_methods.rb
@@ -1,0 +1,20 @@
+module Kaminari
+  module ConfigurationMethods
+    extend ActiveSupport::Concern
+    module ClassMethods
+      # Overrides the default per_page value per model
+      #   class Article < ActiveRecord::Base
+      #     paginates_per 10
+      #   end
+      def paginates_per(val)
+        @_default_per_page = val
+      end
+
+      # This model's default per_page value
+      # returns 25 unless explicitly overridden via <tt>paginates_per</tt>
+      def default_per_page
+        @_default_per_page || Kaminari::DEFAULT_PER_PAGE
+      end
+    end
+  end
+end

--- a/lib/kaminari/mongoid_criteria_methods.rb
+++ b/lib/kaminari/mongoid_criteria_methods.rb
@@ -1,0 +1,16 @@
+module Kaminari
+  module MongoidCriteriaMethods
+    extend ActiveSupport::Concern
+    module InstanceMethods
+      def limit_value
+        options[:limit]
+      end
+      def offset_value
+        options[:skip]
+      end
+      def pagination_count
+        count
+      end
+    end
+  end
+end

--- a/lib/kaminari/page_scope_methods.rb
+++ b/lib/kaminari/page_scope_methods.rb
@@ -1,0 +1,26 @@
+module Kaminari
+  module PageScopeMethods
+    extend ActiveSupport::Concern
+    module InstanceMethods
+      # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
+      #   Model.page(3).per(10)
+      def per(num)
+        if (n = num.to_i) <= 0
+          self
+        else
+          limit(n).offset(offset_value / limit_value * n)
+        end
+      end
+
+      # Total number of pages
+      def num_pages
+        (pagination_count.to_f / limit_value).ceil
+      end
+
+      # Current page number
+      def current_page
+        (offset_value / limit_value) + 1
+      end
+    end
+  end
+end

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -5,8 +5,11 @@ begin; require 'active_record'; rescue LoadError; end
 begin; require 'mongoid'; rescue LoadError; end
 
 require File.join(File.dirname(__FILE__), 'helpers')
+require File.join(File.dirname(__FILE__), 'page_scope_methods')
+require File.join(File.dirname(__FILE__), 'configuration_methods')
 
 module Kaminari
+  DEFAULT_PER_PAGE = 25 unless defined? ::Kaminari::DEFAULT_PER_PAGE
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'kaminari' do |app|
       if defined? ::ActiveRecord


### PR DESCRIPTION
Big refactor to remove code duplication in the Mongoid and ActiveRecord extensions. This should also make it easier to add support to other ORMs which have a similar Named Scope style API.

Lots of new modules, so you may want to do some reorganization and renaming. Having so many modules named *_method.rb feels a little dirty ;)
