### PR TITLE
Do not depend on Rails because it depends on ActiveRecord, whenever you use it or another ORM/ODM in application

### DIFF
--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.add_dependency 'rails', ['>= 3.0.0']
+  s.add_dependency 'railties', ['>= 3.0.0']
   s.add_development_dependency 'bundler', ['>= 1.0.0']
   s.add_development_dependency 'sqlite3', ['>= 0']
   s.add_development_dependency 'mongoid', ['>= 2']


### PR DESCRIPTION
Depend on Railties instead of Rails (fixed autodepending on ActiveRecord if application uses another ORM)
