### PR TITLE
Inheritance

### DIFF
--- a/lib/kaminari/models/active_record_extension.rb
+++ b/lib/kaminari/models/active_record_extension.rb
@@ -18,7 +18,7 @@ module Kaminari
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end
-        end
+        end if kls.superclass == ActiveRecord::Base
       end
     end
   end


### PR DESCRIPTION
If I have two classes like:

```
class Service < ActiveRecord::Base
end

class FacebookService < Service
end
```

I get constant warnings that the scope on `FacebookService` is being overridden, which it is.  This patch makes Kaminari only include itself into `Service`

Thanks for the great gem!
