### PR TITLE
Makes sure we use the params from the templates and merge them with the given params

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -37,7 +37,7 @@ module Kaminari
     #     <span>At the Beginning</span>
     #   <% end %>
     def link_to_previous_page(scope, name, options = {}, &block)
-      params = options.delete(:params) || {}
+      params = options[:params] ? self.params.merge(options.delete :params) : self.params
       param_name = options.delete(:param_name) || Kaminari.config.param_name
       link_to_unless scope.first_page?, name, params.merge(param_name => (scope.current_page - 1)), options.reverse_merge(:rel => 'previous') do
         block.call if block
@@ -62,7 +62,7 @@ module Kaminari
     #     <span>No More Pages</span>
     #   <% end %>
     def link_to_next_page(scope, name, options = {}, &block)
-      params = options.delete(:params) || {}
+      params = options[:params] ? self.params.merge(options.delete :params) : self.params
       param_name = options.delete(:param_name) || Kaminari.config.param_name
       link_to_unless scope.last_page?, name, params.merge(param_name => (scope.current_page + 1)), options.reverse_merge(:rel => 'next') do
         block.call if block
@@ -127,7 +127,7 @@ module Kaminari
     #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
     #
     def rel_next_prev_link_tags(scope, options = {})
-      params = options.delete(:params) || {}
+      params = options[:params] ? self.params.merge(options.delete :params) : self.params
       param_name = options.delete(:param_name) || Kaminari.config.param_name
 
       output = ""

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -27,11 +27,12 @@ describe 'Kaminari::ActionViewExtension' do
       context 'the default behaviour' do
         before do
           def helper.params
-            { term: 'search_criteria', :controller => 'users', :action => 'index'}
+            { :term => 'search_criteria', :controller => 'users', :action => 'index'}
           end
         end
         subject { helper.link_to_previous_page @users, 'Previous' }
         it { should be_a String }
+        it { should match(/term=search_criteria/) }
       end
       context 'with explicit params' do
         subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} }
@@ -63,11 +64,12 @@ describe 'Kaminari::ActionViewExtension' do
       context 'the default behaviour' do
         before do
           def helper.params
-            { term: 'search_criteria', :controller => 'users', :action => 'index'}
+            { :term => 'search_criteria', :controller => 'users', :action => 'index'}
           end
         end
         subject { helper.link_to_next_page @users, 'Next' }
         it { should be_a String }
+        it { should match(/term=search_criteria/) }
       end
       context 'with explicit params' do
         subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -25,6 +25,15 @@ describe 'Kaminari::ActionViewExtension' do
         @users = User.page(50)
       end
       context 'the default behaviour' do
+        before do
+          def helper.params
+            { term: 'search_criteria', :controller => 'users', :action => 'index'}
+          end
+        end
+        subject { helper.link_to_previous_page @users, 'Previous' }
+        it { should be_a String }
+      end
+      context 'with explicit params' do
         subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} }
         it { should be_a String }
         it { should match(/rel="previous"/) }
@@ -47,11 +56,20 @@ describe 'Kaminari::ActionViewExtension' do
     before do
       50.times {|i| User.create! :name => "user#{i}"}
     end
-    context 'having more page' do
+    context 'having more pages' do
       before do
         @users = User.page(1)
       end
       context 'the default behaviour' do
+        before do
+          def helper.params
+            { term: 'search_criteria', :controller => 'users', :action => 'index'}
+          end
+        end
+        subject { helper.link_to_next_page @users, 'Next' }
+        it { should be_a String }
+      end
+      context 'with explicit params' do
         subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
         it { should be_a String }
         it { should match(/rel="next"/) }


### PR DESCRIPTION
Makes sure we use the params from the templates and merge them with the given params if given when creating `#link_to_next_page`, `#link_to_previous_page` or `#rel_next_prev_link_tags`. This makes it consistent with the implementation in `Kaminari::Helpers::Tag#page_url_for`
