### PR TITLE
Subclasses are including ActiveRecordModelExtension too fast

### DIFF
--- a/lib/kaminari/models/active_record_extension.rb
+++ b/lib/kaminari/models/active_record_extension.rb
@@ -4,18 +4,21 @@ module Kaminari
   module ActiveRecordExtension
     extend ActiveSupport::Concern
     included do
+      @_subclasses_loaded = false
       # Future subclasses will pick up the model extension
       class << self
         def inherited_with_kaminari(kls) #:nodoc:
+          # First model should also force subclasses to pick up the model extension as well
+          unless @_subclasses_loaded
+            self.descendants.each do |kls|
+              kls.send(:include, Kaminari::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
+            end
+            @_subclasses_loaded = true
+          end
           inherited_without_kaminari kls
           kls.send(:include, Kaminari::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
         end
         alias_method_chain :inherited, :kaminari
-      end
-
-      # Existing subclasses pick up the model extension as well
-      self.descendants.each do |kls|
-        kls.send(:include, Kaminari::ActiveRecordModelExtension) if kls.superclass == ActiveRecord::Base
       end
     end
   end


### PR DESCRIPTION
Hi,

In regard of this issue: https://github.com/amatsuda/kaminari/pull/119
Everything works fine, unless you want to change the configuration of Kaminari (for example change the page_method_name)

I'm using paper_trail in project, but I'm also kind of forced to change the page_method_name. 
First paper_trail is loaded, then kaminari after ActiveSupport loads, then all 'subclasses' are having ActiveRecordModelExtension included, right with Version model which is provided by paper_trail, but unfortunately the extensions are loaded before the configuration file from project is loaded, therefore, Version model has default kaminari config, while other projects model have proper config.

I've changed active_record_extension to load subclasses when first model is 'loaded' in project.
