### PR TITLE
Fixing displayed number of items on each page w/ Mongoid 2.4.x and MongoMapper.

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -72,7 +72,7 @@ module Kaminari
         offset = (collection.current_page - 1) * collection.limit_value
         output = %{Displaying #{entry_name.pluralize} <b>%d&nbsp;-&nbsp;%d</b> of <b>%d</b> in total} % [
           offset + 1,
-          offset + collection.count,
+          offset + collection.current_page_count,
           collection.total_count
         ]
       end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -7,6 +7,10 @@ module Kaminari
         limit_value ? length : super
       end
     end
+    
+    def current_page_count #:nodoc:
+      count
+    end
 
     def total_count #:nodoc:
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -42,6 +42,10 @@ module Kaminari
     def total_count
       @_total_count || @_original_array.count
     end
+    
+    def current_page_count #:nodoc:
+      count
+    end
 
     # returns another chunk of the original array
     def offset(num)

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -11,5 +11,10 @@ module Kaminari
     def total_count #:nodoc:
       model.count(query.options.except(:limit, :offset, :order))
     end
+
+    def current_page_count #:nodoc:
+      count
+    end
+
   end
 end

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -11,7 +11,16 @@ module Kaminari
     def total_count #:nodoc:
       embedded? ? unpage.count : count
     end
-
+    
+    def current_page_count #:nodoc:
+      # TODO: this needs a better fix, count comes from Mongoid::Context::Mongo or Enumerable which have different signatures
+      begin
+        count(true)
+      rescue ArgumentError
+        count
+      end
+    end
+    
     private
     def unpage
       clone.tap do |crit|

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -11,5 +11,11 @@ module Kaminari
     def total_count #:nodoc:
       count
     end
+
+    def current_page_count #:nodoc:
+      # TODO: this needs a better fix, ie. pass skip_and_limit = true
+      # into http://api.mongodb.org/ruby/1.2.0/Mongo/Cursor.html#count-instance_method
+      to_a.count
+    end
   end
 end

--- a/spec/models/mongo_mapper_spec.rb
+++ b/spec/models/mongo_mapper_spec.rb
@@ -3,80 +3,90 @@ require 'mongo_mapper'
 require 'kaminari/models/mongo_mapper_extension'
 
 describe Kaminari::MongoMapperExtension do
+  
   before do
     begin
       MongoMapper.connection = Mongo::Connection.new('localhost', 27017)
       MongoMapper.database = "kaminari_test"
-      class Developer
+      class MongoMapperExtension_Developer
         include ::MongoMapper::Document
         key :salary, Integer
       end
-
-      stub(subject).count { 300 } # in order to avoid DB access...
     rescue Mongo::ConnectionFailure
       pending 'can not connect to MongoDB'
     end
   end
 
+  before(:each) do
+    MongoMapperExtension_Developer.destroy_all
+    41.times { MongoMapperExtension_Developer.create!({:salary => 1}) }
+  end
+
   describe '#page' do
     context 'page 1' do
-      subject { Developer.page(1) }
+      subject { MongoMapperExtension_Developer.page(1) }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 25 }
       it { should skip(0) }
     end
 
     context 'page 2' do
-      subject { Developer.page 2 }
+      subject { MongoMapperExtension_Developer.page 2 }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
 
     context 'page "foobar"' do
-      subject { Developer.page 'foobar' }
+      subject { MongoMapperExtension_Developer.page 'foobar' }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 25 }
       it { should skip 0 }
     end
 
     context 'with criteria before' do
       it "should have the proper criteria source" do
-        Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+        MongoMapperExtension_Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
       end
 
-      subject { Developer.where(:salary => 1).page 2 }
+      subject { MongoMapperExtension_Developer.where(:salary => 1).page 2 }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
 
     context 'with criteria after' do
       it "should have the proper criteria source" do
-        Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+        MongoMapperExtension_Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
       end
 
-      subject { Developer.page(2).where(:salary => 1) }
+      subject { MongoMapperExtension_Developer.page(2).where(:salary => 1) }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
   end
 
   describe '#per' do
