### PR TITLE
Let one override the rel= attribute

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -41,7 +41,7 @@ module Kaminari
       def link_to_next_page(scope, name, options = {}, &block)
         params = options.delete(:params) || {}
         param_name = options.delete(:param_name) || Kaminari.config.param_name
-        link_to_unless scope.last_page?, name, params.merge(param_name => (scope.current_page + 1)), options.merge(:rel => 'next') do
+        link_to_unless scope.last_page?, name, params.merge(param_name => (scope.current_page + 1)), options.reverse_merge(:rel => 'next') do
           block.call if block
         end
       end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -23,8 +23,15 @@ describe 'Kaminari::ActionViewExtension' do
       before do
         @users = User.page(1)
       end
-      subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
-      it { should be_a String }
+      context 'the default behaviour' do
+        subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
+        it { should be_a String }
+        it { should match /rel="next"/ }
+      end
+      context 'overriding rel=' do
+        subject { helper.link_to_next_page @users, 'More', :rel => 'external', :params => {:controller => 'users', :action => 'index'} }
+        it { should match /rel="external"/ }
+      end
     end
     context 'the last page' do
       before do


### PR DESCRIPTION
Hey Akira,

In one of my projects, I had to override the value of rel= attribute. Feel free to pull :-)

Here's the scenario where I had to do this:

I wanted to use the in-page "load more" pattern with jQuery Mobile.

Long story short, the only way I found to prevent jQM from handling the link was to have rel="external" on it (event.stopImmediatePropagation() didn't work).

So this is not exactly semantic, but I figure it may come in handy to other people who want to override rel="next".

Comes with beefed up specs.

Cheers,

Mat
