### PR TITLE
TestHelpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pkg
 # log
 log
 
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore
@@ -43,3 +44,6 @@ log
 #
 # For vim:
 #*.swp
+
+#For RubyMine
+.idea

--- a/README.rdoc
+++ b/README.rdoc
@@ -144,7 +144,7 @@ Kaminari includes a handy template generator.
 
     % rails g kaminari:views default -e haml
 
-* themes
+*themes
 
   The generator has the ability to fetch several sample template themes from
   the external repository (https://github.com/amatsuda/kaminari_themes) in 
@@ -173,10 +173,27 @@ and then modify your controller spec to look like
 
 the stubs will return the values needed to set the pagination as being on the first and only page.
 If specific pagination values are needed they can be defined using a hash
-    stub_pagination_methods(mocked_result, :total_count => 50, :current_page => 3, :per_page => 10)
+    stub_pagination(mocked_result, :total_count => 50, :current_page => 3, :per_page => 10)
 
 will create the same pagination links as a total count of 50 elements are available, with 10
-elements per page and page 3 being the current_page
+elements per page and page 3 being the current_page.
+
+=== Detecting mocking framework
+
+If you are using RSpec >= 2.5.2 there is no need to explicitly pass the mocking framework you
+are using to the stub_pagination method, as it is automatically detected by the TestHelpers.
+For earlier versions you are required to explicitly use the same string you would pass to
++RSpec.configuration.mock_with+, so the actual method call is
+    stub_pagination(mocked_result, :mock => :rspec, :total_count => 50, :current_page => 3, :per_page => 10)
+
+=== Default values
+
+The TestHelpers will also try to guess values so that you don't need to explicitly pass them all.
+* +:per_page+ will default to 25
+* +:current_page+ will default to 1
+* +:total_page+ will default to 1 if the object passed as resource is not a collection, otherwise it will
+  invoke get the value from resource.length
+
 
 == For more information
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -183,15 +183,15 @@ elements per page and page 3 being the current_page.
 If you are using RSpec >= 2.5.2 there is no need to explicitly pass the mocking framework you
 are using to the stub_pagination method, as it is automatically detected by the TestHelpers.
 For earlier versions you are required to explicitly use the same string you would pass to
-+RSpec.configuration.mock_with+, so the actual method call is
++RSpec.configuration.mock_with+ , so the actual method call is
     stub_pagination(mocked_result, :mock => :rspec, :total_count => 50, :current_page => 3, :per_page => 10)
 
 === Default values
 
 The TestHelpers will also try to guess values so that you don't need to explicitly pass them all.
-* +:per_page+ will default to 25
-* +:current_page+ will default to 1
-* +:total_page+ will default to 1 if the object passed as resource is not a collection, otherwise it will
+* :per_page will default to 25
+* :current_page will default to 1
+* :total_page will default to 1 if the object passed as resource is not a collection, otherwise it will
   invoke get the value from resource.length
 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -157,6 +157,27 @@ Kaminari includes a handy template generator.
     % rails g kaminari:views
 
 
+
+== Rendering views with RSpec's render_view
+
+If you are rendering the views from your controller spec using render_views AND you are mocking
+the data returned from the db with something along the lines of
+    Model.stub_chain(:order, :page, :per).and_return([model_mock])
+
+you may want to also stub the methods needed by the pagination partials, in order to do that, just
+add the following to your +spec_helper+
+    config.include Kaminari::TestHelpers, :type => :controller
+
+and then modify your controller spec to look like
+    Model.stub_chain(:order, :page, :per).and_return(stub_pagination_methods([model_mock]))
+
+the stubs will return the values needed to set the pagination as being on the first and only page.
+If specific pagination values are needed they can be defined using a hash
+    stub_pagination_methods(mocked_result, :total_count => 50, :current_page => 3, :per_page => 10)
+
+will create the same pagination links as a total count of 50 elements are available, with 10
+elements per page and page 3 being the current_page
+
 == For more information
 
 Check out Kaminari recipes on the GitHub Wiki for more advanced tips and techniques.

--- a/lib/kaminari.rb
+++ b/lib/kaminari.rb
@@ -1,2 +1,3 @@
 require File.join(File.dirname(__FILE__), 'kaminari/railtie')
 require File.join(File.dirname(__FILE__), 'kaminari/engine')
+require File.join(File.dirname(__FILE__), 'kaminari/test_helpers')

--- a/lib/kaminari/test_helpers.rb
+++ b/lib/kaminari/test_helpers.rb
@@ -30,9 +30,9 @@ module Kaminari
 
       values = {}
       values[:total_count] = options[:total_count] || (resource.respond_to?(:length) ? resource.length : 1)
-      values[:per_page] = options[:per_page] || 25
-      values[:num_pages] = (values[:total_count] / values[:per_page]) + ((values[:total_count] % values[:per_page]) == 0 ? 0 : 1)
-      values[:current_page] = options[:current_page] || 1
+      values[:limit_value] = options[:per_page] || 25
+      values[:num_pages] = (values[:total_count] / values[:limit_value]) + ((values[:total_count] % values[:limit_value]) == 0 ? 0 : 1)
+      values[:current_page] = [(options[:current_page] || 1), values[:num_pages]].min
       return values
     end
 

--- a/lib/kaminari/test_helpers.rb
+++ b/lib/kaminari/test_helpers.rb
@@ -1,0 +1,18 @@
+module Kaminari
+  module TestHelpers
+
+    def stub_pagination_methods(resource, options={})
+      return nil unless resource
+      total_count = options[:total_count] || (resource.respond_to?(:length) ? resource.length : 1)
+      per_page = options[:per_page] || 25
+      num_pages = (total_count / per_page) + 1
+      current_page = options[:current_page] || 1
+      resource.stub(:current_page).and_return(current_page)
+      resource.stub(:num_pages).and_return(num_pages)
+      resource.stub(:limit_value).and_return(per_page)
+      # redundant return, but makes it clearer
+      return resource
+    end
+
+  end
+end

--- a/lib/kaminari/test_helpers.rb
+++ b/lib/kaminari/test_helpers.rb
@@ -1,17 +1,81 @@
 module Kaminari
   module TestHelpers
 
-    def stub_pagination_methods(resource, options={})
+    def stub_pagination(resource, options={})
       return nil unless resource
-      total_count = options[:total_count] || (resource.respond_to?(:length) ? resource.length : 1)
-      per_page = options[:per_page] || 25
-      num_pages = (total_count / per_page) + 1
-      current_page = options[:current_page] || 1
-      resource.stub(:current_page).and_return(current_page)
-      resource.stub(:num_pages).and_return(num_pages)
-      resource.stub(:limit_value).and_return(per_page)
-      # redundant return, but makes it clearer
+      mock_framework = options[:mock] || :rr
+      values = calculate_values(resource, options)
+      case mock_framework
+        when :rspec then stub_pagination_with_rspec(resource, values)
+        when :rr then stub_pagination_with_rr(resource, values)
+        when :mocha then stub_pagination_with_mocha(resource, values)
+        when :flexmock then stub_pagination_with_flexmock(resource, values)
+        when :nothing then resource
+        else
+          raise ArgumentError, "Invalid mock argument #{options[:mock]} / framework not supported"
+      end
+    end
+
+    def discover_mock_framework
+
+      mock_framework = RSpec.configuration.mock_framework
+      return mock_framework.framework_name if mock_framework.respond_to? :framework_name
+      puts("WARNING: Could not detect mocking framework, defaulting to :nothing, use :mock option to override")
+      return :nothing
+
+    end
+
+
+    def calculate_values(resource, options={})
+
+      values = {}
+      values[:total_count] = options[:total_count] || (resource.respond_to?(:length) ? resource.length : 1)
+      values[:per_page] = options[:per_page] || 25
+      values[:num_pages] = (values[:total_count] / values[:per_page]) + ((values[:total_count] % values[:per_page]) == 0 ? 0 : 1)
+      values[:current_page] = options[:current_page] || 1
+      return values
+    end
+
+    def stub_pagination_with_rspec(resource, values)
+
+      values.each do |key, value |
+        resource.stub(key).and_return(value)
+      end
+
       return resource
+
+    end
+
+    def stub_pagination_with_rr(resource, values)
+
+      values.each do |key, value|
+        eval "stub(resource).#{key} { #{value} }"
+      end
+
+      return resource
+
+    end
+
+    def stub_pagination_with_mocha(resource, values)
+
+      values.each do |key, value|
+        resource.stubs(key).returns(value)
+      end
+
+      return resource
+
+    end
+
+    def stub_pagination_with_flexmock(resource, values)
+
+      mock = flexmock(resource)
+
+      values.each do |key, value|
+        mock.should_receive(key).zero_or_more_times.and_return(value)
+      end
+
+      return mock
+
     end
 
   end

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -1,0 +1,167 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+include Kaminari::TestHelpers
+
+describe "Kaminari::TestHelpers::" do
+
+  describe "discover_mock_framework" do
+
+    context "when the mock framework does not support framework_name" do
+
+      before do
+        dumb_framework = Object.new
+        stub(RSpec.configuration).mock_framework { dumb_framework }
+      end
+
+      it "should return :nothing" do
+        puts ("in here")
+        discover_mock_framework.should == :nothing
+
+      end
+
+    end
+
+    context "when the mock framework does support framework_name" do
+
+      before do
+        mock_framework = RSpec.configuration.mock_framework
+        stub(mock_framework).respond_to?(:framework_name) { true }
+        stub(mock_framework).framework_name { :my_framework }
+      end
+
+      it "should return the framework name" do
+        discover_mock_framework.should == :my_framework
+      end
+
+    end
+
+  end
+
+  describe "calculate_values" do
+
+    context "when no total_count is specified" do
+
+      context "and when passed an object that does not implement length" do
+
+        it "sets total_count to 1" do
+
+          values = calculate_values(Object.new)
+          values[:total_count].should == 1
+
+        end
+
+      end
+
+      context "and when passed an object that implements length" do
+
+        it "sets total_count to the length of the object" do
+
+          values = calculate_values([ Object.new, Object.new])
+          values[:total_count].should == 2
+
+        end
+
+      end
+
+
+    end
+
+    context "when total_count is specified" do
+
+      it "sets the total_count to the specified value" do
+
+        values = calculate_values(Object.new, :total_count => 13)
+        values[:total_count].should == 13
+
+      end
+
+    end
+
+    context "when per_page is not specified" do
+
+      it "set per_page to the default of 25" do
+
+        values = calculate_values(Object.new)
+        values[:per_page].should == 25
+
+      end
+
+    end
+
+    context "when per_page is specified" do
+
+      it "sets per_page to the specified value" do
+
+        values = calculate_values(Object.new, :per_page => 17)
+        values[:per_page].should == 17
+
+      end
+
+    end
+
+    it "sets num_pages based on total_count and per_page" do
+      values = calculate_values(Object.new, :total_count => 50, :per_page => 25)
+      values[:num_pages].should == 2
+    end
+
+    context "when current_page is not specified" do
+
+      it "set current_page to the default of 1" do
+
+        values = calculate_values(Object.new)
+        values[:current_page].should == 1
+
+      end
+
+    end
+
+    context "when current_page is specified" do
+
+      it "sets current_page to the specified value" do
+
+        values = calculate_values(Object.new, :current_page => 19)
+        values[:current_page].should == 19
+
+      end
+
+    end
+
+  end
+
+  describe "stub_pagination" do
+
+    context "when passed a nil resource" do
+
+      it "returns nil" do
+        result = stub_pagination(nil)
+        result.should be_nil
+      end
+
+    end
+
+    context "when passed a non nil resource" do
+
+      # we check for total_count, to know if the stubbing was successful, no need to check for each
+      # method individually
+      it "has the total_count method stubbed" do
+        resource = Object.new
+        result = stub_pagination(resource, :mock => :rr, :total_count => 23)
+        result.total_count.should == 23
+      end
+
+      context "and an unknown mocking framework" do
+
+        it "raises an error" do
+          resource = Object.new
+          expect { stub_pagination(resource, :mock => :my_mock)}.to raise_error(ArgumentError)
+
+        end
+
+      end
+
+    end
+
+  end
+
+end
+
+

--- a/spec/test_helpers_spec.rb
+++ b/spec/test_helpers_spec.rb
@@ -81,7 +81,7 @@ describe "Kaminari::TestHelpers::" do
       it "set per_page to the default of 25" do
 
         values = calculate_values(Object.new)
-        values[:per_page].should == 25
+        values[:limit_value].should == 25
 
       end
 
@@ -89,10 +89,10 @@ describe "Kaminari::TestHelpers::" do
 
     context "when per_page is specified" do
 
-      it "sets per_page to the specified value" do
+      it "sets limit_value to the specified value" do
 
         values = calculate_values(Object.new, :per_page => 17)
-        values[:per_page].should == 17
+        values[:limit_value].should == 17
 
       end
 
@@ -116,10 +116,25 @@ describe "Kaminari::TestHelpers::" do
 
     context "when current_page is specified" do
 
-      it "sets current_page to the specified value" do
+      context "and the current_page value is <= num_pages" do
 
-        values = calculate_values(Object.new, :current_page => 19)
-        values[:current_page].should == 19
+        it "sets current_page to the specified value" do
+
+          values = calculate_values(Object.new, :current_page => 19, :total_count => 500, :per_page => 20)
+          values[:current_page].should == 19
+
+        end
+
+      end
+
+      context "and the current_page value is > num_pages" do
+
+        it "sets current_page to the max value allowed by num_pages" do
+
+          values = calculate_values(Object.new, :current_page => 19, :total_count => 100, :per_page => 20)
+          values[:current_page].should == 5
+        end
+
 
       end
 


### PR DESCRIPTION
Hi,
I have added the TestHelpers module which includes methods to stub out the `current_page`, `total_count` and other methods used in the pagination partials, to allow spec-ing the controllers with `render_views`. The code is fairly simple and I have tested with all 4 mocking frameworks supported by RSpec. Also I have asked (and they have already implemented it) extra functionality from rspec-core so that it is possible for my TestHelpers to automatically detect the mocking framework being used and generate the correct stub calls. TestHelpers have been tested with both rspec-core-2.5.1 (without the extra functionality) and with the git version of it (with the extra functionality). 

I don't know if this better sits together with kaminari in the same gem, or I should create a kaminari-rspec gem (tentative name) of my own. As the owner of kaminari, I let the choice to you, and I am fine with both solutions.

regards,
marco
