### PR TITLE
Fix for incorrect record count when query uses "distinct" 

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,9 +3,19 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        if distinct_column_name.nil?
+          c = except(:offset, :limit).count
+        else  
+          c = except(:offset, :limit).count(distinct_column_name, :distinct => true)
+        end
         # .group returns an OrderdHash that responds to #count
         c.respond_to?(:count) ? c.count : c
+      end
+      
+      # Get the column name used in distinct query.
+      # This could have been set on the Model class, or the ActiveRecord::Relation 
+      def distinct_column_name
+        @distinct_column || distinct_column
       end
     end
   end

--- a/lib/kaminari/models/configuration_methods.rb
+++ b/lib/kaminari/models/configuration_methods.rb
@@ -15,6 +15,21 @@ module Kaminari
       def default_per_page
         @_default_per_page || Kaminari::DEFAULT_PER_PAGE
       end
+      
+      # Set the name of the column to use during .count()
+      # Setting this will cause call to count to use: count(:id, :distinct => true) for all the Models paged queries. 
+      # Example:
+      #   class User < ActiveRecord::Base
+      #     use_distinct :id
+      #   end
+      def use_distinct(column)
+        @distinct_column = column
+      end
+      
+      # Returns the distinct column name set on the Model, or nil if not using distinct
+      def distinct_column
+        @distinct_column
+      end
     end
   end
 end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -21,6 +21,14 @@ module Kaminari
       def current_page
         (offset_value / limit_value) + 1
       end
+      
+      # Set the name of the column to use during .count()
+      # Setting this will cause call to count to use: count(:id, :distinct => true)
+      # Example: User.page(3).per(5).use_distinct(:id)
+      def use_distinct(column)
+        @distinct_column = column
+        self
+      end
     end
   end
 end


### PR DESCRIPTION
The use case is with a fairly complex query that can produce duplicates of the same record in its results.
It avoid the duplicates I have added the use of "distinct" to the query. This then returns the correct data, but if you do a count() on the query you get the total records (including the duplicates), so you end up having to call count(:id, :distinct => true) to get the real count.

As you can imagine this throws off the paging total since it uses just count(). 

I have added two way to support this:

1) Setting "use_distinct" on the Model. Setting this will cause call to count to use: count(:id, :distinct => true) for all the Models paged queries. 
Example:
  class User < ActiveRecord::Base
    use_distinct :id
  end

2) Setting "use_distinct" on the ActiveRecord::Relation. Setting this will cause call to count to use: count(:id, :distinct => true) for the ActiveRecord::Relation instance.
Example:
   User.page(3).per(5).use_distinct(:id)
