### PR TITLE
Support for grouped values coming from count

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -9,6 +9,8 @@ module Kaminari
     end
     
     def current_page_count #:nodoc:
+      return count.length if count.is_a?(ActiveSupport::OrderedHash)
+
       count
     end
 


### PR DESCRIPTION
Calling count on a relation is not guaranteed to return an integer. It can return an OrderedHash if the relation is using a group clause.

> Grouped values: This returns an ordered hash of the values and groups them by the :group option.

[Source](http://ar.rubyonrails.org/classes/ActiveRecord/Calculations/ClassMethods.html#M000297)

This fix checks to see if that is the case and returns the length of that hash instead of the hash itself.
