### PR TITLE
Allow nil for #per, to return records without limit (like ActiveRelation#limit)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,7 +62,11 @@ Then bundle:
   To show a lot more users per each page (change the +per_page+ value)
     User.page(7).per(50)
   Note that the +per+ scope is not directly defined on the models but is just a method defined on the page scope. This is absolutely reasonable because you will never actually use +per_page+ without specifying the +page+ number.
-
+  
+  If you would like to specify "no limit" while still using the +per+ scope, you can pass +nil+:
+    User.count                 # => 1000
+    User.page(1).per(nil).size # => 1000
+    
 * the +padding+ scope
 
   Occasionally you need to padding a number of records that is not a multiple of the page size.

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,7 +3,9 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if (n = num.to_i) <= 0
+      if num.nil?
+        limit(nil)
+      elsif (n = num.to_i) <= 0
         self
       elsif max_per_page && max_per_page < n
         limit(max_per_page).offset(offset_value / limit_value * max_per_page)

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -58,6 +58,11 @@ if defined? ActiveRecord
             it { should have(5).users }
             its('first.name') { should == 'user001' }
           end
+          
+          context "page 1 per nil" do
+            subject { model_class.page(1).per(nil) }
+            it { should have(model_class.count).users }
+          end
         end
 
         describe '#padding' do


### PR DESCRIPTION
This option would make the `per` scope consistent with how ActiveRecord's `limit` works. Incidentally, it is also how `will_paginate` functions.

``` ruby
Post.count #=> 1000
Post.limit(nil).count #=> 1000
```

This commit would allow us to do something similar, by _explicitly_ passing in nil. Leaving off `per` would still return the `default_per_page`:

``` ruby
Post.count #=> 1000
Post.page(params[:page]).per(nil).count #=> 1000
Post.page(params[:page]).count #=> 25

```

This is useful when, for example, you're systematically setting the `per_page` attribute for each model, for an admin CMS, and for some sections, pagination doesn't make sense or would be wrong. It will help keep consistent queries throughout an application.

``` ruby
class User < ActiveRecord::Base
  def self.per_page
    nil
  end
end

class Post < ActiveRecord::Base
  def self.per_page
    50
  end
end

class AdminController < ApplicationController
  def index
    @klass = params[:controller].singularize.camelize.constantize
    @records = @klass.page(params[:page]).per(@klass.per_page)
  end
end 
```

This is an overly-simple example, but I think you can see how it could come in handy, and why it makes more sense to allow this, to keep consistent with ActiveRecord.
