### PR TITLE
Require dm-core instead of data_mapper to detect DataMapper

### DIFF
--- a/lib/kaminari/hooks.rb
+++ b/lib/kaminari/hooks.rb
@@ -6,7 +6,7 @@ module Kaminari
         ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
       end
 
-      begin; require 'data_mapper'; rescue LoadError; end
+      begin; require 'dm-core'; rescue LoadError; end
       if defined? ::DataMapper
         require 'dm-aggregates'
         require 'kaminari/models/data_mapper_extension'


### PR DESCRIPTION
Requiring data_mapper pulls in unnecessary dependencies. All that's truly needed is dm-core and dm-aggregates (which is already required).