-    subject { Developer.page(2).per(10) }
+    subject { MongoMapperExtension_Developer.page(2).per(10) }
     it { should be_a Plucky::Query }
     its(:current_page) { should == 2 }
     its(:limit_value) { should == 10 }
-    its(:num_pages) { should == 30 }
+    its(:num_pages) { should == 5 }
+    its(:current_page_count) { should == 10 }
     it { should skip 10 }
   end
 end

--- a/spec/models/mongo_mapper_spec.rb
+++ b/spec/models/mongo_mapper_spec.rb
@@ -8,7 +8,7 @@ describe Kaminari::MongoMapperExtension do
     begin
       MongoMapper.connection = Mongo::Connection.new('localhost', 27017)
       MongoMapper.database = "kaminari_test"
-      class MongoMapperExtension_Developer
+      class MongoMapperExtensionDeveloper
         include ::MongoMapper::Document
         key :salary, Integer
       end
@@ -18,13 +18,13 @@ describe Kaminari::MongoMapperExtension do
   end
 
   before(:each) do
-    MongoMapperExtension_Developer.destroy_all
-    41.times { MongoMapperExtension_Developer.create!({:salary => 1}) }
+    MongoMapperExtensionDeveloper.destroy_all
+    41.times { MongoMapperExtensionDeveloper.create!({:salary => 1}) }
   end
 
   describe '#page' do
     context 'page 1' do
-      subject { MongoMapperExtension_Developer.page(1) }
+      subject { MongoMapperExtensionDeveloper.page(1) }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
@@ -34,7 +34,7 @@ describe Kaminari::MongoMapperExtension do
     end
 
     context 'page 2' do
-      subject { MongoMapperExtension_Developer.page 2 }
+      subject { MongoMapperExtensionDeveloper.page 2 }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
@@ -44,7 +44,7 @@ describe Kaminari::MongoMapperExtension do
     end
 
     context 'page "foobar"' do
-      subject { MongoMapperExtension_Developer.page 'foobar' }
+      subject { MongoMapperExtensionDeveloper.page 'foobar' }
       it { should be_a Plucky::Query }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
@@ -55,10 +55,10 @@ describe Kaminari::MongoMapperExtension do
 
     context 'with criteria before' do
       it "should have the proper criteria source" do
-        MongoMapperExtension_Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+        MongoMapperExtensionDeveloper.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
       end
 
-      subject { MongoMapperExtension_Developer.where(:salary => 1).page 2 }
+      subject { MongoMapperExtensionDeveloper.where(:salary => 1).page 2 }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
       its(:num_pages) { should == 2 }
@@ -68,10 +68,10 @@ describe Kaminari::MongoMapperExtension do
 
     context 'with criteria after' do
       it "should have the proper criteria source" do
-        MongoMapperExtension_Developer.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
+        MongoMapperExtensionDeveloper.where(:salary => 1).page(2).criteria.source.should == {:salary => 1}
       end
 
-      subject { MongoMapperExtension_Developer.page(2).where(:salary => 1) }
+      subject { MongoMapperExtensionDeveloper.page(2).where(:salary => 1) }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
       its(:num_pages) { should == 2 }
@@ -81,7 +81,7 @@ describe Kaminari::MongoMapperExtension do
   end
 
   describe '#per' do
-    subject { MongoMapperExtension_Developer.page(2).per(10) }
+    subject { MongoMapperExtensionDeveloper.page(2).per(10) }
     it { should be_a Plucky::Query }
     its(:current_page) { should == 2 }
     its(:limit_value) { should == 10 }

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -9,7 +9,7 @@ describe Kaminari::MongoidExtension do
       Mongoid.configure do |config|
         config.master = Mongo::Connection.new.db("kaminari_test")
       end
-      class MongoidExtension_Developer
+      class MongoidExtensionDeveloper
         include ::Mongoid::Document
         field :salary, type: Integer
       end
@@ -19,16 +19,16 @@ describe Kaminari::MongoidExtension do
   end
 
   before(:each) do
-    MongoidExtension_Developer.all.destroy
+    MongoidExtensionDeveloper.all.destroy
     41.times do
