### PR TITLE
remove ApplicationController from rails fake app

### DIFF
--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -28,8 +28,7 @@ require 'fake_app/mongoid/models' if defined? Mongoid
 require 'fake_app/mongo_mapper/models' if defined? MongoMapper
 
 # controllers
-class ApplicationController < ActionController::Base; end
-class UsersController < ApplicationController
+class UsersController < ActionController::Base
   def index
     @users = User.page params[:page]
     render :inline => <<-ERB
@@ -40,7 +39,7 @@ ERB
 end
 
 if defined? ActiveRecord
-  class AddressesController < ApplicationController
+  class AddressesController < ActionController::Base
     def index
       @addresses = User::Address.page params[:page]
       render :inline => <<-ERB


### PR DESCRIPTION
the ApplicationController is not needed, the Rails FaceApp Controller can inherit directly from ActionController::Base
