### PR TITLE
Make Kaminari.config.default_per_page changeable again 

### DIFF
--- a/lib/kaminari/models/configuration_methods.rb
+++ b/lib/kaminari/models/configuration_methods.rb
@@ -27,7 +27,7 @@ module Kaminari
       # This model's max +per_page+ value
       # returns +max_per_page+ value unless explicitly overridden via <tt>max_paginates_per</tt>
       def max_per_page
-        @_max_per_page ||= Kaminari.config.max_per_page
+        @_max_per_page || Kaminari.config.max_per_page
       end
     end
   end


### PR DESCRIPTION
This is a fix for #280. The change in @eaca75e breaks one of spree's specs so I've just reverted the change.
I believe this doesn't effect anything including performance though `@var ||= config.value` style is usually preferred.
