### PR TITLE
Align kaminari views format

### DIFF
--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote} %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote %>
 </span>

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote
 '


### PR DESCRIPTION
kaminari view format is little difference between _first_page.html.xxx and _last_page.html.xxx.
so I remove hash brace from _last_page.html.xxx. :)

_first_page.html.haml is like this:

``` ruby
%span.first
  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
```

_last_page.html.haml is like this:

``` ruby
%span.last
  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
```
