### PR TITLE
Localize entry_name in page_entries_info helper

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -97,7 +97,7 @@ module Kaminari
           collection.model_name.human.downcase
         end
       end
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = t(entry_name, count: collection.total_count)
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)


### PR DESCRIPTION
Hi, I'm having trouble localizing the `entry_name` when using the `page_entries_info` helper.

config/locales/sk.yml

``` ruby
sk:
  helpers:
      more_pages:
        display_entries: "Zobrazuje sa %{total} %{entry_name}."
  judge:
    one: "sudca"
    few: "sudcovia"
    other: "sudcov"
```

In my views I would like to have:

``` ruby
<%= page_entries_info @judges %>
```

to produce  `"Zobrazuje sa 10 sudcov."`, but it always outputs `"Zobrazuje sa 10 judges."`, I've tried some things, like this:

``` ruby
<%= page_entries_info @judges, entry_name: t(:judge, count: @judges.count) %>
```

but nothing seems to work. Any suggestions?

Then I looked at the code and I think my commit pretty much solves the thing.
