### PR TITLE
Tweak travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ services: mongodb
 script: "bundle exec rake spec"
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
-  - ruby-head
 
 gemfile:
   - gemfiles/active_record_32.gemfile
@@ -14,8 +12,3 @@ gemfile:
   - gemfiles/mongo_mapper.gemfile
   - gemfiles/mongoid_30.gemfile
   - gemfiles/sinatra.gemfile
-
-matrix:
-  exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/mongoid_30.gemfile

--- a/gemfiles/active_record_30.gemfile
+++ b/gemfiles/active_record_30.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.0.13'
 gem 'activerecord', '>= 3.0.13', :require => 'active_record'

--- a/gemfiles/active_record_31.gemfile
+++ b/gemfiles/active_record_31.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.1.5'
 gem 'activerecord', '>= 3.1.5', :require => 'active_record'

--- a/gemfiles/active_record_32.gemfile
+++ b/gemfiles/active_record_32.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.2.3'
 gem 'activerecord', '>= 3.2.3', :require => 'active_record'

--- a/gemfiles/data_mapper_12.gemfile
+++ b/gemfiles/data_mapper_12.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.2.3'
 gem 'dm-core', '>= 1.2.0'

--- a/gemfiles/mongo_mapper.gemfile
+++ b/gemfiles/mongo_mapper.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.2.3'
 gem 'mongo_mapper', '>= 0.11.0'

--- a/gemfiles/mongoid_24.gemfile
+++ b/gemfiles/mongoid_24.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.2.3'
 gem 'mongoid', '~> 2.4.0'

--- a/gemfiles/mongoid_30.gemfile
+++ b/gemfiles/mongoid_30.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'railties', '>= 3.2.3'
 gem 'mongoid', '>= 3.0'

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'activerecord', '>= 3.2.3', :require => 'active_record'
 gem 'sinatra', '>= 1.3'


### PR DESCRIPTION
- Some libraries such as capybara doesn't support Ruby 1.8. I think we can remove 1.8 from travis.
- ruby-head in travis is too old version.
