### PR TITLE
Allow count, total count to pass parameters to super

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -18,7 +18,11 @@ module Kaminari
 
         # .group returns an OrderdHash that responds to #count
         c = c.count(column_name, options)
-        c.respond_to?(:count) ? c.count(column_name, options) : c
+        if c.is_a?(ActiveSupport::OrderedHash)
+          c.count
+        else
+          c.respond_to?(:count) ? c.count(column_name, options) : c
+        end
       end
     end
   end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -16,15 +16,9 @@ module Kaminari
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
 
-        # a workaround to count the actual model instances on distinct query because count + distinct returns wrong value in some cases. see https://github.com/amatsuda/kaminari/pull/160
-        uses_distinct_sql_statement = c.to_sql =~ /DISTINCT/i
-        if uses_distinct_sql_statement
-          c.length
-        else
-          # .group returns an OrderdHash that responds to #count
-          c = c.count(column_name, options)
-          c.respond_to?(:count) ? c.count(column_name, options) : c
-        end
+        # .group returns an OrderdHash that responds to #count
+        c = c.count(column_name, options)
+        c.respond_to?(:count) ? c.count(column_name, options) : c
       end
     end
   end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -3,12 +3,12 @@ module Kaminari
     # a workaround for AR 3.0.x that returns 0 for #count when page > 1
     # if +limit_value+ is specified, load all the records and count them
     if ActiveRecord::VERSION::STRING < '3.1'
-      def count #:nodoc:
-        limit_value ? length : super
+      def count(column_name = nil, options = {}) #:nodoc:
+        limit_value ? length : super(column_name, options)
       end
     end
 
-    def total_count #:nodoc:
+    def total_count(column_name = nil, options = {}) #:nodoc:
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
       @total_count ||= begin
         c = except(:offset, :limit, :order)
@@ -22,8 +22,8 @@ module Kaminari
           c.length
         else
           # .group returns an OrderdHash that responds to #count
-          c = c.count
-          c.respond_to?(:count) ? c.count : c
+          c = c.count(column_name, options)
+          c.respond_to?(:count) ? c.count(column_name, options) : c
         end
       end
     end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -35,6 +35,13 @@ if defined? ActiveRecord
           User.page(1).count(:name, distinct: true).should == 4
         end
       end
+      context "when the scope returns an ActiveSupport::OrderedHash" do
+        it "should not throw exception by passing options to count" do
+          -> {
+            @author.readers.by_read_count.page(1).total_count(:name, distinct: true)
+          }.should_not raise_exception
+        end
+      end
     end
   end
 end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -25,6 +25,16 @@ if defined? ActiveRecord
           User.includes(:books_authored).where("books.title LIKE 'title00%'").page(1).total_count.should == 2
         end
       end
+      context "when total_count receives options" do
+        it "should return a distinct total count" do
+          User.page(1).total_count(:name, distinct: true).should == 4
+        end
+      end
+      context "when count receives options" do
+        it "should return a distinct set by column" do
+          User.page(1).count(:name, distinct: true).should == 4
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I have moved this commit into a feature branch, per the Github merge recommendations. This has also been rebased against upstream.

This commit allows for options to be passed to count, ie object.total_count(:distinct => true) 
