### PR TITLE
make default theme configurable

### DIFF
--- a/lib/generators/kaminari/templates/kaminari_config.rb
+++ b/lib/generators/kaminari/templates/kaminari_config.rb
@@ -7,4 +7,5 @@ Kaminari.configure do |config|
   # config.right = 0
   # config.page_method_name = :page
   # config.param_name = :page
+  # config.theme = :custom_theme
 end

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -25,6 +25,7 @@ module Kaminari
     config_accessor :right
     config_accessor :page_method_name
     config_accessor :max_pages
+    config_accessor :theme
 
     def param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
@@ -47,5 +48,6 @@ module Kaminari
     config.page_method_name = :page
     config.param_name = :page
     config.max_pages = nil
+    config.theme = nil
   end
 end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,7 +15,7 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
-      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false, :theme => Kaminari.config.theme)
       paginator.to_s
     end
 


### PR DESCRIPTION
I am using kaminari with some custom themes. I felt it is lousy to write `:theme => :my_theme_1` in options every time in views, and it's troublesome when I want to replace my theme from one to another, I think it can be more convenient to set default theme in config file like this:

```
Kaminari.configure do |config|
  config.theme = :custom_theme
end
```

What do you think?
