### PR TITLE
kaminari and its helpers works well around Sinatra(and also Padrino) with least dependency

### DIFF
--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -41,4 +41,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'steak', ['>= 0']
   s.add_development_dependency 'capybara', ['>= 0']
   s.add_development_dependency 'database_cleaner', ['>= 0']
+  s.add_development_dependency 'padrino-helpers', ['~> 0.10']
+  s.add_development_dependency 'rack-test', ['>= 0']
+  s.add_development_dependency 'sinatra-contrib', ['~> 1.3']
+  s.add_development_dependency 'nokogiri', ['>= 0']
 end

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -21,9 +21,14 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.add_dependency 'railties', ['>= 3.0.0']
+  %w{ activesupport actionpack railties }.each do |gem|
+    s.add_dependency gem, ['>= 3.0.0']
+  end
   s.add_development_dependency 'bundler', ['>= 1.0.0']
   s.add_development_dependency 'sqlite3', ['>= 0']
+  %w{ activerecord activemodel }.each do |gem|
+    s.add_development_dependency gem, ['>= 3.0.0']
+  end
   s.add_development_dependency 'mongoid', ['>= 2']
   s.add_development_dependency 'mongo_mapper', ['>= 0.9']
   s.add_development_dependency 'dm-core', ['>= 1.1.0']

--- a/lib/kaminari.rb
+++ b/lib/kaminari.rb
@@ -1,2 +1,52 @@
-require 'kaminari/railtie'
-require 'kaminari/engine'
+module Kaminari
+
+  def self.frameworks
+    frameworks = []
+    case
+      when defined?(::Rails)   then frameworks << 'rails'
+      when defined?(::Sinatra) then frameworks << 'sinatra/base'
+    end
+    frameworks
+  end
+
+  def self.load_framework!
+    raise "No framework specified!" if frameworks.empty?
+    frameworks.each do |framework|
+      begin
+        require framework
+      rescue NameError => e
+        raise "can\'t load framework #{framework.inspect}. Have you added it to Gemfile?"
+      end
+    end
+  end
+
+
+  def self.load_kaminari!
+    require 'kaminari/config'
+    require 'kaminari/helpers/action_view_extension'
+    require 'kaminari/helpers/paginator'
+    require 'kaminari/models/page_scope_methods'
+    require 'kaminari/models/configuration_methods'
+  end
+
+  def self.hook!
+    load_framework!
+    load_kaminari!
+    require 'kaminari/hooks'
+    if defined?(::Rails)
+      require 'kaminari/railtie'
+      require 'kaminari/engine'
+    elsif defined?(::Sinatra)
+      require 'kaminari/sinatra'
+    else
+      Kaminari::Hooks.init!
+    end
+  end
+
+  def self.load!
+    hook!
+  end
+
+end
+
+Kaminari.load!

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -1,5 +1,8 @@
-require 'kaminari/helpers/tags'
+require 'active_support/inflector'
+require 'action_view'
+require 'action_view/log_subscriber'
 require 'action_view/context'
+require 'kaminari/helpers/tags'
 
 module Kaminari
   module Helpers

