### PR TITLE
Use custom routes proxy

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -25,7 +25,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        (@options[:routes_proxy] || @template).url_for @params.merge(@param_name => (page <= 1 ? nil : page))
       end
     end
 

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -133,3 +133,25 @@ describe 'Kaminari::Helpers::Paginator' do
 #     end
 #   end
 end
+
+describe 'Kaminari::Helpers::Tag' do
+  let :template do
+    stub(r = Object.new) do
+      render.with_any_args
+      params { {} }
+      options { {} }
+      url_for {|h| "/foo?page=#{h[:page]}"}
+    end
+    r
+  end
+
+  describe '#page_url_for' do
+    it "uses custom routes_proxy" do
+      routes_proxy = Object.new
+      stub(routes_proxy).url_for { |h| "/path/from/custom/proxy?page=#{h[:page]}" }
+
+      tag = Tag.new(template, :param_name => :page, :routes_proxy => routes_proxy)
+      expect(tag.page_url_for(2)).to eq "/path/from/custom/proxy?page=2"
+    end
+  end
+end


### PR DESCRIPTION
I'm working on an app that uses a Rails Engine (Spree). In a template that I'm working in, I need Kaminari to compute the URL using `main_app.url_for`, not `self.url_for`. 

This pull request allows the routes_proxy to be passed explicitly like:

``` ruby
paginate @orders, routes_proxy: main_app
```

`main_app` is an instance of `ActionDispatch::Routing::RoutesProxy`. For more information, see the [Routes section of the Rails Guide to Engines](http://guides.rubyonrails.org/engines.html#routes).
