### PR TITLE
Supported route prefix (or namespace) which was added in Rails 3.1.

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -13,7 +13,7 @@ module Kaminari
     # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
     # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
     # * <tt>:remote</tt> - Ajax? (false by default)
-    # * <tt>:route_prefix</tt> - namespace of router (current engine's namespace by default)
+    # * <tt>:route_set</tt> - namespace of router (current engine's namespace by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
       paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
@@ -40,8 +40,8 @@ module Kaminari
     def link_to_previous_page(scope, name, options = {}, &block)
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      route_prefix = options.delete(:route_prefix)
-      url = (route_prefix || self).url_for params.merge(param_name => (scope.current_page - 1))
+      route_set = options.delete(:route_set)
+      url = (route_set || self).url_for params.merge(param_name => (scope.current_page - 1))
       link_to_unless scope.first_page?, name, url, options.reverse_merge(:rel => 'previous') do
         block.call if block
       end
@@ -67,8 +67,8 @@ module Kaminari
     def link_to_next_page(scope, name, options = {}, &block)
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      route_prefix = options.delete(:route_prefix)
-      url = (route_prefix || self).url_for params.merge(param_name => (scope.current_page + 1))
+      route_set = options.delete(:route_set)
+      url = (route_set || self).url_for params.merge(param_name => (scope.current_page + 1))
       link_to_unless scope.last_page?, name, url, options.reverse_merge(:rel => 'next') do
         block.call if block
       end
@@ -134,14 +134,14 @@ module Kaminari
     def rel_next_prev_link_tags(scope, options = {})
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      route_prefix = options.delete(:route_prefix)
+      route_set = options.delete(:route_set)
 
       output = ""
       unless scope.last_page?
-        output << '<link rel="next" href="' + (route_prefix || self).url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>'
+        output << '<link rel="next" href="' + (route_set || self).url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>'
       end
       unless scope.first_page?
-        output << '<link rel="prev" href="' + (route_prefix || self).url_for(params.merge(param_name => (scope.current_page - 1))) + '"/>'
+        output << '<link rel="prev" href="' + (route_set || self).url_for(params.merge(param_name => (scope.current_page - 1))) + '"/>'
       end
 
       output.html_safe

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -16,6 +16,7 @@ module Kaminari
       def initialize(template, options = {}) #:nodoc:
         @template, @options = template, options.dup
         @param_name = @options.delete(:param_name)
+        @route_prefix = @options.delete(:route_prefix)
         @theme = @options[:theme] ? "#{@options.delete(:theme)}/" : ''
         @params = @options[:params] ? template.params.merge(@options.delete :params) : template.params
       end
@@ -25,7 +26,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        (@route_prefix || @template).url_for @params.merge(@param_name => (page <= 1 ? nil : page))
       end
     end
 

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -16,7 +16,7 @@ module Kaminari
       def initialize(template, options = {}) #:nodoc:
         @template, @options = template, options.dup
         @param_name = @options.delete(:param_name)
-        @route_prefix = @options.delete(:route_prefix)
+        @route_set = @options.delete(:route_set)
         @theme = @options[:theme] ? "#{@options.delete(:theme)}/" : ''
         @params = @options[:params] ? template.params.merge(@options.delete :params) : template.params
       end
@@ -26,7 +26,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        (@route_prefix || @template).url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        (@route_set || @template).url_for @params.merge(@param_name => (page <= 1 ? nil : page))
       end
     end
 

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -16,8 +16,19 @@ app.config.root = File.dirname(__FILE__)
 Rails.backtrace_cleaner.remove_silencers!
 app.initialize!
 
+# fake engine
+module MyEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace MyEngine
+    routes.draw do
+      resources :items
+    end
+  end
+end
+
 # routes
 app.routes.draw do
+  mount MyEngine::Engine, :at => '/mounted_engine'
   resources :users
 end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -15,9 +15,11 @@ describe 'Kaminari::ActionViewExtension' do
       end
     end
 
