### PR TITLE
Don't use database_cleaner v1

### DIFF
--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ['>= 0']
   s.add_development_dependency 'rr', ['>= 0']
   s.add_development_dependency 'capybara', ['>= 1.0']
-  s.add_development_dependency 'database_cleaner', ['>= 0']
+  s.add_development_dependency 'database_cleaner', ['< 1']
   s.add_development_dependency 'rdoc', ['>= 0']
 end


### PR DESCRIPTION
Or else tests for DataMapper don't run on master. Has this happened to 
anyone else? I get `undefined method or variable 'uses_sequence'` when 
using database_cleaner 1.0.1.
