### PR TITLE
ActiveRecord::Base inherited callback should call super

### DIFF
--- a/lib/kaminari/models/active_record_extension.rb
+++ b/lib/kaminari/models/active_record_extension.rb
@@ -24,6 +24,8 @@ module Kaminari
             include Kaminari::PageScopeMethods
           end
         end
+        
+        super
       end
     end
   end

--- a/spec/models/scopes_spec.rb
+++ b/spec/models/scopes_spec.rb
@@ -101,4 +101,9 @@ describe Kaminari::ActiveRecordExtension do
     its(:total_count) { should == 11 }
     its(:num_pages) { should == 3 }
   end
+
+  context 'activerecord descendants' do
+    subject { ActiveRecord::Base.descendants }
+    its(:length) { should_not == 0 }
+  end
 end


### PR DESCRIPTION
The `inherited` callback that is added by Kaminari fails to call `super`. This breaks the default callbacks added by ActiveRecord itself. One effect is that ActiveRecord::Base.descendants now always remains empty.

Please review the simple patch that I wrote to fix this issue. Thank you! 
