### PR TITLE
enable to paginate throurh embedded documents in mongoid

### DIFF
--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -11,7 +11,15 @@ module Kaminari
       end
 
       def total_count #:nodoc:
-        count
+        embedded? ? unpage.count : count
+      end
+
+      private
+      def unpage
+        clone.tap do |crit|
+          crit.options.delete :limit
+          crit.options.delete :skip
+        end
       end
     end
   end

--- a/lib/kaminari/models/mongoid_extension.rb
+++ b/lib/kaminari/models/mongoid_extension.rb
@@ -7,7 +7,7 @@ module Kaminari
 
       included do
         def page(*args)
-          self.klass.page(*args).criteria.merge(self)
+          super(*args).criteria.merge(self)
         end
       end
     end


### PR DESCRIPTION
As being discussed on #89, kaminari doesn't work with embedded documents in mongoid now.
The reason why it doesn't is that `Criteria#total_count` always returns the same number as what `Criteria#limit_value` returns when its embedded flag is set to true. also `Criteria#page` breaks embedded relation.

Commit includes fixes for them. Rspec tests all pass but I think the `before :all` part is a bit dirty and there is a better way or fixture to do it.
