### PR TITLE
From PATH_INFO to REQUEST_PATH in Sinatra helper

### DIFF
--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -78,7 +78,7 @@ module Kaminari::Helpers
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, options = {}, &block)
-        current_path = env['PATH_INFO'] rescue nil
+        current_path = env['REQUEST_PATH'] rescue nil
         current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
         paginator = Kaminari::Helpers::Paginator.new(
           ActionViewTemplateProxy.new(:current_params => current_params, :current_path => current_path, :param_name => options[:param_name] || Kaminari.config.param_name),


### PR DESCRIPTION
While developing Pardino application and dealing with admin-module I faced a problem, that the Kaminati paginate function, return paths like `/:resource`, while it should return something like `/admin/:resource`.
Padrino environment contains two things PATH_INFO and REQUEST_PATH. I believe PATH_INFO contains path relative to Padrino::Application instance, while instance may have its own mapping, and REQUEST_PATH contains url relative path. So I suppose, REQUEST_PATH is more appropriate there.
