### PR TITLE
Issue #137: kaminari disastrous with very large num_pages

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -8,6 +8,31 @@ module Kaminari
       # so that this instance can actually "render"
       include ::ActionView::Context
 
+      module Windows
+        def relevant_pages options
+          [left_window(options), inside_window(options), right_window(options)].map(&:to_a).flatten.uniq.sort.reject { |x| x < 1 or x > options[:num_pages] }
+        end
+
+        def all_pages options
+          1.upto(options[:num_pages])
+        end
+
+        protected
+        def left_window options
+          1.upto(options[:left] + 1)
+        end
+
+        def right_window options
+          (options[:num_pages] - options[:right]).upto(options[:num_pages])
+        end
+
+        def inside_window options
+          (options[:current_page] - options[:window]).upto(options[:current_page] + options[:window])
+        end
+      end
+
+      include Windows
+
       def initialize(template, options) #:nodoc:
         @window_options = {}.tap do |h|
           h[:window] = options.delete(:window) || options.delete(:inner_window) || Kaminari.config.window
@@ -35,6 +60,14 @@ module Kaminari
         return to_enum(:each_page) unless block_given?
 
         1.upto(@options[:num_pages]) do |i|
+          yield PageProxy.new(@window_options.merge(@options), i, @last)
+        end
+      end
+
+      def each_relevant_page
+        return to_enum(:each_relevant_page) unless block_given?
+
+        relevant_pages(@window_options.merge(@options)).each do |i|
           yield PageProxy.new(@window_options.merge(@options), i, @last)
         end
       end


### PR DESCRIPTION
Submitting this as a formal pull request.

Let's say you have a page size of 10, and the total number of hits is 3 million. That would mean 300k hypothetical pages.

https://github.com/amatsuda/kaminari/blob/master/app/views/kaminari/_paginator.html.erb

calls #each_page (https://github.com/amatsuda/kaminari/blob/master/lib/kaminari/helpers/paginator.rb#L34), which will iterate through each of these 300k hypothetical pages, AND create a PageProxy for each of them. Even though only a handful of them will actually be shown.

This commit address issue #137 by adding #each_relevant_page, an iterator that only visits pages in the inner or outer windows, and Kaminari::Helpers::Paginator::Windows (should be renamed) that does the heavy lifting
