### PR TITLE
Add support for Sinatra views overrides (add app views paths)

### DIFF
--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -10,6 +10,11 @@ module Kaminari::Helpers
       def registered(app)
         app.register Padrino::Helpers
         app.helpers  HelperMethods
+        @app = app
+      end
+
+      def view_paths
+        @app.views
       end
 
       alias included registered
@@ -31,6 +36,7 @@ module Kaminari::Helpers
 
       def render(*args)
         base = ActionView::Base.new.tap do |a|
+          a.view_paths << SinatraHelpers.view_paths
           a.view_paths << File.expand_path('../../../../app/views', __FILE__)
         end
         base.render(*args)


### PR DESCRIPTION
Sinatra application views paths must be specified manually in Kaminari helper as sinatra does not uses ActionView.

Works well on my Padrino app, should be working with Sinatra too, not using any Padrino stuff for this fix.

Sorry for not writing a test, kind of complicated to mock all this.
