### PR TITLE
Add helper to generate rel="next" and rel="prev" link tags for SEO (fixes Issue #163).

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -78,5 +78,45 @@ module Kaminari
       end
       output.html_safe
     end
+
+    # Renders rel="next" and rel="prev" links to be used in the head.
+    #
+    # ==== Examples
+    # Basic usage:
+    #
+    #   In head:
+    #   <head>
+    #     <title>My Website</title>
+    #     <%= yield :head %>
+    #   </head>
+    #
+    #   Somewhere in body:
+    #   <% content_for :head do %>
+    #     <%= rel_next_prev_link_tags @items %>
+    #   <% end %>
+    #
+    #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
+    #
+    def rel_next_prev_link_tags(scope, options = {})
+      params = options.delete(:params) || {}
+      param_name = options.delete(:param_name) || Kaminari.config.param_name
+
+      output = ""
+
+      if !scope.first_page? && !scope.last_page?
+        # If not first and not last, then output both links.
+        output << '<link rel="next" href="' + url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>'
+        output << '<link rel="prev" href="' + url_for(params.merge(param_name => (scope.current_page - 1))) + '"/>'
+      elsif scope.first_page?
+        # If first page, add next link unless last page.
+        output << '<link rel="next" href="' + url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>' unless scope.last_page?
+      else
+        # If last page, add prev link unless first page.
+        output << '<link rel="prev" href="' + url_for(params.merge(param_name => (scope.current_page - 1))) + '"/>' unless scope.first_page?
+      end
+
+      output.html_safe
+    end
+
   end
 end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -112,4 +112,40 @@ describe 'Kaminari::ActionViewExtension' do
       end
     end
   end
+
+  describe '#rel_next_prev_link_tags' do
+    before do
+      75.times {|i| User.create! :name => "user#{i}"}
+    end
+    context 'the first page' do
+      before do
+        @users = User.page(1).per(25)
+      end
+
+      subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'users', :action => 'index'} }
+      it { should be_a String }
+      it { should match /rel="next"/ }
+      it { should_not match /rel="prev"/ }
+    end
+    context 'the middle page' do
+      before do
+        @users = User.page(2).per(25)
+      end
+
+      subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'users', :action => 'index'} }
+      it { should be_a String }
+      it { should match /rel="next"/ }
+      it { should match /rel="prev"/ }
+    end
+    context 'the last page' do
+      before do
+        @users = User.page(3).per(25)
+      end
+
+      subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'users', :action => 'index'} }
+      it { should be_a String }
+      it { should_not match /rel="next"/ }
+      it { should match /rel="prev"/ }
+    end
+  end
 end


### PR DESCRIPTION
I added a view helper method to generate the rel="next" and rel="prev" link tags that are used for SEO.  I added rspec tests for the view helper, but was not able to get rspec to run successfully (I think I just have the wrong versions of gems installed).  But it should be pretty straightforward.

@Rio517 - This happens to fix https://github.com/amatsuda/kaminari/issues/163.
