### PR TITLE
A possible fix for issue 340

### DIFF
--- a/gemfiles/active_record_40.gemfile
+++ b/gemfiles/active_record_40.gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'railties', '>= 4.0.0'
 gem 'activerecord', '>= 4.0.0', :require => 'active_record'
 gem 'rspec-rails', '>= 2.0'
-gem 'database_cleaner', '>= 1.0.1'
+gem 'database_cleaner', '~> 1.0.1'
 
 gemspec :path => '../'

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', '>= 3.2.3', :require => 'active_record'
+gem 'activerecord', '~> 3.2.3', :require => 'active_record'
 gem 'sinatra', '~> 1.3.0'
 gem 'tilt', '~> 1.3.0'
 gem 'padrino-helpers', '~> 0.10.6'

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ['>= 0']
   s.add_development_dependency 'rr', ['>= 0']
   s.add_development_dependency 'capybara', ['>= 1.0']
-  s.add_development_dependency 'database_cleaner', ['>= 0']
+  s.add_development_dependency 'database_cleaner', ['>= 0', '~> 1.0.1']
   s.add_development_dependency 'rdoc', ['>= 0']
 end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,7 +88,7 @@ module Kaminari
     def page_entries_info(collection, options = {})
       entry_name = if options[:entry_name]
         options[:entry_name]
-      elsif collection.empty? || collection.is_a?(::Kaminari::PaginatableArray)
+      elsif collection.is_a?(::Kaminari::PaginatableArray)
         'entry'
       else
         if collection.respond_to? :model  # DataMapper

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -77,7 +77,7 @@ describe 'Kaminari::ActionViewExtension' do
       end
       context 'having no entries' do
         subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-        it      { should == 'No entries found' }
+        it      { should == 'No users found' }
 
         context 'setting the entry name option to "member"' do
           subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
@@ -151,7 +151,7 @@ describe 'Kaminari::ActionViewExtension' do
       end
       context 'having no entries' do
         subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-        it      { should == 'No entries found' }
+        it      { should == 'No addresses found' }
       end
 
       context 'having 1 entry' do

--- a/spec/spec_helper_for_sinatra.rb
+++ b/spec/spec_helper_for_sinatra.rb
@@ -1,4 +1,5 @@
 require 'kaminari/sinatra'
+require 'kaminari/helpers/action_view_extension'
 require 'rack/test'
 require 'sinatra/test_helpers'
 require 'capybara/rspec'
@@ -16,7 +17,7 @@ module HelperMethodForHelperSpec
 
   def helper
     # OMG terrible object...
-    Kaminari::Helpers::SinatraHelpers::ActionViewTemplateProxy.new(:current_params => {}, :current_path => '/', :param_name => Kaminari.config.param_name).extend(Padrino::Helpers, Kaminari::ActionViewExtension, Kaminari::Helpers::SinatraHelpers::HelperMethods, FakeEnv)
+    ::Kaminari::Helpers::SinatraHelpers::ActionViewTemplateProxy.new(:current_params => {}, :current_path => '/', :param_name => Kaminari.config.param_name).extend(Padrino::Helpers, Kaminari::ActionViewExtension, Kaminari::Helpers::SinatraHelpers::HelperMethods, FakeEnv)
   end
 end
 


### PR DESCRIPTION
Historically, `#page_entries_info` uses `entry` when collection is empty. But, I agree with @znz in amatsuda/kaminari#340. `#page_entries_info` should use model name even if the given collection is empty.
