### PR TITLE
page_entries_info view helper ported from will_paginate

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -45,6 +45,39 @@ module Kaminari
           block.call if block
         end
       end
+
+      # Renders a helpful message with numbers of displayed vs. total entries.
+      # Ported from mislav/will_paginate
+      #
+      # ==== Examples
+      # Basic usage:
+      #
+      #   <%= page_entries_info @posts %>
+      #   #-> Displaying posts 6 - 10 of 26 in total
+      #
+      # By default, the message will use the humanized class name of objects
+      # in collection: for instance, "project types" for ProjectType models.
+      # Override this with the <tt>:entry_name</tt> parameter:
+      #
+      #   <%= page_entries_info @posts, :entry_name => 'item' %>
+      #   #-> Displaying items 6 - 10 of 26 in total
+      def page_entries_info(collection, options = {})
+        entry_name = options[:entry_name] || (collection.empty?? 'entry' : collection.first.class.name.underscore.sub('_', ' '))
+        if collection.num_pages < 2
+          case collection.total_count
+          when 0; "No #{entry_name.pluralize} found"
+          when 1; "Displaying <b>1</b> #{entry_name}"
+          else;   "Displaying <b>all #{collection.total_count}</b> #{entry_name.pluralize}"
+          end
+        else
+          offset = (collection.current_page - 1) * collection.limit_value
+          %{Displaying #{entry_name.pluralize} <b>%d&nbsp;-&nbsp;%d</b> of <b>%d</b> in total} % [
+            offset + 1,
+            offset + collection.count,
+            collection.total_count
+          ]
+        end
+      end
     end
   end
 end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -1,11 +1,9 @@
 require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe 'Kaminari::ActionViewExtension' do
-  before do
-    50.times {|i| User.create! :name => "user#{i}"}
-  end
   describe '#paginate' do
     before do
+      50.times {|i| User.create! :name => "user#{i}"}
       @users = User.page(1)
     end
     subject { helper.paginate @users, :params => {:controller => 'users', :action => 'index'} }
@@ -19,6 +17,9 @@ describe 'Kaminari::ActionViewExtension' do
   end
 
   describe '#link_to_next_page' do
+    before do
+      50.times {|i| User.create! :name => "user#{i}"}
+    end
     context 'having more page' do
       before do
         @users = User.page(1)
@@ -32,6 +33,76 @@ describe 'Kaminari::ActionViewExtension' do
       end
       subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
       it { should_not be }
+    end
+  end
+
+  describe '#page_entries_info' do
+    before do
+      @users = User.page(1).per(25)
+    end
+    context 'having no entries' do
+      subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+      it      { should == 'No entries found' }
+    end
+
+    context 'having 1 entry' do
+      before do
+        User.create!
+        @users = User.page(1).per(25)
+      end
+      subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+      it      { should == 'Displaying <b>1</b> user' }
+
+      context 'setting the entry name option to "member"' do
+        subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying <b>1</b> member' }
+      end
+    end
+
+    context 'having more than 1 but less than a page of entries' do
+      before do
+        10.times {|i| User.create!}
+        @users = User.page(1).per(25)
+      end
+      subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+      it      { should == 'Displaying <b>all 10</b> users' }
+
+      context 'setting the entry name option to "member"' do
+        subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying <b>all 10</b> members' }
+      end
+    end
+
+    context 'having more than one page of entries' do
+      before do
+        50.times {|i| User.create!}
+      end
+
+      describe 'the first page' do
+        before do
+          @users = User.page(1).per(25)
+        end
+        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+
+        context 'setting the entry name option to "member"' do
+          subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+        end
+      end
+
+      describe 'the next page' do
+        before do
+          @users = User.page(2).per(25)
+        end
+        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying users <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+
+        context 'setting the entry name option to "member"' do
+          subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Renders a helpful message with numbers of displayed vs. total entries.
Ported from mislav/will_paginate

Basic usage:
  <%= page_entries_info @posts %>
  # => Displaying posts 6 - 10 of 26 in total

Very useful in views to display paginated collection information. Present in Mislav's will_paginate.

Commit includes helper and test coverage.
