### PR TITLE
require 'dm-aggregates' in DataMapper hook

### DIFF
--- a/lib/kaminari/hooks.rb
+++ b/lib/kaminari/hooks.rb
@@ -8,6 +8,7 @@ module Kaminari
 
       begin; require 'data_mapper'; rescue LoadError; end
       if defined? ::DataMapper
+        require 'dm-aggregates'
         require 'kaminari/models/data_mapper_extension'
         ::DataMapper::Collection.send :include, Kaminari::DataMapperExtension::Collection
         ::DataMapper::Model.append_extensions Kaminari::DataMapperExtension::Model


### PR DESCRIPTION
To work fine Kaminari need dm-aggregates so it's better to require it
if the DataMapper extension is active to be sure this gem is install in
runtime and can avoid some issue see #220
