### PR TITLE
Use blocks to set default config values

### DIFF
--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -17,14 +17,14 @@ module Kaminari
   # need a Class for 3.0
   class Configuration #:nodoc:
     include ActiveSupport::Configurable
-    config_accessor :default_per_page
-    config_accessor :max_per_page
-    config_accessor :window
-    config_accessor :outer_window
-    config_accessor :left
-    config_accessor :right
-    config_accessor :page_method_name
-    config_accessor :max_pages
+    config_accessor(:default_per_page) { 25 }
+    config_accessor(:max_per_page) { nil }
+    config_accessor(:window) { 4 }
+    config_accessor(:outer_window) { 0 }
+    config_accessor(:left) { 0 }
+    config_accessor(:right) { 0 }
+    config_accessor(:page_method_name) { :page }
+    config_accessor(:max_pages) { nil }
 
     def param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
@@ -34,18 +34,5 @@ module Kaminari
     writer, line = 'def param_name=(value); config.param_name = value; end', __LINE__
     singleton_class.class_eval writer, __FILE__, line
     class_eval writer, __FILE__, line
-  end
-
-  # this is ugly. why can't we pass the default value to config_accessor...?
-  configure do |config|
-    config.default_per_page = 25
-    config.max_per_page = nil
-    config.window = 4
-    config.outer_window = 0
-    config.left = 0
-    config.right = 0
-    config.page_method_name = :page
-    config.param_name = :page
-    config.max_pages = nil
   end
 end


### PR DESCRIPTION
I saw this comment in the config class:

`# this is ugly. why can't we pass the default value to config_accessor...?`

Turns out you can! See here: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/configurable.rb#L106
