### PR TITLE
Made kaminari work better with polymorphic eager loading in rails 3

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,7 +3,7 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        c = except(:offset, :limit, :includes, :order).count
         # .group returns an OrderdHash that responds to #count
         c.respond_to?(:count) ? c.count : c
       end


### PR DESCRIPTION
Ignoring :include and :order when calling 'count' on an Arel Relation which allows 'count' to be called on a relation with polymorphic eager loads. Includes should be safe to ignore because they should not actually affect the number of rows returned. I can't think of a situation in which I would tell rails to include models in such a way that it would affect the count when I am about to call 'count'.