-      MongoidExtension_Developer.create!({:salary => 1})
+      MongoidExtensionDeveloper.create!({:salary => 1})
     end
   end
 
   describe '#page' do
     
     context 'page 1' do
-      subject { MongoidExtension_Developer.page 1 }
+      subject { MongoidExtensionDeveloper.page 1 }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
@@ -38,7 +38,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'page 2' do
-      subject { MongoidExtension_Developer.page 2 }
+      subject { MongoidExtensionDeveloper.page 2 }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
@@ -48,7 +48,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'page "foobar"' do
-      subject { MongoidExtension_Developer.page 'foobar' }
+      subject { MongoidExtensionDeveloper.page 'foobar' }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
@@ -58,7 +58,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria before' do
-      subject { MongoidExtension_Developer.where(:salary => 1).page 2 }
+      subject { MongoidExtensionDeveloper.where(:salary => 1).page 2 }
       its(:selector) { should == {:salary => 1} }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
@@ -68,7 +68,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria after' do
-      subject { MongoidExtension_Developer.page(2).where(:salary => 1) }
+      subject { MongoidExtensionDeveloper.page(2).where(:salary => 1) }
       its(:selector) { should == {:salary => 1} }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
@@ -79,7 +79,7 @@ describe Kaminari::MongoidExtension do
   end
 
   describe '#per' do
-    subject { MongoidExtension_Developer.page(2).per(10) }
+    subject { MongoidExtensionDeveloper.page(2).per(10) }
     it { should be_a Mongoid::Criteria }
     its(:current_page) { should == 2 }
     its(:limit_value) { should == 10 }
@@ -90,7 +90,7 @@ describe Kaminari::MongoidExtension do
 
   describe '#page in embedded documents' do
     before :all do
-      class MongoMongoidExtension_Developer
+      class MongoMongoidExtensionDeveloper
         include ::Mongoid::Document
         field :salary, :type => Integer
         embeds_many :frameworks
@@ -105,7 +105,7 @@ describe Kaminari::MongoidExtension do
     end
 
     before :all do
-      @mongo_developer = MongoMongoidExtension_Developer.new
+      @mongo_developer = MongoMongoidExtensionDeveloper.new
       @mongo_developer.frameworks.new(:name => "rails", :language => "ruby")
       @mongo_developer.frameworks.new(:name => "merb", :language => "ruby")
       @mongo_developer.frameworks.new(:name => "sinatra", :language => "ruby")

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -3,80 +3,94 @@ require 'mongoid'
 require 'kaminari/models/mongoid_extension'
 
 describe Kaminari::MongoidExtension do
-  before :all do
-    class Developer
-      include ::Mongoid::Document
-      field :salary, :type => Integer
+
+  before do
+    begin
+      Mongoid.configure do |config|
+        config.master = Mongo::Connection.new.db("kaminari_test")
+      end
+      class MongoidExtension_Developer
+        include ::Mongoid::Document
+        field :salary, type: Integer
+      end
+    rescue Mongo::ConnectionFailure
+      pending 'can not connect to MongoDB'
+    end
+  end
+
+  before(:each) do
+    MongoidExtension_Developer.all.destroy
+    41.times do
+      MongoidExtension_Developer.create!({:salary => 1})
     end
   end
 
   describe '#page' do
-    before do
-      stub(subject).count { 300 } # in order to avoid DB access...
-    end
-
+    
     context 'page 1' do
-      subject { Developer.page 1 }
+      subject { MongoidExtension_Developer.page 1 }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 25 }
       it { should skip(0) }
     end
 
     context 'page 2' do
-      subject { Developer.page 2 }
+      subject { MongoidExtension_Developer.page 2 }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
 
     context 'page "foobar"' do
-      subject { Developer.page 'foobar' }
+      subject { MongoidExtension_Developer.page 'foobar' }
       it { should be_a Mongoid::Criteria }
       its(:current_page) { should == 1 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 25 }
       it { should skip 0 }
     end
 
     context 'with criteria before' do
-      subject { Developer.where(:salary => 1).page 2 }
+      subject { MongoidExtension_Developer.where(:salary => 1).page 2 }
       its(:selector) { should == {:salary => 1} }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
 
     context 'with criteria after' do
