### PR TITLE
Memoize count for AR when calling total_count - Increases performance for large datasets

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -12,6 +12,7 @@ module Kaminari
 
       def total_count #:nodoc:
         # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
+        return @total_count if @total_count
         c = except(:offset, :limit, :order)
         # a workaround for 3.1.beta1 bug. see: https://github.com/rails/rails/issues/406
         c = c.reorder nil
@@ -19,7 +20,7 @@ module Kaminari
         c = c.except(:includes) unless references_eager_loaded_tables?
         # .group returns an OrderdHash that responds to #count
         c = c.count
-        c.respond_to?(:count) ? c.count : c
+        @total_count = c.respond_to?(:count) ? c.count : c
       end
     end
   end


### PR DESCRIPTION
Doing count on RDBMS can be painfully slow for larger datasets. Memoizing takes care of the problem.

Memoizing doesn't seem to have a negative effect since we should only care about how many records there were in the DB when we did the initial count query.
