### PR TITLE
Order count bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
   gem 'sqlite3', '>= 1.3.3'
   gem 'mongoid', '2.0.0.rc.7'
   gem 'bson_ext', '~> 1.2'
+  gem 'database_cleaner'
 #   platforms :mri_18 do
 #     gem 'ruby-debug'
 #   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     childprocess (0.1.7)
       ffi (~> 0.6.3)
     culerity (0.2.15)
+    database_cleaner (0.6.6)
     diff-lcs (1.1.2)
     erubis (2.6.6)
       abstract (>= 1.0.0)
@@ -151,6 +152,7 @@ DEPENDENCIES
   bson_ext (~> 1.2)
   bundler (>= 1.0.0)
   capybara (>= 0.4.1.1)
+  database_cleaner
   jeweler (>= 1.5.2)
   mongoid (= 2.0.0.rc.7)
   rack!

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,7 +3,8 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
+        c = except(:offset, :limit, :order).count
         # .group returns an OrderdHash that responds to #count
         c.respond_to?(:count) ? c.count : c
       end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -20,9 +20,39 @@ end
 
 # models
 class User < ActiveRecord::Base
-  default_scope order(:name)
+  has_many :authorships
+  has_many :readerships
+  has_many :books_authored, :through => :authorships, :source => :book
+  has_many :books_read, :through => :readerships, :source => :book
+
+  def readers
+    User.joins(:books_read => :authors).where(:authors_books => {:id => self})
+  end
+
+  scope :by_name, order(:name)
+  scope :by_read_count, lambda {
+    cols = if connection.adapter_name == "PostgreSQL"
+      column_names.map { |column| %{"users"."#{column}"} }.join(", ")
+    else
+      '"users"."id"'
+    end
+    group(cols).select("count(readerships.id) AS read_count, #{cols}").order('read_count DESC')
+  }
 end
-class Book < ActiveRecord::Base; end
+class Authorship < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :book
+end
+class Readership < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :book
+end
+class Book < ActiveRecord::Base
+  has_many :authorships
+  has_many :readerships
+  has_many :authors, :through => :authorships, :source => :user
+  has_many :readers, :through => :readerships, :source => :user
+end
 
 # controllers
 class ApplicationController < ActionController::Base; end
@@ -44,5 +74,7 @@ class CreateAllTables < ActiveRecord::Migration
   def self.up
     create_table(:users) {|t| t.string :name; t.integer :age}
     create_table(:books) {|t| t.string :title}
+    create_table(:readerships) {|t| t.integer :user_id; t.integer :book_id }
+    create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id }
   end
 end

--- a/spec/models/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record_relation_methods_spec.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe Kaminari::ActiveRecordRelationMethods do
+  describe '#total_count' do
+    before do
+      @author = User.create! :name => 'author'
+      @books = 2.times.map { @author.books_authored.create! }
+      @readers = 4.times.map { User.create! :name => 'reader' }
+      @books.each {|book| book.readers << @readers }
+    end
+
+    context "when the scope includes an order which references a generated column" do
+      it "should successfully count the results" do
+        @author.readers.by_read_count.page(1).total_count.should == @readers.size
+      end
+    end
+  end
+end

--- a/spec/models/scopes_spec.rb
+++ b/spec/models/scopes_spec.rb
@@ -2,7 +2,6 @@ require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe Kaminari::ActiveRecordExtension do
   before :all do
-    User.delete_all
     1.upto(100) {|i| User.create! :name => "user#{'%03d' % i}", :age => (i / 10)}
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rails'
 require 'mongoid'
 require 'kaminari'
+require 'database_cleaner'
 # Ensure we use 'syck' instead of 'psych' in 1.9.2
 # RubyGems >= 1.5.0 uses 'psych' on 1.9.2, but
 # Psych does not yet support YAML 1.1 merge keys.

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,13 @@
+DatabaseCleaner.strategy = :transaction
+
+RSpec.configure do |config|
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+  end
+  config.before :each do
+    DatabaseCleaner.start
+  end
+  config.after :each do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
This fixes errors of the sort:

SQLite3::SQLException: no such column: read_count: SELECT COUNT(*) AS count_all, "users"."id" AS users_id FROM "users" INNER JOIN "readerships" "readerships" ON "users"."id" = "readerships"."user_id" INNER JOIN "books" ON "books"."id" = "readerships"."book_id" INNER JOIN "authorships" "authorships" ON "books"."id" = "authorships"."book_id" INNER JOIN "users" "authors_books" ON "authors_books"."id" = "authorships"."user_id" WHERE "authors_books"."id" = 1 GROUP BY "users"."id" ORDER BY read_count DESC

generated by #total_count when the scope orders on a generated column, for example, when grouping.  See the associated test for the details.  Haven't tested it on Postgres yet, but will in a sec, and it works on sqlite3.
