### PR TITLE
Adds #params_only/#params_except options to filter out params used for pagination links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,6 +85,8 @@ You can configure the following default values by overriding these values using 
   right             # 0 by default
   page_method_name  # :page by default
   param_name        # :page by default
+  params_except     # [] by default
+  params_only       # [] by default
 
 There's a handy generator that generates the default configuration file into config/initializers directory.
 Run the following generator command, then edit the generated file.
@@ -177,6 +179,14 @@ Run the following generator command, then edit the generated file.
     <%= page_entries_info @users %>
   This renders a helpful message with numbers of displayed vs. total entries.
 
+* filtering out unuseful search params with +params_except+ and +params_only+
+
+    <%= paginate @users, :params_except => [:utm_source] %>
+    <%= paginate @users, :params_only => [:search_params] %>
+  This filters out 'utm_source' from query params/passed only :search_params parameter to page links
+
+
+
 === I18n and labels
 
 The default labels for 'first', 'last', 'previous', '...' and 'next' are stored in the I18n yaml inside the engine, and rendered through I18n API. You can switch the label value per I18n.locale for your internationalized application.
@@ -211,7 +221,7 @@ Kaminari includes a handy template generator.
 * themes
 
   The generator has the ability to fetch several sample template themes from
-  the external repository (https://github.com/amatsuda/kaminari_themes) in 
+  the external repository (https://github.com/amatsuda/kaminari_themes) in
   addition to the bundled "default" one, which will help you creating a nice
   looking paginator.
     % rails g kaminari:views THEME

--- a/README.rdoc
+++ b/README.rdoc
@@ -179,7 +179,7 @@ Run the following generator command, then edit the generated file.
     <%= page_entries_info @users %>
   This renders a helpful message with numbers of displayed vs. total entries.
 
-* filtering out unuseful search params with +params_except+ and +params_only+
+* filtering out unuseful params in pagination links with +params_except+ and +params_only+
 
     <%= paginate @users, :params_except => [:utm_source] %>
     <%= paginate @users, :params_only => [:search_params] %>

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -25,6 +25,8 @@ module Kaminari
     config_accessor :right
     config_accessor :page_method_name
     config_accessor :max_pages
+    config_accessor :params_except
+    config_accessor :params_only
 
     def param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
@@ -47,5 +49,7 @@ module Kaminari
     config.page_method_name = :page
     config.param_name = :page
     config.max_pages = nil
+    config.params_except = []
+    config.params_only = []
   end
 end

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -26,6 +26,8 @@ module Kaminari
         #FIXME for compatibility. remove num_pages at some time in the future
         @options[:total_pages] ||= @options[:num_pages]
         @options[:num_pages] ||= @options[:total_pages]
+        @options[:params_except] ||= Kaminari.config.params_except
+        @options[:params_only] ||= Kaminari.config.params_only
         @last = nil
         # initialize the output_buffer for Context
         @output_buffer = ActionView::OutputBuffer.new

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -15,9 +15,9 @@ module Kaminari
     class Tag
       def initialize(template, options = {}) #:nodoc:
         @template, @options = template, options.dup
+        @params = self.class.params_for(@options, template.params)
         @param_name = @options.delete(:param_name)
         @theme = @options[:theme] ? "#{@options.delete(:theme)}/" : ''
-        @params = @options[:params] ? template.params.merge(@options.delete :params) : template.params
       end
 
       def to_s(locals = {}) #:nodoc:
@@ -26,6 +26,21 @@ module Kaminari
 
       def page_url_for(page)
         @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+      end
+
+      def self.params_for(options, params)
+        options = options.dup
+        param_name = options.delete(:param_name)
+        params = params.merge(options.delete(:params) || {})
+
+        params.tap do |params|
+          if (only = options.delete(:params_only)).present?
+            params.slice!(param_name, *only)
+          end
+          if (except = options.delete(:params_except)).present?
+            params.except!(*except - [param_name])
+          end
+        end
       end
     end
 

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -56,6 +56,18 @@ describe Kaminari::Configuration do
     end
   end
 
+  describe 'params_except' do
+    context 'by default' do
+      its(:params_except) { should == [] }
+    end
+  end
+
+  describe 'params_only' do
+    context 'by default' do
+      its(:params_only) { should == [] }
+    end
+  end
+
   describe 'param_name' do
     context 'by default' do
       its(:param_name) { should == :page }

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -20,6 +20,30 @@ describe 'Kaminari::Helpers::Paginator' do
     it { should == {:controller => 'foo', :action => 'bar'} }
   end
 
+  describe '#params_except' do
+    before do
+      @paginator = Paginator.new(
+        template,
+        :params => { :controller => 'foo', :action => 'bar', :utm_source => 'baz' },
+        :params_except => [:utm_source]
+      )
+    end
+    subject { @paginator.page_tag(template).instance_variable_get('@params') }
+    it { should == { :controller => 'foo', :action => 'bar' } }
+  end
+
+  describe '#params_only' do
+    before do
+      @paginator = Paginator.new(
+        template,
+        :params => { :controller => 'foo', :action => 'bar', :utm_source => 'baz' },
+        :params_only => [:controller]
+      )
+    end
+    subject { @paginator.page_tag(template).instance_variable_get('@params') }
+    it { should == { :controller => 'foo' }
+  end
+
   describe '#param_name' do
     before do
       @paginator = Paginator.new(template, :param_name => :pagina)

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -41,7 +41,7 @@ describe 'Kaminari::Helpers::Paginator' do
       )
     end
     subject { @paginator.page_tag(template).instance_variable_get('@params') }
-    it { should == { :controller => 'foo' }
+    it { should == { :controller => 'foo' } }
   end
 
   describe '#param_name' do


### PR DESCRIPTION
Filtering out unuseful params in pagination links with +params_except+ and +params_only+

``` erb
<%= paginate @users, :params_except => [:utm_source] %>
<%= paginate @users, :params_only => [:search_params] %>
```

This filters out `utm_source` from query params/passed only :search_params parameter to page links.