-      subject { Developer.page(2).where(:salary => 1) }
+      subject { MongoidExtension_Developer.page(2).where(:salary => 1) }
       its(:selector) { should == {:salary => 1} }
       its(:current_page) { should == 2 }
       its(:limit_value) { should == 25 }
-      its(:num_pages) { should == 12 }
+      its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 16 }
       it { should skip 25 }
     end
   end
 
   describe '#per' do
-    before do
-      stub(subject).count { 300 } # in order to avoid DB access...
-    end
-
-    subject { Developer.page(2).per(10) }
+    subject { MongoidExtension_Developer.page(2).per(10) }
     it { should be_a Mongoid::Criteria }
     its(:current_page) { should == 2 }
     its(:limit_value) { should == 10 }
-    its(:num_pages) { should == 30 }
+    its(:num_pages) { should == 5 }
+    its(:current_page_count) { should == 10 }
     it { should skip 10 }
   end
 
   describe '#page in embedded documents' do
     before :all do
-      class MongoDeveloper
+      class MongoMongoidExtension_Developer
         include ::Mongoid::Document
         field :salary, :type => Integer
         embeds_many :frameworks
@@ -86,44 +100,47 @@ describe Kaminari::MongoidExtension do
         include ::Mongoid::Document
         field :name, :type => String
         field :language, :type => String
-        embedded_in :mongo_developer
+        embedded_in :mongo_MongoidExtension_Developer
       end
     end
 
     before :all do
-      @mongo_developer = MongoDeveloper.new
-      @mongo_developer.frameworks.new(:name => "rails", :language => "ruby")
-      @mongo_developer.frameworks.new(:name => "merb", :language => "ruby")
-      @mongo_developer.frameworks.new(:name => "sinatra", :language => "ruby")
-      @mongo_developer.frameworks.new(:name => "cakephp", :language => "php")
-      @mongo_developer.frameworks.new(:name => "tornado", :language => "python")
+      @mongo_MongoidExtension_Developer = MongoMongoidExtension_Developer.new
+      @mongo_MongoidExtension_Developer.frameworks.new(:name => "rails", :language => "ruby")
+      @mongo_MongoidExtension_Developer.frameworks.new(:name => "merb", :language => "ruby")
+      @mongo_MongoidExtension_Developer.frameworks.new(:name => "sinatra", :language => "ruby")
+      @mongo_MongoidExtension_Developer.frameworks.new(:name => "cakephp", :language => "php")
+      @mongo_MongoidExtension_Developer.frameworks.new(:name => "tornado", :language => "python")
     end
 
     context 'page 1' do
-      subject { @mongo_developer.frameworks.page(1).per(1) }
+      subject { @mongo_MongoidExtension_Developer.frameworks.page(1).per(1) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 5 }
       its(:limit_value) { should == 1 }
       its(:current_page) { should == 1 }
       its(:num_pages) { should == 5 }
+      its(:current_page_count) { should == 1 }
     end
 
     context 'with criteria after' do
-      subject { @mongo_developer.frameworks.page(1).per(2).where(:language => "ruby") }
+      subject { @mongo_MongoidExtension_Developer.frameworks.page(1).per(2).where(:language => "ruby") }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }
       its(:current_page) { should == 1 }
       its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 2 }
     end
 
     context 'with criteria before' do
-      subject { @mongo_developer.frameworks.where(:language => "ruby").page(1).per(2) }
+      subject { @mongo_MongoidExtension_Developer.frameworks.where(:language => "ruby").page(1).per(2) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }
       its(:current_page) { should == 1 }
       its(:num_pages) { should == 2 }
+      its(:current_page_count) { should == 2 }
     end
   end
 end

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -100,21 +100,21 @@ describe Kaminari::MongoidExtension do
         include ::Mongoid::Document
         field :name, :type => String
         field :language, :type => String
-        embedded_in :mongo_MongoidExtension_Developer
+        embedded_in :mongo_mongoid_extension_developer
       end
     end
 
     before :all do
