### PR TITLE
allow any HTML attributes on any links

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    options:       any HTML options like class: 'list'
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={}) %>
 </span>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -4,9 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
-    options:       any HTML options like class: 'list'
+    html:       any HTML options like class: 'list'
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={}) %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, html||={} %>
 </span>

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    options:       any HTML options like class: 'list'
 %span.first
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={})

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -4,7 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
--#    options:       any HTML options like class: 'list'
+-#    html:       any HTML options like class: 'list'
 %span.first
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={})
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, html||={}

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    options      : any HTML options like class 'list'
 span.first
-  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={})
 '

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -4,8 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
-    options      : any HTML options like class 'list'
+    html         : any HTML options like class 'list'
 span.first
-  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, { :remote => remote }.merge(options||={})
+  == link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, html||={}
 '

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -3,6 +3,5 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
 -%>
 <span class="page gap"><%= raw(t 'views.pagination.truncate') %></span>

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -3,6 +3,5 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
 %span.page.gap
   = raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -3,7 +3,6 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
 span.page.gap
   == raw(t 'views.pagination.truncate')
 '

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -4,9 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
-    options:       any HTML options like class: 'list'
+    html:       any HTML options like class: 'list'
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={}) %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, html||={} %>
 </span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    options:       any HTML options like class: 'list'
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={}) %>
 </span>

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    options:       any HTML options like class: 'list'
 %span.last
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={})

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -4,7 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
--#    options:       any HTML options like class: 'list'
+-#    html:       any HTML options like class: 'list'
 %span.last
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={})
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, html||={}

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    options      : any HTML options like class 'list'
 span.last
-	== link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, :remote => remote
+  == link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={})
 '

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -4,8 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
-    options      : any HTML options like class 'list'
+    html         : any HTML options like class 'list'
 span.last
-  == link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { :remote => remote }.merge(options||={})
+  == link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, html||={}
 '

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    options:       any HTML options like class: 'list'
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', { :remote => remote }.merge(options||={}) %>
 </span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -4,9 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
-    options:       any HTML options like class: 'list'
+    html:       any HTML options like class: 'list'
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', { :remote => remote }.merge(options||={}) %>
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', html||={} %>
 </span>

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -4,7 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
--#    options:       any HTML options like class: 'list'
+-#    html:       any HTML options like class: 'list'
 %span.next
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, { :rel => 'next', :remote => remote }.merge(options||={})
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, {:rel => 'next'}.merge(html||={})

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    options:       any HTML options like class: 'list'
 %span.next
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, { :rel => 'next', :remote => remote }.merge(options||={})

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,10 +1,11 @@
 / Link to the "Next" page
-	- available local variables
+  - available local variables
     url          : url to the next page
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    options      : any HTML options like class 'list'
 span.next
-  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, { :rel => 'next', :remote => remote }.merge(options||={})
 '

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -4,8 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
-    options      : any HTML options like class 'list'
+    html         : any HTML options like class 'list'
 span.next
-  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, { :rel => 'next', :remote => remote }.merge(options||={})
+  == link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, {:rel => 'next'}.merge(html||={})
 '

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,7 +6,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    options:       any HTML options like class: 'list'
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={}) %>
 </span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -5,9 +5,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
-    options:       any HTML options like class: 'list'
+    html:       any HTML options like class: 'list'
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={}) %>
+  <%= link_to_unless page.current?, page, url, {:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(html||={}) %>
 </span>

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -5,7 +5,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
--#    options:       any HTML options like class: 'list'
+-#    html:       any HTML options like class: 'list'
 %span{:class => "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={})
+  = link_to_unless page.current?, page, url, {:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(html||={})

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -6,5 +6,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    options:       any HTML options like class: 'list'
 %span{:class => "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={})

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -6,6 +6,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    options      : any HTML options like class 'list'
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={})
 '

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -5,8 +5,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
-    options      : any HTML options like class 'list'
+    html      : any HTML options like class 'list'
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(options||={})
+  == link_to_unless page.current?, page, url, {:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}.merge(html||={})
 '

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -3,7 +3,6 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -3,7 +3,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav.pagination

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -3,7 +3,6 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
     paginator    : the paginator that renders the pagination tags inside
 
 == paginator.render do

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -4,9 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
-    options:       any HTML options like class: 'list'
+    html:       any HTML options like class: 'list'
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={}) %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev'}.merge(html||={}) %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    options:       any HTML options like class: 'list'
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote %>
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={}) %>
 </span>

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    options:       any HTML options like class: 'list'
 %span.prev
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={})

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -4,7 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
--#    options:       any HTML options like class: 'list'
+-#    html:       any HTML options like class: 'list'
 %span.prev
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={})
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev'}.merge(html||={})

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    options      : any HTML options like class 'list'
 span.prev
-  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={})
 '

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -4,8 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
-    options      : any HTML options like class 'list'
+    html         : any HTML options like class 'list'
 span.prev
-  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev', :remote => remote }.merge(options||={})
+  == link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, { :rel => 'prev'}.merge(html||={})
 '


### PR DESCRIPTION
@billychan @zzak @yuki24 @amatsuda 

As everything we want to add in are supported natively by the Rails link_to helper. So what we need to do is just have one attribute called :options.

So in _first_page.html.erb it becomes:

``` erb
  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, {remote: remote}.merge(options||={}) %>
```

Then you can add any attributes you want:

``` erb
  <%= paginate @users, options: {remote: true, class: 'ajax_index', data: {pjax: true} } %>
```

In this way, it will not break the existing code and can still achieve what we need. And the PR title can be changed to "allow any HTML attributes on any links" :smile: 

By using this way, we can even remove the original remote: remote as by default link_to helper :remote is false. Much cleaner. 

So it becomes:

``` erb
  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, options||={} %>
```

This PR only added in the options support. 
