### PR TITLE
No easy way to make a link with html in it

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -36,11 +36,20 @@ module Kaminari
     #   <%= link_to_previous_page @users, 'Previous Page' do %>
     #     <span>At the Beginning</span>
     #   <% end %>
+    #
+    # Alternatively, you can pass :force_block option to render block always.
     def link_to_previous_page(scope, name, options = {}, &block)
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      link_to_unless scope.first_page?, name, params.merge(param_name => (scope.current_page - 1)), options.reverse_merge(:rel => 'previous') do
-        block.call if block
+      force_block = options.delete(:force_block)
+      if force_block
+        link_to params.merge(param_name => (scope.current_page - 1)), options.reverse_merge(:rel => 'previous') do
+          block.call if block
+        end
+      else
+        link_to_unless scope.first_page?, name, params.merge(param_name => (scope.current_page - 1)), options.reverse_merge(:rel => 'previous') do
+          block.call if block
+        end
       end
     end
 
@@ -61,11 +70,20 @@ module Kaminari
     #   <%= link_to_next_page @users, 'Next Page' do %>
     #     <span>No More Pages</span>
     #   <% end %>
+    #
+    # Alternatively, you can pass :force_block option to render block always.
     def link_to_next_page(scope, name, options = {}, &block)
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      link_to_unless scope.last_page?, name, params.merge(param_name => (scope.current_page + 1)), options.reverse_merge(:rel => 'next') do
-        block.call if block
+      force_block = options.delete(:force_block)
+      if force_block
+        link_to params.merge(param_name => (scope.current_page + 1)), options.reverse_merge(:rel => 'next') do
+          block.call if block
+        end
+      else
+        link_to_unless scope.last_page?, name, params.merge(param_name => (scope.current_page + 1)), options.reverse_merge(:rel => 'next') do
+          block.call if block
+        end
       end
     end
 

--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -45,6 +45,20 @@ module Kaminari::Helpers
         @current_path + (query.empty? ? '' : "?#{query.to_query}")
       end
 
+      alias_method :old_link_to, :link_to
+      def link_to(name_given, options = {}, html_options = {}, &block)
+        if name_given.is_a? Hash
+          html_options = options
+          options = url_for(name_given)
+          name = if block_given?
+            block.arity <= 1 ? capture(name, &block) : capture(name, options, html_options, &block)
+          end
+          old_link_to(name, options, html_options)
+        else
+          old_link_to(name_given, options, html_options)
+        end
+      end
+
       def link_to_unless(condition, name, options = {}, html_options = {}, &block)
         options = url_for(options) if options.is_a? Hash
         if condition

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -20,6 +20,29 @@ describe 'Kaminari::ActionViewExtension' do
     before do
       50.times {|i| User.create! :name => "user#{i}"}
     end
+    context 'called with a block' do
+      before do
+        @users = User.page(50)
+      end
+      context 'the default behaviour' do
+        subject do
+          helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} do
+            'Alternative text'
+          end
+        end
+        it { should match(/Previous/) }
+        it { should_not match(/Alternative text/) }
+      end
+      context 'with force_block option' do
+        subject do
+          helper.link_to_previous_page @users, 'Previous', :force_block => true, :params => {:controller => 'users', :action => 'index'} do
+            'Alternative text'
+          end
+        end
+        it { should_not match(/Previous/) }
+        it { should match(/Alternative text/) }
+      end
+    end
     context 'having previous pages' do
       before do
         @users = User.page(50)
@@ -46,6 +69,29 @@ describe 'Kaminari::ActionViewExtension' do
   describe '#link_to_next_page' do
     before do
       50.times {|i| User.create! :name => "user#{i}"}
+    end
+    context 'called with a block' do
+      before do
+        @users = User.page(1)
+      end
+      context 'the default behaviour' do
+        subject do
+          helper.link_to_next_page @users, 'Next', :params => {:controller => 'users', :action => 'index'} do
+            'Alternative text'
+          end
+        end
+        it { should match(/Next/) }
+        it { should_not match(/Alternative text/) }
+      end
+      context 'with force_block option' do
+        subject do
+          helper.link_to_next_page @users, 'Next', :force_block => true, :params => {:controller => 'users', :action => 'index'} do
+            'Alternative text'
+          end
+        end
+        it { should_not match(/Next/) }
+        it { should match(/Alternative text/) }
+      end
     end
     context 'having more page' do
       before do


### PR DESCRIPTION
I've been looking for a way to add a link for a next page. `link_to_next_page` wouldn't do because it only adds a link with a string within, but I need to add an html code there:

``` html
<a href='next'>
  Some string
  <span></span>
</a>
```

Normally you could've passed a block and render it, but kaminari [uses](https://github.com/amatsuda/kaminari/blob/master/lib/kaminari/helpers/action_view_extension.rb#L42) `link_to_unless` in links to next and previous page, so block is not even executed if current page isn't first or last.

Alternate way could be to use templates, but they are way to massive to achieve this simple task. Besides, there are some situations where you just can't replace links with templates (or implementation of it gets really ugly), e.g. when you have links to previous page and next page before and after paginating items correspondingly.

There are two possible solutions to this problem, as I see it.
First is that `link_to_next_page` could use `link_to` instead of `link_to_unless`. That would make sense but will probably break existing functionality, so it's not good.
Second is that `link_to_next_page` could take an option, which would make it use `link_to`. The code would grow a bit clumsy but you'll be able to make links with inner html in it without much trouble as it is now. I've implemented this solution in this pull request.

If I am missing something, I am open to suggestions.
