### PR TITLE
paginator helper support for Sunspot Search object

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -17,7 +17,22 @@ module Kaminari
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, options = {}, &block)
-        paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :num_pages => scope.num_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+        if scope.is_a?(Sunspot::Search::AbstractSearch)
+          scope_options = {
+            :current_page => scope.query.page, 
+            :num_pages => (scope.total / scope.query.per_page).ceil,
+            :per_page => scope.query.per_page
+          }
+        else
+          scope_options = {
+            :current_page => scope.current_page,
+            :num_pages => scope.num_pages,
+            :per_page => scope.limit_value
+          }
+        end
+        
+        options = options.reverse_merge(scope_options.merge(:param_name => Kaminari.config.param_name, :remote => false))
+        paginator = Kaminari::Helpers::Paginator.new self, options
         paginator.to_s
       end
 


### PR DESCRIPTION
See https://github.com/amatsuda/kaminari/issues/47

Because sunspot takes care of it's own pagination i decided to just implement the support of sunspot in the helper.
This is the same way will_paginate supports sunspot and avoids having to implement two kind of pagination helpers.
