### PR TITLE
Added MongoMapper Support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,7 @@ No special collection class or anything for the paginated values, instead using 
 As the whole pagination helper is basically just a collection of links and non-links, Kaminari renders each of them through its own partial template inside the Engine. So, you can easily modify their behaviour, style or whatever by overriding partial templates.
 
 === ORM & template engine agnostic
-Kaminari supports multiple ORMs (ActiveRecord, Mongoid) and multiple template engines (ERB, Haml).
+Kaminari supports multiple ORMs (ActiveRecord, Mongoid, MongoMapper) and multiple template engines (ERB, Haml).
 
 === Modern
 The pagination helper outputs the HTML5 <nav> tag by default. Plus, the helper supports Rails 3 unobtrusive Ajax.
@@ -34,6 +34,8 @@ The pagination helper outputs the HTML5 <nav> tag by default. Plus, the helper s
 * Haml 3
 
 * Mongoid 2 (beta)
+
+* MongoMapper 0.9
 
 == Install
 

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', ['>= 1.0.0']
   s.add_development_dependency 'sqlite3', ['>= 0']
   s.add_development_dependency 'mongoid', ['>= 2']
+  s.add_development_dependency 'mongo_mapper', ['>= 0.9']
   s.add_development_dependency 'rspec', ['>= 0']
   s.add_development_dependency 'rspec-rails', ['>= 0']
   s.add_development_dependency 'rr', ['>= 0']

--- a/lib/kaminari/models/mongo_mapper_extension.rb
+++ b/lib/kaminari/models/mongo_mapper_extension.rb
@@ -1,0 +1,18 @@
+require File.join(File.dirname(__FILE__), 'plucky_criteria_methods')
+
+module Kaminari
+  module MongoMapperExtension
+    module Document
+      extend ActiveSupport::Concern
+      include Kaminari::ConfigurationMethods
+
+      included do
+        # Fetch the values at the specified page number
+        #   Model.page(5)
+        scope :page, Proc.new {|num|
+          limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
+        }
+      end
+    end
+  end
+end

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -1,0 +1,18 @@
+module Kaminari
+  module PluckyCriteriaMethods
+    extend ActiveSupport::Concern
+    module InstanceMethods
+      def limit_value #:nodoc:
+        options[:limit]
+      end
+
+      def offset_value #:nodoc:
+        options[:skip]
+      end
+
+      def total_count #:nodoc:
+        count
+      end
+    end
+  end
+end

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,6 +1,7 @@
 require 'rails'
 # ensure ORMs are loaded *before* initializing Kaminari
 begin; require 'mongoid'; rescue LoadError; end
+begin; require 'mongo_mapper'; rescue LoadError; end
 
 require File.join(File.dirname(__FILE__), 'config')
 require File.join(File.dirname(__FILE__), 'helpers/action_view_extension')
@@ -19,6 +20,12 @@ module Kaminari
         require File.join(File.dirname(__FILE__), 'models/mongoid_extension')
         ::Mongoid::Document.send :include, Kaminari::MongoidExtension::Document
         ::Mongoid::Criteria.send :include, Kaminari::MongoidExtension::Criteria
+      end
+      if defined? ::MongoMapper
+        require File.join(File.dirname(__FILE__), 'models/mongo_mapper_extension')
+        ::MongoMapper::Document.send :include, Kaminari::MongoMapperExtension::Document
+        ::Plucky::Query.send :include, Kaminari::PluckyCriteriaMethods
+        ::Plucky::Query.send :include, Kaminari::PageScopeMethods
       end
       require File.join(File.dirname(__FILE__), 'models/array_extension')
       ActiveSupport.on_load(:action_view) do

--- a/spec/models/mongo_mapper_spec.rb
+++ b/spec/models/mongo_mapper_spec.rb
@@ -1,0 +1,80 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+require 'mongo_mapper'
+require File.expand_path('../../lib/kaminari/models/mongo_mapper_extension', File.dirname(__FILE__))
+
+describe Kaminari::MongoMapperExtension do
+  before :all do
+    MongoMapper.connection = Mongo::Connection.new('localhost', 27017)
+    MongoMapper.database = "kaminari_test"
+    class Developer
+      include ::MongoMapper::Document
+      key :salary, Integer
+    end
+  end
+  before do
+    stub(subject).count { 300 } # in order to avoid DB access...
+  end
+
+  describe '#page' do
+    context 'page 1' do
+      subject { Developer.page(1) }
+      it { should be_a Plucky::Query }
+      its(:current_page) { should == 1 }
+      its(:limit_value) { should == 25 }
+      its(:num_pages) { should == 12 }
+      it { should skip(0) }
+    end
+
+    context 'page 2' do
+      subject { Developer.page 2 }
+      it { should be_a Plucky::Query }
+      its(:current_page) { should == 2 }
+      its(:limit_value) { should == 25 }
+      its(:num_pages) { should == 12 }
+      it { should skip 25 }
+    end
+    
+    context 'page "foobar"' do
+      subject { Developer.page 'foobar' }
+      it { should be_a Plucky::Query }
+      its(:current_page) { should == 1 }
+      its(:limit_value) { should == 25 }
+      its(:num_pages) { should == 12 }
+      it { should skip 0 }
+    end
+    
+    context 'with criteria before' do
+      it "should have the proper criteria source" do
+        Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+      end
+      
+      subject { Developer.where(:salary => 1).page 2 }
+      its(:current_page) { should == 2 }
+      its(:limit_value) { should == 25 }
+      its(:num_pages) { should == 12 }
+      it { should skip 25 }
+    end
+    
+    context 'with criteria after' do
+      it "should have the proper criteria source" do
+        Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+      end
+      
+      subject { Developer.page(2).where(:salary => 1) }
+      its(:current_page) { should == 2 }
+      its(:limit_value) { should == 25 }
+      its(:num_pages) { should == 12 }
+      it { should skip 25 }
+    end
+
+  end
+
+  describe '#per' do
+    subject { Developer.page(2).per(10) }
+    it { should be_a Plucky::Query }
+    its(:current_page) { should == 2 }
+    its(:limit_value) { should == 10 }
+    its(:num_pages) { should == 30 }
+    it { should skip 10 }
+  end
+end


### PR DESCRIPTION
Hey,

I added MongoMapper support. This will be compatible with the latest MongoMapper gem release (0.9) which is also ActiveModel compliant. All tests pass. I had to tweak the the MongoMapper tests to reflect Plucky (the querying interface/gem used by MongoMapper) properly.

Would really appreciate it if you can accept the pull request and update the gem. MongoMapper is a great library and needs a little bit more love from 3rd parties, and so here I am...giving it some love :)

Haris
