### PR TITLE
Paginator#page(:first) returns PageProxy, hide redundant First/Last links.

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -8,7 +8,7 @@
 -%>
 <%= paginator.render do -%>
   <nav class="pagination">
-    <%= first_page_tag unless current_page.first? %>
+    <%= first_page_tag unless paginator.page(:first).inside_window? %>
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
@@ -18,6 +18,6 @@
       <% end -%>
     <% end -%>
     <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <%= last_page_tag unless paginator.page(:last).inside_window? %>
   </nav>
 <% end -%>

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -7,7 +7,7 @@
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav.pagination
-    = first_page_tag unless current_page.first?
+    = first_page_tag unless paginator.page(:first).inside_window?
     = prev_page_tag unless current_page.first?
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
@@ -15,4 +15,4 @@
       - elsif !page.was_truncated?
         = gap_tag
     = next_page_tag unless current_page.last?
-    = last_page_tag unless current_page.last?
+    = last_page_tag unless paginator.page(:last).inside_window?

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -8,7 +8,7 @@
 
 == paginator.render do
   nav.pagination
-    == first_page_tag unless current_page.first?
+    == first_page_tag unless paginator.page(:first).inside_window?
     == prev_page_tag unless current_page.first?
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
@@ -16,4 +16,4 @@
       - elsif !page.was_truncated?
         == gap_tag
     == next_page_tag unless current_page.last?
-    == last_page_tag unless current_page.last?
+    == last_page_tag unless paginator.page(:last).inside_window?

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -19,7 +19,7 @@ module Kaminari
         end
         @template, @options = template, options
         @theme = @options[:theme] ? "#{@options[:theme]}/" : ''
-        @options[:current_page] = PageProxy.new @window_options.merge(@options), @options[:current_page], nil
+        @options[:current_page] = page @options[:current_page]
         # initialize the output_buffer for Context
         @output_buffer = ActionView::OutputBuffer.new
       end
@@ -35,8 +35,22 @@ module Kaminari
         return to_enum(:each_page) unless block_given?
 
         1.upto(@options[:num_pages]) do |i|
-          yield PageProxy.new(@window_options.merge(@options), i, @last)
+          yield page(i, @last)
         end
+      end
+
+      # converts :first and :last to Fixnum, returns anything else unchanged.
+      def page_number(number)
+        case number
+          when :first then 1
+          when :last then @options[:num_pages]
+          else number
+        end
+      end
+
+      # create a PageProxy for the given page number, understands :first and :last
+      def page(number, last = nil)
+        PageProxy.new @window_options.merge(@options), page_number(number), last
       end
 
       def page_tag(page)


### PR DESCRIPTION
Hi Akira,

It seems unnecessary to show "First" when there is a "1" link, and "Last" when the last page number is linked.  I've made it possible to opt out of that by exposing a `Paginator#page` which templates can use to check if the :first or :last page are in the current window.

I've updated the default _paginator templates:

``` erb
<%= first_page_tag unless paginator.page(:first).inside_window? %>
...
<%= last_page_tag unless paginator.page(:last).inside_window? %>
```

The only thing I'm not sure about is whether `inside_window?` is correct for all possible configurations. It would be nice if there was something like `PageProxy#visible?` to check if that page link is being displayed.

Let me know your thoughts - I'd be happy to at least get in the `Paginator#page` functionality, even if we don't change the default templates.

Cheers!
Paul

PS: is it possible to get the tests running without installing all the MongoDB stuff?
