### PR TITLE
remove the Railtie and use only the Engine

### DIFF
--- a/lib/kaminari.rb
+++ b/lib/kaminari.rb
@@ -1,7 +1,7 @@
 module Kaminari
 end
 
-# load Rails/Railtie
+# load Rails/Engine
 begin
   require 'rails'
 rescue LoadError
@@ -32,8 +32,7 @@ require 'kaminari/models/page_scope_methods'
 require 'kaminari/models/configuration_methods'
 require 'kaminari/hooks'
 
-# if not using Railtie, call `Kaminari::Hooks.init` directly
+# if not using Engine, call `Kaminari::Hooks.init` directly
 if defined? Rails
-  require 'kaminari/railtie'
   require 'kaminari/engine'
 end

--- a/lib/kaminari/engine.rb
+++ b/lib/kaminari/engine.rb
@@ -1,4 +1,7 @@
 module Kaminari #:nodoc:
   class Engine < ::Rails::Engine #:nodoc:
+    initializer 'kaminari' do |_app|
+      Kaminari::Hooks.init
+    end
   end
 end

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,7 +1,0 @@
-module Kaminari
-  class Railtie < ::Rails::Railtie #:nodoc:
-    initializer 'kaminari' do |_app|
-      Kaminari::Hooks.init
-    end
-  end
-end

--- a/spec/fake_gem.rb
+++ b/spec/fake_gem.rb
@@ -1,4 +1,4 @@
-# Simulate a gem providing a subclass of ActiveRecord::Base before the Railtie is loaded.
+# Simulate a gem providing a subclass of ActiveRecord::Base before the Engine is loaded.
 
 class GemDefinedModel < ActiveRecord::Base
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Bundler.require
 require 'capybara/rspec'
 require 'database_cleaner'
 
-# Simulate a gem providing a subclass of ActiveRecord::Base before the Railtie is loaded.
+# Simulate a gem providing a subclass of ActiveRecord::Base before the Engine is loaded.
 require 'fake_gem' if defined? ActiveRecord
 
 if defined? Rails


### PR DESCRIPTION
the Railtie is not needed while Engine is a subclass of Railtie:
https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L337