-    context 'using route prefix' do
-      subject { helper.paginate @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
-      it { should match(%r(/mounted_engine/items)) }
+    if defined? Rails
+      context 'using route prefix' do
+        subject { helper.paginate @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        it { should match(%r(/mounted_engine/items)) }
+      end
     end
   end
 
@@ -38,9 +40,11 @@ describe 'Kaminari::ActionViewExtension' do
         subject { helper.link_to_previous_page @users, 'Previous', :rel => 'external', :params => {:controller => 'users', :action => 'index'} }
         it { should match(/rel="external"/) }
       end
-      context 'using route prefix' do
-        subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
-        it { should match(%r(/mounted_engine/items)) }
+      if defined? Rails
+        context 'using route prefix' do
+          subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+          it { should match(%r(/mounted_engine/items)) }
+        end
       end
     end
     context 'the first page' do
@@ -69,9 +73,11 @@ describe 'Kaminari::ActionViewExtension' do
         subject { helper.link_to_next_page @users, 'More', :rel => 'external', :params => {:controller => 'users', :action => 'index'} }
         it { should match(/rel="external"/) }
       end
-      context 'using route prefix' do
-        subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
-        it { should match(%r(/mounted_engine/items)) }
+      if defined? Rails
+        context 'using route prefix' do
+          subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+          it { should match(%r(/mounted_engine/items)) }
+        end
       end
     end
     context 'the last page' do
@@ -239,9 +245,11 @@ describe 'Kaminari::ActionViewExtension' do
 
   describe '#rel_next_prev_link_tags' do
     shared_context 'using route prefix' do
-      context 'using route prefix' do
-        subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
-        it { should match(%r(/mounted_engine/items)) }
+      if defined? Rails
+        context 'using route prefix' do
+          subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+          it { should match(%r(/mounted_engine/items)) }
+        end
       end
     end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -14,6 +14,11 @@ describe 'Kaminari::ActionViewExtension' do
         lambda { helper.escape_javascript(helper.paginate @users, :params => {:controller => 'users', :action => 'index'}) }.should_not raise_error
       end
     end
+
+    context 'using route prefix' do
+      subject { helper.paginate @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+      it { should match(%r(/mounted_engine/items)) }
+    end
   end
 
   describe '#link_to_previous_page' do
@@ -32,6 +37,10 @@ describe 'Kaminari::ActionViewExtension' do
       context 'overriding rel=' do
         subject { helper.link_to_previous_page @users, 'Previous', :rel => 'external', :params => {:controller => 'users', :action => 'index'} }
         it { should match(/rel="external"/) }
+      end
+      context 'using route prefix' do
+        subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        it { should match(%r(/mounted_engine/items)) }
       end
     end
     context 'the first page' do
@@ -59,6 +68,10 @@ describe 'Kaminari::ActionViewExtension' do
       context 'overriding rel=' do
         subject { helper.link_to_next_page @users, 'More', :rel => 'external', :params => {:controller => 'users', :action => 'index'} }
         it { should match(/rel="external"/) }
+      end
+      context 'using route prefix' do
+        subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        it { should match(%r(/mounted_engine/items)) }
       end
     end
     context 'the last page' do
@@ -225,6 +238,13 @@ describe 'Kaminari::ActionViewExtension' do
   end
 
   describe '#rel_next_prev_link_tags' do
+    shared_context 'using route prefix' do
+      context 'using route prefix' do
+        subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        it { should match(%r(/mounted_engine/items)) }
+      end
+    end
+
     before do
       75.times {|i| User.create! :name => "user#{i}"}
     end
@@ -237,6 +257,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should match(/rel="next"/) }
       it { should_not match(/rel="prev"/) }
+      include_context 'using route prefix'
     end
     context 'the middle page' do
       before do
@@ -247,6 +268,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should match(/rel="next"/) }
       it { should match(/rel="prev"/) }
+      include_context 'using route prefix'
     end
     context 'the last page' do
       before do
@@ -257,6 +279,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should_not match(/rel="next"/) }
       it { should match(/rel="prev"/) }
+      include_context 'using route prefix'
     end
   end
 end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -16,8 +16,8 @@ describe 'Kaminari::ActionViewExtension' do
     end
 
     if defined? Rails
-      context 'using route prefix' do
-        subject { helper.paginate @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+      context 'using custom route set' do
+        subject { helper.paginate @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_set => my_engine }
         it { should match(%r(/mounted_engine/items)) }
       end
     end
@@ -41,8 +41,8 @@ describe 'Kaminari::ActionViewExtension' do
         it { should match(/rel="external"/) }
       end
       if defined? Rails
-        context 'using route prefix' do
-          subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        context 'using custom route set' do
+          subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_set => my_engine }
           it { should match(%r(/mounted_engine/items)) }
         end
       end
@@ -74,8 +74,8 @@ describe 'Kaminari::ActionViewExtension' do
         it { should match(/rel="external"/) }
       end
       if defined? Rails
-        context 'using route prefix' do
-          subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        context 'using custom route set' do
+          subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'my_engine/items', :action => 'index'}, :route_set => my_engine }
           it { should match(%r(/mounted_engine/items)) }
         end
       end
@@ -244,10 +244,10 @@ describe 'Kaminari::ActionViewExtension' do
   end
 
   describe '#rel_next_prev_link_tags' do
-    shared_context 'using route prefix' do
+    shared_context 'using custom route set' do
       if defined? Rails
-        context 'using route prefix' do
-          subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_prefix => my_engine }
+        context 'using custom route set' do
+          subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'my_engine/items', :action => 'index'}, :route_set => my_engine }
           it { should match(%r(/mounted_engine/items)) }
         end
       end
@@ -265,7 +265,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should match(/rel="next"/) }
       it { should_not match(/rel="prev"/) }
-      include_context 'using route prefix'
+      include_context 'using custom route set'
     end
     context 'the middle page' do
       before do
@@ -276,7 +276,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should match(/rel="next"/) }
       it { should match(/rel="prev"/) }
-      include_context 'using route prefix'
+      include_context 'using custom route set'
     end
     context 'the last page' do
       before do
@@ -287,7 +287,7 @@ describe 'Kaminari::ActionViewExtension' do
       it { should be_a String }
       it { should_not match(/rel="next"/) }
       it { should match(/rel="prev"/) }
-      include_context 'using route prefix'
+      include_context 'using custom route set'
     end
   end
 end


### PR DESCRIPTION
Supported mountable engine's route prefix (or namespace), which was added in Rails 3.1.

Refinery CMS 2, the most popular cms which supports Rails 3.2, requires this feature because it has highly modularized design and it is common to refer to other engine's url from view.
