### PR TITLE
Fix Missing partial Error when 'paginate' called from different format template

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -21,7 +21,7 @@ module Kaminari
       end
 
       def to_s(locals = {}) #:nodoc:
-        @template.render :partial => "kaminari/#{@theme}#{self.class.name.demodulize.underscore}", :locals => @options.merge(locals)
+        @template.render :partial => "kaminari/#{@theme}#{self.class.name.demodulize.underscore}", :locals => @options.merge(locals), :formats => [:html]
       end
 
       def page_url_for(page)


### PR DESCRIPTION
When I call `paginate` helper from different format template, raise ActionView::Template::Error because of `Missing partial`.

like following

```
Failure/Error: render
     ActionView::Template::Error:
       Missing partial kaminari/paginator with {:locale=>[:ja], :formats=>[:json], :handlers=>[:erb, :builder, :jbuilder, :coffee, :haml]}. Searched in:

...

/home/joker/kaminari/lib/kaminari/helpers/tags.rb:24:in `to_s'
```

it maybe irregular usage, I want to call `paginate` from jbuilder template

for example,

``` ruby
json.posts do
  json.array! @posts do |post|
    json.partial! "entry", post: post
  end
end

json.pagination do
  json.body         paginate(@posts)
  json.total_count  @posts.total_count
  json.per_page     params[:per_page]
  json.current_page @posts.current_page
  json.total_pages  @posts.total_pages
end
```

This patch fixes it.
