### PR TITLE
somewhat cleaner config

### DIFF
--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -6,44 +6,65 @@ module Kaminari
   #     config.default_per_page = 10
   #   end
   def self.configure(&block)
-    yield @config ||= Kaminari::Configuration.new
+    yield Kaminari::Configuration
   end
 
   # Global settings for Kaminari
   def self.config
-    @config
+    Kaminari::Configuration
   end
 
-  # need a Class for 3.0
-  class Configuration #:nodoc:
+  module Configurable
+    # just for patching AS::Configurable#config_accessor
+    extend ActiveSupport::Concern
     include ActiveSupport::Configurable
-    config_accessor :default_per_page
-    config_accessor :max_per_page
-    config_accessor :window
-    config_accessor :outer_window
-    config_accessor :left
-    config_accessor :right
-    config_accessor :page_method_name
 
-    def param_name
+    included do
+      class << self
+        def config_accessor(*names)
+          super
+          names.each do |name|
+            send("#{name}=",yield) if block_given?
+          end
+        end
+      end
+
+      def self.config_writer(*names)
+        # define just the writer (copied from AS::Configurable)
+        names.each do |name|
+          writer, line = "def #{name}=(value); config.#{name} = value; end", __LINE__
+          singleton_class.class_eval writer, __FILE__, line
+          send("#{name}=",yield) if block_given?
+        end
+      end
+    end
+  end
+
+  module Configuration #:nodoc:
+    include Configurable
+
+    CONFIG_OPTIONS = {
+      :default_per_page => 25,
+      :max_per_page     => nil,
+      :window           => 4,
+      :outer_window     => 0,
+      :left             => 0,
+      :right            => 0,
+      :page_method_name => :page
+    }
+
+    CONFIG_OPTIONS.each do |k,v|
+      config_accessor k do
+        v
+      end
+    end
+
+    def self.param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
     end
 
-    # define param_name writer (copied from AS::Configurable)
-    writer, line = 'def param_name=(value); config.param_name = value; end', __LINE__
-    singleton_class.class_eval writer, __FILE__, line
-    class_eval writer, __FILE__, line
-  end
-
-  # this is ugly. why can't we pass the default value to config_accessor...?
-  configure do |config|
-    config.default_per_page = 25
-    config.max_per_page = nil
-    config.window = 4
-    config.outer_window = 0
-    config.left = 0
-    config.right = 0
-    config.page_method_name = :page
-    config.param_name = :page
+    config_writer :param_name do
+      :page
+    end
   end
 end


### PR DESCRIPTION
There was a comment asking why a default values to `config_accessor` can't be passed. 
I got intrigued and found out that it's because passing default values was enabled only in the _ActiveSupport_ edge. (https://github.com/rails/rails/commit/1efe30). 

I've also changed `Kaminari::Configuration` to be a module instead of a class since it's a singleton. 

What do you think?
