### PR TITLE
#total_count should be cached

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,9 +3,9 @@ module Kaminari
     extend ActiveSupport::Concern
     module InstanceMethods
       def total_count #:nodoc:
-        c = except(:offset, :limit).count
+        @_c ||= except(:offset, :limit).count
         # .group returns an OrderdHash that responds to #count
-        c.respond_to?(:count) ? c.count : c
+        @_result ||= @_c.respond_to?(:count) ? @_c.count : @_c
       end
     end
   end


### PR DESCRIPTION
Before, every time `total_count` was called it did a new request to the database, without caching.

```
10.times do
  Movie.page(1).per(10).total_count
end
```

Now, the count is only being made once.
All tests passes.

@amatsuda Keep up the good work!
