### PR TITLE
Allow exclusion of navigation links via the `paginate` method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -152,6 +152,11 @@ Run the following generator command, then edit the generated file.
     <%= paginate @users, :left => 1, :right => 3 %>
   This would output something like <tt>1 ...(snip)... 18 19 20</tt> while having 20 pages in total.
 
+* navigation links (first, last, previous, next) can be excluded by +exclude+ ([] by default)
+
+    <%= paginate @users, :exclude => [:first, :last]
+  This would leave out the first and last links in all cases.
+
 * changing the parameter name (:+param_name+) for the links
 
     <%= paginate @users, :param_name => :pagina %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -4,12 +4,13 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    exclude:       array of symbols for first, prev, next, last
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
   <nav class="pagination">
-    <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
+    <%= first_page_tag unless current_page.first? || exclude.include?(:first) %>
+    <%= prev_page_tag unless current_page.first? || exclude.include?(:prev) %>
     <% each_page do |page| -%>
       <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
         <%= page_tag page %>
@@ -17,7 +18,7 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>
-    <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <%= next_page_tag unless current_page.last? || exclude.include?(:next) %>
+    <%= last_page_tag unless current_page.last? || exclude.include?(:last) %>
   </nav>
 <% end -%>

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -4,15 +4,16 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    exclude:       array of symbols for first, prev, next, last
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav.pagination
-    = first_page_tag unless current_page.first?
-    = prev_page_tag unless current_page.first?
+    = first_page_tag unless current_page.first? || exclude.include?(:first)
+    = prev_page_tag unless current_page.first? || exclude.include?(:prev)
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
         = page_tag page
       - elsif !page.was_truncated?
         = gap_tag
-    = next_page_tag unless current_page.last?
-    = last_page_tag unless current_page.last?
+    = next_page_tag unless current_page.last? || exclude.include?(:next)
+    = last_page_tag unless current_page.last? || exclude.include?(:last)

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -4,16 +4,17 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    exclude:     : array of symbols for first, prev, next, last
     paginator    : the paginator that renders the pagination tags inside
 
 == paginator.render do
   nav.pagination
-    == first_page_tag unless current_page.first?
-    == prev_page_tag unless current_page.first?
+    == first_page_tag unless current_page.first? || exclude.include?(:first)
+    == prev_page_tag unless current_page.first? || exclude.include?(:prev)
     - each_page do |page|
       - if page.left_outer? || page.right_outer? || page.inside_window?
         == page_tag page
       - elsif !page.was_truncated?
         == gap_tag
-    == next_page_tag unless current_page.last?
-    == last_page_tag unless current_page.last?
+    == next_page_tag unless current_page.last? || exclude.include?(:next)
+    == last_page_tag unless current_page.last? || exclude.include?(:last)

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -23,6 +23,7 @@ module Kaminari
         @template, @options = template, options
         @theme = @options[:theme] ? "#{@options[:theme]}/" : ''
         @options[:current_page] = PageProxy.new @window_options.merge(@options), @options[:current_page], nil
+        @options[:exclude] ||= []
         #FIXME for compatibility. remove num_pages at some time in the future
         @options[:total_pages] ||= @options[:num_pages]
         @options[:num_pages] ||= @options[:total_pages]


### PR DESCRIPTION
Allows the exclusion of certain nav links without having to generate and modify the view templates.

``` ruby
# app/views/users/index.html.haml
# ...
= paginate @users, :exclude => [:first, :last]
# ...
```

Supports `haml`, `erb`, and `slim` templates.

Closes #235, long dead but never implemented.

**Update** removed exclusion via `Kaminari.config`.
