### PR TITLE
Patching for rails edge

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GIT
   remote: git://github.com/rack/rack.git
-  revision: e3ffeac0dc04bb8d5994b7923bf12e55d549a279
+  revision: 5e072182014fccb03d9bfd8f36234df8c4bdd5d4
   specs:
     rack (1.2.1)
 
 GIT
   remote: git://github.com/rails/arel.git
-  revision: dbc86c0f2c2fc3c8bacf35c67fb8e0967b0a8980
+  revision: fc353baa803ba5ab2c11d71adcec358ea5c75f44
   specs:
-    arel (2.0.7.beta.20110121165657)
+    arel (2.0.7.beta.20110228092631)
 
 GIT
   remote: git://github.com/rails/rails.git
-  revision: 289cc15f1a89a179116f67e5f666f4ff6d645f03
+  revision: 9333ca74b37c6c24262783daf118984621ace69e
   specs:
     actionmailer (3.1.0.beta)
       actionpack (= 3.1.0.beta)
@@ -21,11 +21,11 @@ GIT
       activemodel (= 3.1.0.beta)
       activesupport (= 3.1.0.beta)
       builder (~> 3.0.0)
-      erubis (~> 2.6.6)
+      erubis (~> 2.7.0)
       i18n (~> 0.5.0)
       rack (~> 1.2.1)
       rack-cache (~> 1.0.0)
-      rack-mount (~> 0.6.13)
+      rack-mount (~> 0.7.1)
       rack-test (~> 0.5.7)
       tzinfo (~> 0.3.23)
     activemodel (3.1.0.beta)
@@ -53,16 +53,16 @@ GIT
     railties (3.1.0.beta)
       actionpack (= 3.1.0.beta)
       activesupport (= 3.1.0.beta)
+      rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       thor (~> 0.14.4)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    abstract (1.0.0)
     bcrypt-ruby (2.1.4)
-    bson (1.2.2)
-    bson_ext (1.2.2)
+    bson (1.3.0)
+    bson_ext (1.3.0)
     builder (3.0.0)
     capybara (0.4.1.2)
       celerity (>= 0.7.9)
@@ -73,14 +73,13 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (>= 0.0.27)
       xpath (~> 0.1.3)
-    celerity (0.8.8)
-    childprocess (0.1.7)
-      ffi (~> 0.6.3)
+    celerity (0.8.9)
+    childprocess (0.1.8)
+      ffi (~> 1.0.6)
     culerity (0.2.15)
     diff-lcs (1.1.2)
-    erubis (2.6.6)
-      abstract (>= 1.0.0)
-    ffi (0.6.3)
+    erubis (2.7.0)
+    ffi (1.0.7)
       rake (>= 0.8.7)
     git (1.2.5)
     i18n (0.5.0)
@@ -95,8 +94,8 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.16)
-    mongo (1.2.2)
-      bson (>= 1.2.2)
+    mongo (1.3.0)
+      bson (>= 1.3.0)
     mongoid (2.0.0.rc.7)
       activemodel (~> 3.0)
       mongo (~> 1.2)
@@ -106,8 +105,10 @@ GEM
     polyglot (0.3.1)
     rack-cache (1.0)
       rack (>= 0.4)
-    rack-mount (0.6.13)
+    rack-mount (0.7.1)
       rack (>= 1.0.0)
+    rack-ssl (1.3.2)
+      rack
     rack-test (0.5.7)
       rack (>= 1.0)
     rake (0.8.7)
@@ -127,9 +128,9 @@ GEM
       railties (~> 3.0)
       rspec (~> 2.5.0)
     rubyzip (0.9.4)
-    selenium-webdriver (0.1.3)
-      childprocess (~> 0.1.5)
-      ffi (~> 0.6.3)
+    selenium-webdriver (0.1.4)
+      childprocess (>= 0.1.7)
+      ffi (>= 1.0.7)
       json_pure
       rubyzip
     sqlite3 (1.3.3)
@@ -138,7 +139,7 @@ GEM
     thor (0.14.6)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
-    tzinfo (0.3.24)
+    tzinfo (0.3.26)
     will_paginate (3.0.pre2)
     xpath (0.1.3)
       nokogiri (~> 1.3)

--- a/lib/kaminari/models/active_record_extension.rb
+++ b/lib/kaminari/models/active_record_extension.rb
@@ -5,7 +5,9 @@ module Kaminari
     included do
       def self.inherited(kls) #:nodoc:
         # TERRIBLE HORRIBLE NO GOOD VERY BAD HACK: inheritable_attributes is not yet set here on AR 3.0
-        unless kls.default_scoping
+        # => What was the purpose of this hack ? All tests are green without it...
+        # => Is it for inherit @_default_per_page attribute between models ? If so, using class_attribute might do the trick
+        unless kls.default_scopes.empty?
           new_inheritable_attributes = Hash[inheritable_attributes.map do |key, value|
             [key, value.duplicable? ? value.dup : value]
           end]
@@ -17,11 +19,11 @@ module Kaminari
 
           # Fetch the values at the specified page number
           #   Model.page(5)
-          scope :page, Proc.new {|num|
-            limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
-          } do
-            include Kaminari::ActiveRecordRelationMethods
-            include Kaminari::PageScopeMethods
+          def self.page(num=nil)
+            limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1)).extending  do
+              include Kaminari::ActiveRecordRelationMethods
+              include Kaminari::PageScopeMethods
+            end
           end
         end
 


### PR DESCRIPTION
Here is a commit for latest rails edge. There is no more scope with procs & lambdas and default_scoping is now an array called default_scopes.
I can't seem to understand the purpose of your hack on inheritable_attributes and all tests are ok without it (see comments in file).
