### PR TITLE
Remove :order from scopes used to count paginated set

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,7 +3,7 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        c = except(:offset, :limit, :order).count
         # .group returns an OrderdHash that responds to #count
         c.respond_to?(:count) ? c.count : c
       end


### PR DESCRIPTION
I'm currently using additional #select's in my scope chain, and I'm ordering by one of those selects. The #count call must drop any other selects (they're usually merged fine).

It was either try and fix here or fix deeper in AR :)

Seeing as the order doesn't affect the count I thought it was a reasonable change.

Let me know what you think - I'll add specs if you think it's worth it.
