### PR TITLE
last? should return true if page is out of range

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -117,7 +117,7 @@ module Kaminari
 
         # the last page or not
         def last?
-          @page == @options[:total_pages]
+          @page >= @options[:total_pages]
         end
 
         # the previous page or not


### PR DESCRIPTION
Like in /lib/kaminari/models/page_scope_methods.rb#last_page? (l48), 
last? should return true if the page is out of range. This prevents that
the paginator keeps rendering 'Next page' links when a page is requested
that is out of range.
