### PR TITLE
Complex queries may break Kaminari total_count

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,6 +61,16 @@ Then bundle:
     User.page(7).per(50)
   Note that the +per+ scope is not directly defined on the models but is just a method defined on the page scope. This is absolutely reasonable because you will never actually use +per_page+ without specifying the +page+ number.
 
+* the +smart_count+ method
+
+  ActiveRecord +count+ method may fail or give wrong results on complex queries. Say, for example, you use +having+ constraint, based on +select+ generated columns. As long as generated columns are thrown away, +having+ constraint will fail and you will get invalid query. If this is your case, you should define a +smart_count+ method on your model or scope. A possible implementation may be (works with any complex query):
+
+    def smart_count
+      count_by_sql("SELECT COUNT(*) FROM (#{scoped.to_sql}) AS count_table")
+    end
+
+  Kaminari will call this method instead of +count+ if it is defined.
+
 === General configuration options
 
 You can configure the following default values by overriding these values using <tt>Kaminari.configure</tt> method.
@@ -163,7 +173,7 @@ Kaminari includes a handy template generator.
 * themes
 
   The generator has the ability to fetch several sample template themes from
-  the external repository (https://github.com/amatsuda/kaminari_themes) in 
+  the external repository (https://github.com/amatsuda/kaminari_themes) in
   addition to the bundled "default" one, which will help you creating a nice
   looking paginator.
     % rails g kaminari:views THEME

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -13,12 +13,17 @@ module Kaminari
       def total_count #:nodoc:
         # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
         c = except(:offset, :limit, :order)
+
         # a workaround for 3.1.beta1 bug. see: https://github.com/rails/rails/issues/406
         c = c.reorder nil
+
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
+
+        # Allow to override default count behaviour
+        c = c.respond_to?(:smart_count) ? c.smart_count : c.count
+
         # .group returns an OrderdHash that responds to #count
-        c = c.count
         c.respond_to?(:count) ? c.count : c
       end
     end

--- a/spec/models/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record_relation_methods_spec.rb
@@ -10,7 +10,8 @@ describe Kaminari::ActiveRecordRelationMethods do
       @books2 = 3.times.map {|i| @author2.books_authored.create!(:title => "title%03d" % i) }
       @books3 = 4.times.map {|i| @author3.books_authored.create!(:title => "subject%03d" % i) }
       @readers = 4.times.map { User.create! :name => 'reader' }
-      @books.each {|book| book.readers << @readers }
+      @books.each { |book| book.readers << @readers }
+      @books2.each { |book| book.readers << @readers.take(2) }
     end
 
     context "when the scope includes an order which references a generated column" do
@@ -22,6 +23,19 @@ describe Kaminari::ActiveRecordRelationMethods do
       it "should keep includes and successfully count the results" do
         # Only @author and @author2 have books titled with the title00x partern
         User.includes(:books_authored).where("books.title LIKE 'title00%'").page(1).total_count.should == 2
+      end
+    end
+
+    context "when the scope responds to smart_count" do
+      module SmartCount
+        def smart_count
+          count_by_sql("SELECT COUNT(*) FROM (#{scoped.to_sql}) AS count_table")
+        end
+      end
+
+      it "should call smart_count on scope and return the given value" do
+        # only 2 users have read more than two books
+        User.joins(:readerships).read_count_at_least(3).extending(SmartCount).page(1).total_count.should == 2
       end
     end
   end


### PR DESCRIPTION
Hi amatsuda,
As long as ActiveRecord count throws away select block, calling count may result in broken query. E.g., if a query has 'having' clause, relaying on select values. Also, count throws away group by, that may result in incorrect number of entities.

I've provided a simple fix, allowing users to override the behavior by providing their own implementation of how to count (See attached patch). It tries to call smart_count before calling count, and kaminari users may define this method by themselves. 

This ticket somehow duplicaties another #85 - but provides a better solution and a test, showing the example of a dangerous query.

Please, accept the patch or solve the issue another way (e.g., providing suggested in patch smart_count implementation that works with any complex query) and I'll use your gem instead of my fork.