-      @developer = MongoMongoidExtension_Developer.new
-      @developer.frameworks.new(:name => "rails", :language => "ruby")
-      @developer.frameworks.new(:name => "merb", :language => "ruby")
-      @developer.frameworks.new(:name => "sinatra", :language => "ruby")
-      @developer.frameworks.new(:name => "cakephp", :language => "php")
-      @developer.frameworks.new(:name => "tornado", :language => "python")
+      @mongo_developer = MongoMongoidExtension_Developer.new
+      @mongo_developer.frameworks.new(:name => "rails", :language => "ruby")
+      @mongo_developer.frameworks.new(:name => "merb", :language => "ruby")
+      @mongo_developer.frameworks.new(:name => "sinatra", :language => "ruby")
+      @mongo_developer.frameworks.new(:name => "cakephp", :language => "php")
+      @mongo_developer.frameworks.new(:name => "tornado", :language => "python")
     end
 
     context 'page 1' do
-      subject { @developer.frameworks.page(1).per(1) }
+      subject { @mongo_developer.frameworks.page(1).per(1) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 5 }
       its(:limit_value) { should == 1 }
@@ -124,7 +124,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria after' do
-      subject { @developer.frameworks.page(1).per(2).where(:language => "ruby") }
+      subject { @mongo_developer.frameworks.page(1).per(2).where(:language => "ruby") }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }
@@ -134,7 +134,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria before' do
-      subject { @developer.frameworks.where(:language => "ruby").page(1).per(2) }
+      subject { @mongo_developer.frameworks.where(:language => "ruby").page(1).per(2) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -105,16 +105,16 @@ describe Kaminari::MongoidExtension do
     end
 
     before :all do
-      @mongo_MongoidExtension_Developer = MongoMongoidExtension_Developer.new
-      @mongo_MongoidExtension_Developer.frameworks.new(:name => "rails", :language => "ruby")
-      @mongo_MongoidExtension_Developer.frameworks.new(:name => "merb", :language => "ruby")
-      @mongo_MongoidExtension_Developer.frameworks.new(:name => "sinatra", :language => "ruby")
-      @mongo_MongoidExtension_Developer.frameworks.new(:name => "cakephp", :language => "php")
-      @mongo_MongoidExtension_Developer.frameworks.new(:name => "tornado", :language => "python")
+      @developer = MongoMongoidExtension_Developer.new
+      @developer.frameworks.new(:name => "rails", :language => "ruby")
+      @developer.frameworks.new(:name => "merb", :language => "ruby")
+      @developer.frameworks.new(:name => "sinatra", :language => "ruby")
+      @developer.frameworks.new(:name => "cakephp", :language => "php")
+      @developer.frameworks.new(:name => "tornado", :language => "python")
     end
 
     context 'page 1' do
-      subject { @mongo_MongoidExtension_Developer.frameworks.page(1).per(1) }
+      subject { @developer.frameworks.page(1).per(1) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 5 }
       its(:limit_value) { should == 1 }
@@ -124,7 +124,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria after' do
-      subject { @mongo_MongoidExtension_Developer.frameworks.page(1).per(2).where(:language => "ruby") }
+      subject { @developer.frameworks.page(1).per(2).where(:language => "ruby") }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }
@@ -134,7 +134,7 @@ describe Kaminari::MongoidExtension do
     end
 
     context 'with criteria before' do
-      subject { @mongo_MongoidExtension_Developer.frameworks.where(:language => "ruby").page(1).per(2) }
+      subject { @developer.frameworks.where(:language => "ruby").page(1).per(2) }
       it { should be_a Mongoid::Criteria }
       its(:total_count) { should == 3 }
       its(:limit_value) { should == 2 }


### PR DESCRIPTION
The number of items on the current page broke in Mongoid 2.4 and looks broken with Mongomapper 0.10.1 (don't know since when). The Mongo Ruby driver takes a parameter to specify whether count should respect `:limit` or whether to return the count for the entire collection.

Introducing `current_page_count` that wraps `count` most of the time, except when count is more complicated.

Fixed specs to work with an actual mongodb database for both mongoid and mongo_mapper and removed the stubs that hid the pagination problem.
