### PR TITLE
Make kaminari more robust against invalid input values

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,7 +3,7 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if num.nil?
+      if (num.nil? || num.is_a?(Array))
         limit(nil).offset(0)
       elsif (n = num.to_i) <= 0
         self

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -63,6 +63,11 @@ if defined? ActiveRecord
             subject { model_class.page(1).per(nil) }
             it { should have(model_class.count).users }
           end
+
+          context "page 1 per []" do
+            subject { model_class.page(1).per([]) }
+            it { should have(model_class.count).users }
+          end
         end
 
         describe '#padding' do


### PR DESCRIPTION
As proposed in the documentation, kaminari methods are often called in the controller with "unsanitized" parameters from the _params_ hash (e.g. `User.order(:name).page params[:page]`). However, this makes the app vulnerable to invalid input: a request with an array instead of an integer (e.g. `...?page[]=2`) causes the app to raise an exception.

I suggest to handle invalid input values within kaminari and attach a fix for the `per` parameter.

Thanks for your consideration,
Boris
