### PR TITLE
Fix coercion error when offset_value is nil

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -4,7 +4,7 @@ module Kaminari
     #   Model.page(3).per(10)
     def per(num)
       if num.nil?
-        limit(nil)
+        limit(nil).offset(0)
       elsif (n = num.to_i) <= 0
         self
       elsif max_per_page && max_per_page < n
@@ -20,6 +20,8 @@ module Kaminari
 
     # Total number of pages
     def total_pages
+      return 1 if limit_value.nil?
+
       total_pages_count = (total_count.to_f / limit_value).ceil
       if max_pages.present? && max_pages < total_pages_count
         max_pages
@@ -32,6 +34,7 @@ module Kaminari
 
     # Current page number
     def current_page
+      return 1 if limit_value.nil?
       (offset_value / limit_value) + 1
     end
 

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -123,6 +123,11 @@ if defined? ActiveRecord
             subject { model_class.page }
             its(:total_pages) { should == 4 }
           end
+          
+          context "with per(nil)" do
+            subject { model_class.page.per(nil) }
+            its(:total_pages) { should == 1 }
+          end
         end
 
 
@@ -135,6 +140,11 @@ if defined? ActiveRecord
           context 'page 2' do
             subject { model_class.page(2).per 3 }
             its(:current_page) { should == 2 }
+          end
+          
+          context "with per(nil)" do
+            subject { model_class.page.per(nil) }
+            its(:current_page) { should == 1 }
           end
         end
 


### PR DESCRIPTION
This commit does two things:
- Adds `.offset(0)` when limit is set to `nil` for consistency (See PR #304)
- Force-returns `1` for `#total_pages` and `#current_page` when
  using `per(nil)`. This avoids "Cannot coerce nil into Fixnum"
  errors, and will also prevent "ZeroDivisionError" if
  `limit_value` is ever typecast using `to_i`.
