### PR TITLE
Fix wrong pagination when used with padding

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -15,6 +15,7 @@ module Kaminari
     end
 
     def padding(num)
+      @_padding = num
       offset(offset_value + num.to_i)
     end
 
@@ -22,7 +23,11 @@ module Kaminari
     def total_pages
       return 1 if limit_value.nil?
 
-      total_pages_count = (total_count.to_f / limit_value).ceil
+      count_without_padding = total_count
+      count_without_padding -= @_padding if @_padding
+      count_without_padding = 0 if count_without_padding < 0
+
+      total_pages_count = (count_without_padding.to_f / limit_value).ceil
       if max_pages.present? && max_pages < total_pages_count
         max_pages
       else
@@ -35,7 +40,12 @@ module Kaminari
     # Current page number
     def current_page
       return 1 if limit_value.nil?
-      (offset_value / limit_value) + 1
+
+      offset_without_padding = offset_value
+      offset_without_padding -= @_padding if @_padding
+      offset_without_padding = 0 if offset_without_padding < 0
+
+      (offset_without_padding / limit_value) + 1
     end
 
     # First page of the collection ?


### PR DESCRIPTION
Pagination just breaks when used with `padding`, because `total_pages` and `current_page` doesn't checks is padding used.

For example:

``` ruby
source = [
  # padding
  1, 2, 3, 4,

  # first page
  5, 6, 7,

  # second
  8, 9,
]
arr = Kaminari.paginate_array(source).page(2).per(3).padding(4)

puts arr.inspect
# => [8, 9] which is correct

puts arr.total_pages # => 3
# whoops, that's wrong, 2 was expected

puts arr.current_page # => 3
# also wrong, 2 was expected
```

Array used just for example, I encounter same problem when work with active record.

I fixed it, but probably it can be written in more sound style to the rest of code.
