### PR TITLE
Using Kaminari.config to specify param_name

### DIFF
--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -22,6 +22,7 @@ module Kaminari
     config_accessor :outer_window
     config_accessor :left
     config_accessor :right
+    config_accessor :param_name
   end
 
   # this is ugly. why can't we pass the default value to config_accessor...?
@@ -31,5 +32,6 @@ module Kaminari
     config.outer_window = 0
     config.left = 0
     config.right = 0
+    config.param_name = :page
   end
 end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -18,7 +18,7 @@ module Kaminari
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, options = {}, &block)
-        Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :num_pages => scope.num_pages, :per_page => scope.limit_value, :param_name => :page, :remote => false)
+        Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :num_pages => scope.num_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
       end
     end
   end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -40,4 +40,10 @@ describe Kaminari::Configuration do
       its(:right) { should == 0 }
     end
   end
+
+  describe 'param_name' do
+    context 'by default' do
+      its(:param_name) { should == :page }
+    end
+  end
 end


### PR DESCRIPTION
Hi Akira

If application tends to change default param name for pager it need to be specified everywhere with `paginate` helper. I think `Kiminari.config` is good place to change defaults for whole application
