### PR TITLE
Explicit integer conversion of page number

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -151,7 +151,7 @@ module Kaminari
         end
 
         def to_i
-          number
+          number.to_i
         end
 
         def to_s


### PR DESCRIPTION
Kaminari paginate method might be passed an object with page numbers represented as string (objects not generated from kaminari page scopes and paginate_array). This ensures that page numbers are properly handled as integers.
