### PR TITLE
Use page 1 in the params

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -25,7 +25,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        @template.url_for @params.merge(@param_name => (page < 1 ? nil : page))
       end
     end
 


### PR DESCRIPTION
When creating the pagination links, page 1 is not included for the links that go to page 1. This means that whatever is being paginated has to know that when no page param is set, it mean page one.

It is better form to explicitly set the page number all the time, ensuring that it will always work regardless of the underlying implementation.
