### PR TITLE
param_name via block

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== 0.12.4
+
+* Support for config.param_name as lambda
+
 == 0.12.3
 
 * Haml 3.1 Support #96 [FlyboyArt, sonic921]

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -23,6 +23,10 @@ module Kaminari
     config_accessor :left
     config_accessor :right
     config_accessor :param_name
+
+    def param_name
+      config.param_name.respond_to?(:call) ? config.param_name.call() : config.param_name 
+    end
   end
 
   # this is ugly. why can't we pass the default value to config_accessor...?

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -25,7 +25,13 @@ module Kaminari
     config_accessor :param_name
 
     def param_name
-      config.param_name.respond_to?(:call) ? config.param_name.call() : config.param_name 
+      if block_given?
+        yield
+      elsif config.param_name.respond_to? :call
+        config.param_name.call()
+      else
+        config.param_name 
+      end
     end
   end
 

--- a/lib/kaminari/version.rb
+++ b/lib/kaminari/version.rb
@@ -1,3 +1,3 @@
 module Kaminari
-  VERSION = '0.12.3'
+  VERSION = '0.12.4'
 end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -45,5 +45,17 @@ describe Kaminari::Configuration do
     context 'by default' do
       its(:param_name) { should == :page }
     end
+
+    context 'configured via config block' do
+      before do
+        Kaminari.configure {|c| c.param_name = lambda { :test } }
+      end
+
+      its(:param_name) { should == :test }
+
+      after do 
+        Kaminari.configure {|c| c.param_name = :page }
+      end
+    end
   end
 end

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -46,7 +46,19 @@ describe Kaminari::Configuration do
       its(:param_name) { should == :page }
     end
 
-    context 'configured via config block' do
+    context 'configured via block' do
+      before do
+        Kaminari.configure {|c| c.param_name { :test } }
+      end
+
+      its(:param_name) { should == :test }
+
+      after do 
+        Kaminari.configure {|c| c.param_name = :page }
+      end
+    end
+
+    context 'configured via config lambda/proc' do
       before do
         Kaminari.configure {|c| c.param_name = lambda { :test } }
       end


### PR DESCRIPTION
Hi,

I am rather appreciative of the work you've put into this.  I've made a slight modification so that you can specify a block in the configuration file, like this:

```
config.param_name = lambda { paginate_param }
```

I've chosen to do this because I want to be able to have multiple paginations per page, and would rather specify them programatically where possible, and override specific cases if there is a need.  I figured that other people may also want this functionality, and have also added the relevant test case.

Thanks!

Adam
