### PR TITLE
Don't use Active Record scopes

### DIFF
--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -9,11 +9,13 @@ module Kaminari
 
       # Fetch the values at the specified page number
       #   Model.page(5)
-      self.scope Kaminari.config.page_method_name, Proc.new {|num|
-        limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
-      } do
-        include Kaminari::ActiveRecordRelationMethods
-        include Kaminari::PageScopeMethods
+      class << self
+        define_method Kaminari.config.page_method_name do |num=nil|
+          result = limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
+          result.extend(Kaminari::ActiveRecordRelationMethods)
+          result.extend(Kaminari::PageScopeMethods)
+          result
+        end
       end
     end
   end


### PR DESCRIPTION
They have problems when defined in abstract base classes, see 
https://github.com/rails/rails/issues/10658

This replaces that scope with a plain class method.
