### PR TITLE
Add max_per_page config value

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,7 +73,7 @@ Then bundle:
 
 You can configure the following default values by overriding these values using <tt>Kaminari.configure</tt> method.
   default_per_page  # 25 by default
-  max_per_page      # 0 by default
+  max_per_page      # nil by default
   window            # 4 by default
   outer_window      # 0 by default
   left              # 0 by default
@@ -104,7 +104,7 @@ Run the following generator command, then edit the generated file.
 * +max_paginates_per+
 
   You can specify max +per_page+ value per each model using the following declarative DSL.
-  If the variable that specified via +per+ scope is more than this variable, max +paginates_per+ is used instead of it. Default value is 0, which means you are not specifying max +per_page+ value.
+  If the variable that specified via +per+ scope is more than this variable, max +paginates_per+ is used instead of it. Default value is nil, which means you are not imposing any max +per_page+ value.
     class User < ActiveRecord::Base
       max_paginates_per 100
     end

--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,7 @@ Then bundle:
 
 You can configure the following default values by overriding these values using <tt>Kaminari.configure</tt> method.
   default_per_page  # 25 by default
+  max_per_page      # 0 by default
   window            # 4 by default
   outer_window      # 0 by default
   left              # 0 by default
@@ -96,6 +97,16 @@ Run the following generator command, then edit the generated file.
   You can specify default +per_page+ value per each model using the following declarative DSL.
     class User < ActiveRecord::Base
       paginates_per 50
+    end
+
+=== Configuring max +per_page+ value for each model
+
+* +max_paginates_per+
+
+  You can specify max +per_page+ value per each model using the following declarative DSL.
+  If the variable that specified via +per+ scope is more than this variable, max +paginates_per+ is used instead of it. Default value is 0, which means you are not specifying max +per_page+ value.
+    class User < ActiveRecord::Base
+      max_paginates_per 100
     end
 
 === Controllers

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -18,6 +18,7 @@ module Kaminari
   class Configuration #:nodoc:
     include ActiveSupport::Configurable
     config_accessor :default_per_page
+    config_accessor :max_per_page
     config_accessor :window
     config_accessor :outer_window
     config_accessor :left
@@ -37,6 +38,7 @@ module Kaminari
   # this is ugly. why can't we pass the default value to config_accessor...?
   configure do |config|
     config.default_per_page = 25
+    config.max_per_page = 0
     config.window = 4
     config.outer_window = 0
     config.left = 0

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -38,7 +38,7 @@ module Kaminari
   # this is ugly. why can't we pass the default value to config_accessor...?
   configure do |config|
     config.default_per_page = 25
-    config.max_per_page = 0
+    config.max_per_page = nil
     config.window = 4
     config.outer_window = 0
     config.left = 0

--- a/lib/kaminari/models/configuration_methods.rb
+++ b/lib/kaminari/models/configuration_methods.rb
@@ -15,6 +15,20 @@ module Kaminari
       def default_per_page
         @_default_per_page ||= Kaminari.config.default_per_page
       end
+
+      # Overrides the max +per_page+ value per model
+      #   class Article < ActiveRecord::Base
+      #     max_paginates_per 100
+      #   end
+      def max_paginates_per(val)
+        @_max_per_page = val
+      end
+
+      # This model's max +per_page+ value
+      # returns +max_per_page+ value unless explicitly overridden via <tt>max_paginates_per</tt>
+      def max_per_page
+        @_max_per_page ||= Kaminari.config.max_per_page
+      end
     end
   end
 end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -5,6 +5,8 @@ module Kaminari
     def per(num)
       if (n = num.to_i) <= 0
         self
+      elsif max_per_page != 0 && max_per_page < n
+        limit(max_per_page).offset(offset_value / limit_value * max_per_page)
       else
         limit(n).offset(offset_value / limit_value * n)
       end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -5,7 +5,7 @@ module Kaminari
     def per(num)
       if (n = num.to_i) <= 0
         self
-      elsif max_per_page != 0 && max_per_page < n
+      elsif max_per_page && max_per_page < n
         limit(max_per_page).offset(offset_value / limit_value * max_per_page)
       else
         limit(n).offset(offset_value / limit_value * n)

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -17,6 +17,21 @@ describe Kaminari::Configuration do
     end
   end
 
+  describe 'max_per_page' do
+    context 'by default' do
+      its(:max_per_page) { should == 0 }
+    end
+    context 'configure via config block' do
+      before do
+        Kaminari.configure {|c| c.max_per_page = 100}
+      end
+      its(:max_per_page) { should == 100 }
+      after do
+        Kaminari.configure {|c| c.max_per_page = 0}
+      end
+    end
+  end
+
   describe 'window' do
     context 'by default' do
       its(:window) { should == 4 }

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -19,7 +19,7 @@ describe Kaminari::Configuration do
 
   describe 'max_per_page' do
     context 'by default' do
-      its(:max_per_page) { should == 0 }
+      its(:max_per_page) { should == nil }
     end
     context 'configure via config block' do
       before do
@@ -27,7 +27,7 @@ describe Kaminari::Configuration do
       end
       its(:max_per_page) { should == 100 }
       after do
-        Kaminari.configure {|c| c.max_per_page = 0}
+        Kaminari.configure {|c| c.max_per_page = nil}
       end
     end
   end

--- a/spec/models/active_record/max_per_page_spec.rb
+++ b/spec/models/active_record/max_per_page_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+if defined? ActiveRecord
+
+  describe 'max per_page' do
+    describe 'AR::Base' do
+      subject { ActiveRecord::Base }
+      it { should_not respond_to :max_paginates_per }
+    end
+
+    subject { User.page(0).per(100) }
+
+    context 'by default' do
+      its(:limit_value) { should == 100 }
+    end
+
+    context 'when explicitly set via max_paginates_per' do
+      before { User.max_paginates_per 10 }
+      its(:limit_value) { should == 10 }
+      after { User.max_paginates_per nil }
+    end
+
+    describe "max per_page value's independency per model" do
+      context "when User's max per_page was changed" do
+        before { User.max_paginates_per 10 }
+        subject { Book.page(0).per(100) }
+        its(:limit_value) { should == 100 }
+        after { User.max_paginates_per nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,
I'm trying to use kaminari for implementing a REST API, and thought it would be great if there was a max_per_page configuration.
It would be useful for the case when you want to handle a "per_page" value from the API request (e.g. set `max_per_page 100` so that you won't accept `per_page = 500` API request, and treat that request just as `per_page = 100`).
I would really appreciate it if you took a look.

Thanks,
Keiko
