### PR TITLE
Do not merge "WHERE" conditions into last one during pagination

### DIFF
--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -11,6 +11,7 @@ module Kaminari
         # Fetch the values at the specified page number
         #   Model.page(5)
         define_method Kaminari.config.page_method_name do |*args|
+          raise ArgumentError.new("wrong number of arguments(#{args.size} for 1)") if args.size > 1
           num = args.first
           self.
             limit(default_per_page).

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -10,7 +10,8 @@ module Kaminari
       class << self
         # Fetch the values at the specified page number
         #   Model.page(5)
-        define_method Kaminari.config.page_method_name do |num = 0|
+        define_method Kaminari.config.page_method_name do |*args|
+          num = args.first
           self.
             limit(default_per_page).
             offset(default_per_page * ([num.to_i, 1].max - 1)).

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -6,14 +6,17 @@ module Kaminari
 
     included do
       self.send(:include, Kaminari::ConfigurationMethods)
-
-      # Fetch the values at the specified page number
-      #   Model.page(5)
-      self.scope Kaminari.config.page_method_name, Proc.new {|num|
-        limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
-      } do
-        include Kaminari::ActiveRecordRelationMethods
-        include Kaminari::PageScopeMethods
+     
+      class << self
+        # Fetch the values at the specified page number
+        #   Model.page(5)
+        define_method Kaminari.config.page_method_name do |num = 0|
+          self.
+            limit(default_per_page).
+            offset(default_per_page * ([num.to_i, 1].max - 1)).
+            extending(Kaminari::ActiveRecordRelationMethods).
+            extending(Kaminari::PageScopeMethods)
+        end       
       end
     end
   end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 if defined? ActiveRecord
   describe Kaminari::ActiveRecordRelationMethods do
+    describe '#page' do
+      it "should accept no arguments" do
+        lambda { User.page }.should_not raise_error
+      end
+
+      it "should accept 1 argument" do
+        lambda { User.page(5) }.should_not raise_error
+      end
+
+      it "should not accept 2 arguments" do
+        lambda { User.page(5,2) }.should raise_error(ArgumentError)
+      end
+    end
+
     describe '#total_count' do
       before do
         @author = User.create! :name => 'author'
@@ -40,6 +54,12 @@ if defined? ActiveRecord
           lambda {
             @author.readers.by_read_count.page(1).total_count(:name, :distinct => true)
           }.should_not raise_exception
+        end
+      end
+      context "when there are multiple conditions for one attribute" do
+        it "should successfully count the results" do
+          scope = User.where(:name => ['author', 'author2']).where(:name => ['author2', 'author3'])
+          scope.page(1).total_count.should == 1
         end
       end
     end


### PR DESCRIPTION
Due to rails merging "where" conditions with same
left hand side, queries like:

``` ruby
Product.where(:number => [1,2,3]).where(:number => [2,3,4]).page(1)
```

Resulted in SQL like

``` sql
SELECT * FROM products WHERE number IN (2,3,4) LIMIT 25 OFFSET 0
```

Which was wrong. It was caused by named scopes.
I got rid of them and used standard class method,
preferred for Rails 3.x.
