### PR TITLE
Made mongoid version requirement more flexible.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
   gem 'arel', :git => 'git://github.com/rails/arel.git'
   gem 'rspec-rails', '>= 2.5.0'
   gem 'sqlite3', '>= 1.3.3'
-  gem 'mongoid', '2.0.0.rc.7'
+  gem 'mongoid', '>= 2.0.0.rc.7'
   gem 'bson_ext', '~> 1.2'
 #   platforms :mri_18 do
 #     gem 'ruby-debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
   specs:
     abstract (1.0.0)
     bcrypt-ruby (2.1.4)
-    bson (1.2.2)
+    bson (1.2.4)
     bson_ext (1.2.2)
     builder (3.0.0)
     capybara (0.4.1.2)
@@ -95,9 +95,9 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.16)
-    mongo (1.2.2)
-      bson (>= 1.2.2)
-    mongoid (2.0.0.rc.7)
+    mongo (1.2.4)
+      bson (>= 1.2.4)
+    mongoid (2.0.0.rc.8)
       activemodel (~> 3.0)
       mongo (~> 1.2)
       tzinfo (~> 0.3.22)
@@ -138,7 +138,7 @@ GEM
     thor (0.14.6)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
-    tzinfo (0.3.24)
+    tzinfo (0.3.25)
     will_paginate (3.0.pre2)
     xpath (0.1.3)
       nokogiri (~> 1.3)
@@ -152,7 +152,7 @@ DEPENDENCIES
   bundler (>= 1.0.0)
   capybara (>= 0.4.1.1)
   jeweler (>= 1.5.2)
-  mongoid (= 2.0.0.rc.7)
+  mongoid (>= 2.0.0.rc.7)
   rack!
   rails!
   rcov

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Akira Matsuda"]
-  s.date = %q{2011-02-24}
+  s.date = %q{2011-03-29}
   s.description = %q{Kaminari is a Scope & Engine based, clean, powerful, customizable and sophisticated paginator for Rails 3}
   s.email = %q{ronnie@dio.jp}
   s.extra_rdoc_files = [
@@ -78,7 +78,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/amatsuda/kaminari}
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.5.2}
+  s.rubygems_version = %q{1.3.7}
   s.summary = %q{A pagination engine plugin for Rails 3}
   s.test_files = [
     "spec/acceptance/acceptance_helper.rb",
@@ -96,6 +96,7 @@ Gem::Specification.new do |s|
   ]
 
   if s.respond_to? :specification_version then
+    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
@@ -111,7 +112,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<arel>, [">= 0"])
       s.add_development_dependency(%q<rspec-rails>, [">= 2.5.0"])
       s.add_development_dependency(%q<sqlite3>, [">= 1.3.3"])
-      s.add_development_dependency(%q<mongoid>, ["= 2.0.0.rc.7"])
+      s.add_development_dependency(%q<mongoid>, [">= 2.0.0.rc.7"])
       s.add_development_dependency(%q<bson_ext>, ["~> 1.2"])
       s.add_runtime_dependency(%q<rails>, [">= 3.0.0"])
     else
@@ -127,7 +128,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<arel>, [">= 0"])
       s.add_dependency(%q<rspec-rails>, [">= 2.5.0"])
       s.add_dependency(%q<sqlite3>, [">= 1.3.3"])
-      s.add_dependency(%q<mongoid>, ["= 2.0.0.rc.7"])
+      s.add_dependency(%q<mongoid>, [">= 2.0.0.rc.7"])
       s.add_dependency(%q<bson_ext>, ["~> 1.2"])
       s.add_dependency(%q<rails>, [">= 3.0.0"])
     end
@@ -144,7 +145,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<arel>, [">= 0"])
     s.add_dependency(%q<rspec-rails>, [">= 2.5.0"])
     s.add_dependency(%q<sqlite3>, [">= 1.3.3"])
-    s.add_dependency(%q<mongoid>, ["= 2.0.0.rc.7"])
+    s.add_dependency(%q<mongoid>, [">= 2.0.0.rc.7"])
     s.add_dependency(%q<bson_ext>, ["~> 1.2"])
     s.add_dependency(%q<rails>, [">= 3.0.0"])
   end

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -78,7 +78,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/amatsuda/kaminari}
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.7}
+  s.rubygems_version = %q{1.5.2}
   s.summary = %q{A pagination engine plugin for Rails 3}
   s.test_files = [
     "spec/acceptance/acceptance_helper.rb",
@@ -96,7 +96,6 @@ Gem::Specification.new do |s|
   ]
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then


### PR DESCRIPTION
A new mongoid gem dropped recently; it is up to version 2.0.0.rc.8. I have altered the Gemfile to require at least rc.7. This should allow both those who have and who have not yet upgraded to rc.8 to still use kaminari.
