### PR TITLE
allow data attributes on any links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -171,6 +171,10 @@ Run the following generator command, then edit the generated file.
     <%= paginate @users, :remote => true %>
   This would add <tt>data-remote="true"</tt> to all the links inside.
 
+* Links with any data attributes
+    <%= paginate @users, :data => {:pjax => true} %>
+  This would add <tt>data-pjax="true"</tt> to all the links inside.
+
 * the +link_to_next_page+ and +link_to_previous_page+ helper method
 
     <%= link_to_next_page @items, 'Next Page' %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -5,6 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="first">
   <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data %>
 </span>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -5,7 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="first">
   <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data %>

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span.first
   = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.first
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -5,6 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span.first
   = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.first
-  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span.first
   == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -5,7 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span.first
   == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -4,5 +4,6 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="page gap"><%= raw(t 'views.pagination.truncate') %></span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -4,6 +4,6 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="page gap"><%= raw(t 'views.pagination.truncate') %></span>

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -4,6 +4,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span.page.gap
   = raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -4,5 +4,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span.page.gap
   = raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -4,7 +4,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span.page.gap
   == raw(t 'views.pagination.truncate')
 '

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -4,6 +4,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span.page.gap
   == raw(t 'views.pagination.truncate')
 '

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data %>
 </span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -5,6 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="last">
   <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data %>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -5,7 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="last">
   <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data %>

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -5,6 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span.last
   = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span.last
   = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -5,7 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span.last
 	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span.last
 	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote
+	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote, :data => data
 '

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -5,7 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="next">
   <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -5,6 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="next">
   <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data %>
 </span>

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span.next
   = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -5,6 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span.next
   = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -5,7 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span.next
   == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data
 '

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.next
-  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data
 '

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span.next
   == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote, :data => data
 '

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,6 +6,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="page<%= ' current' if page.current? %>">
   <%= link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,7 +6,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="page<%= ' current' if page.current? %>">
   <%= link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,5 +8,5 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
 </span>

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -7,4 +7,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span{:class => "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -6,5 +6,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span{:class => "page#{' current' if page.current?}"}
   = link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -6,6 +6,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span{:class => "page#{' current' if page.current?}"}
   = link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -6,6 +6,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span class="page#{' current' if page.current?}"
   == link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
 '

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -7,5 +7,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  == link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
 '

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -6,7 +6,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span class="page#{' current' if page.current?}"
   == link_to_unless page.current?, page, url, {:remote => remote, :data => data, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
 '

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -5,6 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 -%>
 <span class="prev">
   <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -5,7 +5,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 -%>
 <span class="prev">
   <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data %>

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 %span.prev
   = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -5,6 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
--#    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+-#    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 %span.prev
   = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.prev
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
 span.prev
   == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data
 '

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.prev
-  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data
 '

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -5,7 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-    data:          add a data attribute. default nothing. `:data => {pjax: true` will trun to `data-pjax="true"` in html
+    data:          add a data attribute. default nothing. `:data => {pjax: true}` will trun to `data-pjax="true"` in html
 span.prev
   == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote, :data => data
 '

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -13,9 +13,10 @@ module Kaminari
     # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
     # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
     # * <tt>:remote</tt> - Ajax? (false by default)
+    # * <tt>:data</tt> - Add data attributes to links
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
-      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false, :data => nil)
       paginator.to_s
     end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -14,6 +14,19 @@ describe 'Kaminari::ActionViewExtension' do
         lambda { helper.escape_javascript(helper.paginate @users, :params => {:controller => 'users', :action => 'index'}) }.should_not raise_error
       end
     end
+
+    context 'data attribute' do
+      it "returns data attributes once defined" do
+        output = helper.paginate @users, :params => {:controller => 'users', :action => 'index'}, data: {pjax: true}
+        output.should match /data-pjax=\"true\"/
+      end
+
+      it "returns no data attributes if no such args" do
+        output = helper.paginate @users, :params => {:controller => 'users', :action => 'index'}
+        output.should be_a String
+        output.should_not match /data-/
+      end
+    end
   end
 
   describe '#link_to_previous_page' do


### PR DESCRIPTION
On a project I wanted to add data attributes to all pagination links, then I customized all templates to add
    `:data => data`

And call pagination like

``` ruby
paginate @user, data: { pjax: true }
```

This works.

However if I remove data attributes in `paginate` call, an error will thrown as "undefined local variable or method `data'"

Since data attributes is quite popular, I suggest to add a default value of `data: nil` in helper.
