### PR TITLE
Update readme for 'per'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,6 +67,11 @@ Then bundle:
     User.count                 # => 1000
     User.page(1).per(nil).size # => 1000
     
+  Remember that +per+ utilizes +limit+ and so it will override any +limit+ that was set previously
+    User.count                  # => 1000
+    a = User.limit(5).count     # => 5
+    b = a.page(1).per(20).count # => 20 not 5    
+
 * the +padding+ scope
 
   Occasionally you need to pad a number of records that is not a multiple of the page size.

--- a/README.rdoc
+++ b/README.rdoc
@@ -67,10 +67,10 @@ Then bundle:
     User.count                 # => 1000
     User.page(1).per(nil).size # => 1000
     
-  Remember that +per+ utilizes +limit+ and so it will override any +limit+ that was set previously
+  Keep in mind that +per+ utilizes internally +limit+ and so it will override any +limit+ that was set previously
     User.count                  # => 1000
     a = User.limit(5).count     # => 5
-    b = a.page(1).per(20).count # => 20 not 5    
+    b = a.page(1).per(20).size  # => 20 
 
 * the +padding+ scope
 


### PR DESCRIPTION
Add information about per using limit as there was some confusion with per(n) overriding previously used 'limit'.
