### PR TITLE
quickfix to avoid a crash when the query already has a count/group_by 

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,7 +3,11 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        begin
+          c = except(:offset, :limit).count
+        rescue
+          c = except(:offset, :limit).all.size
+        end
         # .group returns an OrderdHash that responds to #count
         c.respond_to?(:count) ? c.count : c
       end


### PR DESCRIPTION
when a query already has a count (e.g selecting users that belong to more than 3 groups), kaminari crashes, this fixes that situation