--- a/lib/kaminari/helpers/sinatra_helper.rb
+++ b/lib/kaminari/helpers/sinatra_helper.rb
@@ -1,0 +1,126 @@
+require 'active_support/core_ext/object'
+require 'active_support/core_ext/string'
+
+begin
+
+require 'padrino-helpers'
+module Kaminari::Helpers
+  module SinatraHelper
+    class << self
+      def registered(app)
+        app.register Padrino::Helpers
+        app.helpers  HelperMethods
+      end
+
+      alias included registered
+    end
+    
+    class ActionViewTemplateProxy
+      def initialize(opts={})
+        @current_path = opts[:current_path]
+        @param_name = (opts[:param_name] || :page).to_sym
+        @current_params = opts[:current_params]
+        @current_params.delete(@param_name)
+      end
+
+      def render(*args)
+        base = ActionView::Base.new.tap do |a|
+          a.view_paths << File.expand_path('../../../../app/views', __FILE__)
+        end
+        base.render(*args)
+      end
+
+      def url_for(params)
+        extra_params = {}
+        if page = params[@param_name] and page != 1
+          extra_params[@param_name] = page
+        end
+        query = @current_params.merge(extra_params)
+        @current_path + (query.empty? ? '' : "?#{query.to_query}")
+      end
+      
+      def params
+        @current_params
+      end
+    end
+  
+    module HelperMethods
+      # A quick backport from Rails' link_to_unless helper
+      def link_to_unless(condition, *args, &blk)
+        unless condition
+          link_to *args 
+        else
+          block_given? ? blk.call : nil
+        end
+      end
+    
+      # A helper that renders the pagination links - for Sinatra.
+      #
+      #   <%= paginate @articles %>
+      #
+      # ==== Options
+      # * <tt>:window</tt> - The "inner window" size (4 by default).
+      # * <tt>:outer_window</tt> - The "outer window" size (0 by default).
+      # * <tt>:left</tt> - The "left outer window" size (0 by default).
+      # * <tt>:right</tt> - The "right outer window" size (0 by default).
+      # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
+      # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
+      # * <tt>:remote</tt> - Ajax? (false by default)
+      # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
+      def paginate(scope, options = {}, &block)
+        current_path = env['PATH_INFO'] rescue nil
+        current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
+        paginator = Kaminari::Helpers::Paginator.new(
+          ActionViewTemplateProxy.new(:current_params => current_params, :current_path => current_path, :param_name => options[:param_name] || Kaminari.config.param_name),
+          options.reverse_merge(:current_page => scope.current_page, :num_pages => scope.num_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+        )
+        paginator.to_s
+      end
+
+      # A simple "Twitter like" pagination link that creates a link to the next page.
+      # Works on Sinatra.
+      #
+      # ==== Examples
+      # Basic usage:
+      #
+      #   <%= link_to_next_page @items, 'Next Page' %>
+      #
+      # Ajax:
+      #
+      #   <%= link_to_next_page @items, 'Next Page', :remote => true %>
+      #
+      # By default, it renders nothing if there are no more results on the next page.
+      # You can customize this output by passing a block.
+      #
+      #   <%= link_to_next_page @users, 'Next Page' do %>
+      #     <span>No More Pages</span>
+      #   <% end %>
+      def link_to_next_page(scope, name, options = {}, &block)
+        params = options.delete(:params) || (Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {})
+        param_name = options.delete(:param_name) || Kaminari.config.param_name
+        query = params.merge(param_name => (scope.current_page + 1))
+        link_to_unless scope.last_page?, name, env['PATH_INFO'] + (query.empty? ? '' : "?#{query.to_query}"), options.merge(:rel => 'next') do
+          block.call; nil if block
+        end
+      end
+    end
+  end
+end
+
+if defined? I18n
+  I18n.load_path += Dir.glob(File.expand_path('../../../../config/locales/*.yml', __FILE__))
+end
+
+rescue LoadError
+
+$stderr.puts "[!]You shold install `padrino-helpers' gem if you want to use kaminari's pagination helpers with Sinatra."
+$stderr.puts "[!]Kaminari::Helpers::SinatraHelper does nothing now..."
+
+module Kaminari::Helpers
+  module SinatraHelper
+    def self.registered(*)
+    end
+  end
+end
+
+end

--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -5,7 +5,7 @@ begin
 
 require 'padrino-helpers'
 module Kaminari::Helpers
-  module SinatraHelper
+  module SinatraHelpers
     class << self
       def registered(app)
         app.register Padrino::Helpers
@@ -45,15 +45,6 @@ module Kaminari::Helpers
     end
   
     module HelperMethods
-      # A quick backport from Rails' link_to_unless helper
-      def link_to_unless(condition, *args, &blk)
-        unless condition
-          link_to *args 
-        else
-          block_given? ? blk.call : nil
-        end
-      end
-    
       # A helper that renders the pagination links - for Sinatra.
       #
       #   <%= paginate @articles %>
@@ -63,7 +54,7 @@ module Kaminari::Helpers
       # * <tt>:outer_window</tt> - The "outer window" size (0 by default).
       # * <tt>:left</tt> - The "left outer window" size (0 by default).
       # * <tt>:right</tt> - The "right outer window" size (0 by default).
-      # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
+      # * <tt>:params</tt> - url_for parameters for the links (:id, :locale, etc.)
       # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
@@ -90,17 +81,19 @@ module Kaminari::Helpers
       #   <%= link_to_next_page @items, 'Next Page', :remote => true %>
       #
       # By default, it renders nothing if there are no more results on the next page.
-      # You can customize this output by passing a block.
+      # You can customize this output by passing a parameter <tt>:placeholder</tt>.
       #
-      #   <%= link_to_next_page @users, 'Next Page' do %>
-      #     <span>No More Pages</span>
-      #   <% end %>
-      def link_to_next_page(scope, name, options = {}, &block)
+      #   <%= link_to_next_page @items, 'Next Page', :placeholder => %{<span>No More Pages</span>} %>
+      #
+      def link_to_next_page(scope, name, options = {})
         params = options.delete(:params) || (Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {})
         param_name = options.delete(:param_name) || Kaminari.config.param_name
+        placeholder = options.delete(:placeholder) || ""
         query = params.merge(param_name => (scope.current_page + 1))
-        link_to_unless scope.last_page?, name, env['PATH_INFO'] + (query.empty? ? '' : "?#{query.to_query}"), options.merge(:rel => 'next') do
-          block.call; nil if block
+        unless scope.last_page?
+          link_to name, env['PATH_INFO'] + (query.empty? ? '' : "?#{query.to_query}"), options.merge(:rel => 'next')
+        else
+          placeholder
         end
       end
     end

--- a/lib/kaminari/hooks.rb
+++ b/lib/kaminari/hooks.rb
@@ -1,0 +1,37 @@
+module Kaminari
+  class Hooks
+    def self.init!
+      ActiveSupport.on_load(:active_record) do
+        require 'kaminari/models/active_record_extension'
+        ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
+      end
+
+      if defined? ::Mongoid
+        require 'kaminari/models/mongoid_extension'
+        ::Mongoid::Document.send :include, Kaminari::MongoidExtension::Document
+        ::Mongoid::Criteria.send :include, Kaminari::MongoidExtension::Criteria
+      end
+
+      ActiveSupport.on_load(:mongo_mapper) do
+        require 'kaminari/models/mongo_mapper_extension'
+        ::MongoMapper::Document.send :include, Kaminari::MongoMapperExtension::Document
+        ::Plucky::Query.send :include, Kaminari::PluckyCriteriaMethods
+        ::Plucky::Query.send :include, Kaminari::PageScopeMethods
+      end
+
+      if defined? ::DataMapper
+        require 'kaminari/models/data_mapper_extension'
+        ::DataMapper::Collection.send :include, Kaminari::DataMapperExtension::Collection
+        ::DataMapper::Model.append_extensions Kaminari::DataMapperExtension::Model
+        # ::DataMapper::Model.send :extend, Kaminari::DataMapperExtension::Model
+      end
+      require 'kaminari/models/array_extension'
+
+      require File.join(File.dirname(__FILE__), 'models/array_extension')
+
+      ActiveSupport.on_load(:action_view) do
+        ::ActionView::Base.send :include, Kaminari::ActionViewExtension
+      end
+    end
+  end
+end

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/module'
 module Kaminari
   # Kind of Array that can paginate
   class PaginatableArray < Array

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,49 +1,7 @@
-require 'rails'
-# ensure ORMs are loaded *before* initializing Kaminari
-begin; require 'mongoid'; rescue LoadError; end
-begin; require 'mongo_mapper'; rescue LoadError; end
-begin; require 'dm-core'; require 'dm-aggregates'; rescue LoadError; end
-
-require 'kaminari/config'
-require 'kaminari/helpers/action_view_extension'
-require 'kaminari/helpers/paginator'
-require 'kaminari/models/page_scope_methods'
-require 'kaminari/models/configuration_methods'
-
 module Kaminari
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'kaminari' do |app|
-      ActiveSupport.on_load(:active_record) do
-        require 'kaminari/models/active_record_extension'
-        ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
-      end
-
-      if defined? ::Mongoid
-        require 'kaminari/models/mongoid_extension'
-        ::Mongoid::Document.send :include, Kaminari::MongoidExtension::Document
-        ::Mongoid::Criteria.send :include, Kaminari::MongoidExtension::Criteria
-      end
-
-      ActiveSupport.on_load(:mongo_mapper) do
-        require 'kaminari/models/mongo_mapper_extension'
-        ::MongoMapper::Document.send :include, Kaminari::MongoMapperExtension::Document
-        ::Plucky::Query.send :include, Kaminari::PluckyCriteriaMethods
-        ::Plucky::Query.send :include, Kaminari::PageScopeMethods
-      end
-
-      if defined? ::DataMapper
-        require 'kaminari/models/data_mapper_extension'
-        ::DataMapper::Collection.send :include, Kaminari::DataMapperExtension::Collection
-        ::DataMapper::Model.append_extensions Kaminari::DataMapperExtension::Model
-#         ::DataMapper::Model.send :extend, Kaminari::DataMapperExtension::Model
-      end
-      require 'kaminari/models/array_extension'
-
-      require File.join(File.dirname(__FILE__), 'models/array_extension')
-
-      ActiveSupport.on_load(:action_view) do
-        ::ActionView::Base.send :include, Kaminari::ActionViewExtension
-      end
+      Kaminari::Hooks.init!
     end
   end
 end

--- a/lib/kaminari/sinatra.rb
+++ b/lib/kaminari/sinatra.rb
@@ -1,7 +1,7 @@
 require 'kaminari'
 module Kaminari
   module Helpers
-    autoload :SinatraHelper, 'kaminari/helpers/sinatra_helper'
+    autoload :SinatraHelpers, 'kaminari/helpers/sinatra_helpers'
   end
 end
 Kaminari::Hooks.init!

--- a/lib/kaminari/sinatra.rb
+++ b/lib/kaminari/sinatra.rb
@@ -1,0 +1,8 @@
+require 'kaminari'
+module Kaminari
+  module Helpers
+    autoload :SinatraHelper, 'kaminari/helpers/sinatra_helper'
+  end
+end
+Kaminari::Hooks.init!
+

--- a/spec/acceptance/users_spec.rb
+++ b/spec/acceptance/users_spec.rb
@@ -3,6 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/acceptance_helper')
 
 feature 'Users' do
   background do
+    User.delete_all
     1.upto(100) {|i| User.create! :name => "user#{'%03d' % i}" }
   end
   scenario 'navigating by pagination links' do

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -2,6 +2,7 @@ require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe 'Kaminari::ActionViewExtension' do
   before do
+    User.delete_all
     50.times {|i| User.create! :name => "user#{i}"}
   end
   describe '#paginate' do

--- a/spec/helpers/sinatra_helpers_spec.rb
+++ b/spec/helpers/sinatra_helpers_spec.rb
@@ -1,0 +1,174 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+require File.expand_path('../spec_helper_for_sinatra', File.dirname(__FILE__))
+
+ERB_TEMPLATE_FOR_PAGINATE = <<EOT
+<div>
+<ul>
+<% @users.each do |user| %>
+  <li class="user_info"><%= user.id %></li>
+<% end %>
+</ul>
+<%= paginate @users, @options %>
+</div>
+EOT
+
+ERB_TEMPLATE_FOR_NEXT_PAGE = <<EOT
+<div>
+<ul>
+<% @users.each do |user| %>
+  <li class="user_info"><%= user.id %></li>
+<% end %>
+</ul>
+<%= link_to_next_page(@users, "Next!", {:id => 'next_page_link'}.merge(@options || {})) %>
+</div>
+EOT
+
+describe 'Kaminari::Helpers::SinatraHelper' do
+  before do
+    50.times {|i| User.create! :name => "user#{i}"}
+  end
+
+  describe '#paginate' do
+    before do
+      mock_app do
+        register Kaminari::Helpers::SinatraHelpers
+        get '/users' do
+          @page = params[:page] || 1
+          @users = User.page(@page)
+          @options = {}
+          erb ERB_TEMPLATE_FOR_PAGINATE
+        end
+      end
+    end
+
+    context 'normal paginations with Sinatra' do
+      before { get '/users' }
+
+      it 'should have a navigation tag' do
+        last_document.search('nav.pagination').should_not be_empty
+      end
+
+      it 'should have pagination links' do
+        last_document.search('.page a').should have_at_least(1).items
+        last_document.search('.next a').should have_at_least(1).items
+        last_document.search('.last a').should have_at_least(1).items
+      end
+
+      it 'should point to current page' do
+        last_document.search('.current').text.should match /1/
+
+        get '/users?page=2'
+        last_document.search('.current').text.should match /2/
+      end
+
+      it 'should load 25 users' do
+        last_document.search('li.user_info').should have(25).items
+      end
+
+      it 'should preserve params' do
+        get '/users?foo=bar'
+        last_document.search('.page a').should(be_all do |elm|
+          elm.attribute('href').value =~ /foo=bar/
+        end)
+      end
+    end
+
+    context 'optional paginations with Sinatra' do
+      it 'should have 5 windows with 1 gap' do
+        mock_app do
+          register Kaminari::Helpers::SinatraHelpers
+          get '/users' do
+            @page = params[:page] || 1
+            @users = User.page(@page).per(5)
+            @options = {}
+            erb ERB_TEMPLATE_FOR_PAGINATE
+          end
+        end
+
+        get '/users'
+        last_document.search('.page').should have(6).items
+        last_document.search('.gap').should have(1).item
+      end
+
+      it 'should controll the inner window size' do
+        mock_app do
+          register Kaminari::Helpers::SinatraHelpers
+          get '/users' do
+            @page = params[:page] || 1
+            @users = User.page(@page).per(3)
+            @options = {:window => 10}
+            erb ERB_TEMPLATE_FOR_PAGINATE
+          end
+        end
+
+        get '/users'
+        last_document.search('.page').should have(12).items
+        last_document.search('.gap').should have(1).item
+      end
+
+      it 'should specify a page param name' do
+        mock_app do
+          register Kaminari::Helpers::SinatraHelpers
+          get '/users' do
+            @page = params[:page] || 1
+            @users = User.page(@page).per(3)
+            @options = {:param_name => :user_page}
+            erb ERB_TEMPLATE_FOR_PAGINATE
+          end
+        end
+
+        get '/users'
+        last_document.search('.page a').should(be_all do |elm|
+          elm.attribute('href').value =~ /user_page=\d+/
+        end)
+      end
+    end
+  end
+
+  describe '#link_to_next_page' do
+    before do
+      mock_app do
+        register Kaminari::Helpers::SinatraHelpers
+        get '/users' do
+          @page = params[:page] || 1
+          @users = User.page(@page)
+          erb ERB_TEMPLATE_FOR_NEXT_PAGE
+        end
+
+        get '/users_placeholder' do
+          @page = params[:page] || 1
+          @options = {:placeholder => %{<span id='no_next_page'>No Next Page</span>}}
+          @users = User.page(@page)
+          erb ERB_TEMPLATE_FOR_NEXT_PAGE
+        end
+      end
+    end
+
+    context 'having more page' do
+      it 'should have a more page link' do
+        get '/users'
+        last_document.search('a#next_page_link').should be_present
+        last_document.search('a#next_page_link').text.should match /Next!/
+      end
+    end
+
+    context 'the last page' do
+      before do
+        User.delete_all
+        50.times {|i| User.create! :name => "user#{i}"}
+      end
+
+      it 'should not have a more page link' do
+        get '/users?page=2'
+        last_document.search('a#next_page_link').should be_empty
+      end
+
+      it 'should have a no more page notation using placeholder' do
+        get '/users_placeholder?page=2'
+        last_document.search('a#next_page_link').should be_empty
+        last_document.search('span#no_next_page').should be_present
+        last_document.search('span#no_next_page').text.should match /No Next Page/
+      end
+    end
+  end
+end

--- a/spec/spec_helper_for_sinatra.rb
+++ b/spec/spec_helper_for_sinatra.rb
@@ -1,0 +1,14 @@
+require 'sinatra/base'
+require 'kaminari/sinatra'
+require 'rack/test'
+require 'sinatra/test_helpers'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+  config.include Sinatra::TestHelpers
+end
+
+require 'nokogiri'
+def last_document
+  Nokogiri::HTML(last_response.body)
+end


### PR DESCRIPTION
こんにちは。

twitter 等でお世話になりました。近藤うちお(@udzura)です。

このたび、 「最低限の依存」で kaminari gem とそのヘルパーを Sinatra で動かせるようになりました。 (super thanks to #161 & #174)

主な仕様は以下のとおりです。
- `gem 'kaminari', :require => 'kaminari/sinatra'` で Sinatra でも pagination scopes が利用可能になる
- Kaminari::Hooks は良いアイデアだと思ったのでマージ
- activesupport actionpack railties に依存(たとえSinatraでも)
- Sinatra での link_to_next_page ヘルパーは、ブロックをとらず :placeholder オプションを取る

（素の ERB, Erubis では

``` erb
   <%= link_to_next_page @users, 'Next Page' do %>
     <span>No More Pages</span>
   <% end %>
```

がSyntaxErrorになってしまうためです。。）
- Sinatra::Base を継承したクラスで `register Kaminari::Helpers::SinatraHelpers` を宣言すれば、ヘルパーが使用可能になる。ただし、 padrino-helper がロード可能な状態でないと警告が出て何もしない。
- テストあります

既存のテストは壊していないことを確認しています。

よろしければマージしていただければ、嬉しく思います。ご確認ください。

---- locale :en

Hi, Matsuda-san.

I am Uchio Kondo (@udzura), thank you for mentions on twitter.

This request is a patch to make kaminari and its helpers work well with Sinatra with "least" dependency (super thanks to #161 & #174)

Major specifications are below:
- With `gem 'kaminari', :require => 'kaminari/sinatra'`, pagination scopes are abailable for Sinatra.
- Kaminari::Hooks is a good idea, then merged.
- Dependent on %{activesupport actionpack railties} even if they use Sinatra.
- link_to_next_page helper method takes a :placeholder option, not a block for Sinatra.

( This is because below causes a Syntax Error:

``` erb
   <%= link_to_next_page @users, 'Next Page' do %>
     <span>No More Pages</span>
   <% end %>
```

for a naive ERB and Erubis. )
- You can `register Kaminari::Helpers::SinatraHelpers`, but if padrino-helper wouldn't be loadable it'd do nothing with warnings.
- With basic tests.

And existing tests doesn't seem to be broken.

I'm happy if you accept the request, so would you check it out?
