### PR TITLE
Add the ability to call #num_pages method

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -24,7 +24,7 @@ module Kaminari
         @theme = @options[:theme] ? "#{@options[:theme]}/" : ''
         @options[:current_page] = PageProxy.new @window_options.merge(@options), @options[:current_page], nil
         #FIXME for compatibility. remove num_pages at some time in the future
-        @options[:total_pages] ||= @options[:num_pages]
+        @options[:num_pages] ||= @options[:total_pages]
         @last = nil
         # initialize the output_buffer for Context
         @output_buffer = ActionView::OutputBuffer.new


### PR DESCRIPTION
This PR is for solving #284.
from version 14.0, Paginator class will get `@options[:total_pages]` instead of `@options[:num_pages]`. Sometimes, this causes NoMethodError so I just pass the same value to `@options[:num_pages]`.

Note that we won't make `num_page` deprecated for now.
