### PR TITLE
total_count should use length instead of count when using more complex queries

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -20,8 +20,8 @@ module Kaminari
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
         
-        uses_distinct_on_sql = c.to_sql =~ /DISTINCT ON/i
-        if uses_distinct_on_sql
+        uses_distinct_sql_statement = c.to_sql =~ /DISTINCT/i
+        if uses_distinct_sql_statement
           return c.length
         end
           

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -18,8 +18,8 @@ module Kaminari
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
         # .group returns an OrderdHash that responds to #count
-        c = c.count
-        c.respond_to?(:count) ? c.count : c
+        c = c.length
+        c.respond_to?(:length) ? c.length : c
       end
     end
   end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -13,13 +13,21 @@ module Kaminari
       def total_count #:nodoc:
         # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
         c = except(:offset, :limit, :order)
+        
         # a workaround for 3.1.beta1 bug. see: https://github.com/rails/rails/issues/406
         c = c.reorder nil
+        
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
+        
+        uses_distinct_on_sql = c.to_sql =~ /DISTINCT ON/i
+        if uses_distinct_on_sql
+          return c.length
+        end
+          
         # .group returns an OrderdHash that responds to #count
-        c = c.length
-        c.respond_to?(:length) ? c.length : c
+        c = c.count
+        c.respond_to?(:count) ? c.count : c
       end
     end
   end


### PR DESCRIPTION
total_count should use length instead of count which omits select resulting in invalid number of paginated items when using DISTINCT ON in Postgres (have not tested on MySQL)  and perhaps when using GROUP BY

In my scenario:

```
  votes = Vote.select('DISTINCT ON (subject_id) * ').
         order('subject_id DESC').
         where(:user_id => user_ids).count      #=> 19 -- it skips the DISTINCT ON #select 


  votes = Vote.select('DISTINCT ON (subject_id) * ').
         order('subject_id DESC').
         where(:user_id => user_ids).length      #=> 4 -- performs full query and returns correct value.
```

The incorrect value used by Kaminari results in invalid item count, which causes Kaminari's paginator to generate incorrect number of pages/links to pages.

My solution is not pefrect it is only a workaround which works for me. 
The ideal, optimized way of fixing this would be detecting whether a user is using DISTINCT ON or a custom query and then choosing accordingly either .length or .count.

Alternatively Kaminari could somewhere accept an option value to whether use count or length.

Thank you for creating Kaminari.
Dennis
