### PR TITLE
Remove page parameter for first page in SEO rel prev tags

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -124,7 +124,7 @@ module Kaminari
     #     <%= rel_next_prev_link_tags @items %>
     #   <% end %>
     #
-    #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
+    #   #-> <link rel="next" href="/items/page/4" /><link rel="prev" href="/items/page/2" />
     #
     def rel_next_prev_link_tags(scope, options = {})
       params = options.delete(:params) || {}

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -135,7 +135,8 @@ module Kaminari
       if !scope.first_page? && !scope.last_page?
         # If not first and not last, then output both links.
         output << '<link rel="next" href="' + url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>'
-        output << '<link rel="prev" href="' + url_for(params.merge(param_name => (scope.current_page - 1))) + '"/>'
+        prev_page = scope.current_page - 1
+        output << '<link rel="prev" href="' + url_for(params.merge(param_name => (prev_page <= 1 ? nil : prev_page))) + '"/>'
       elsif scope.first_page?
         # If first page, add next link unless last page.
         output << '<link rel="next" href="' + url_for(params.merge(param_name => (scope.current_page + 1))) + '"/>' unless scope.last_page?

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -246,7 +246,7 @@ describe 'Kaminari::ActionViewExtension' do
       subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'users', :action => 'index'} }
       it { should be_a String }
       it { should match(/rel="next"/) }
-      it { should match(/rel="prev"/) }
+      it { should match(/rel="prev" href=\"\/users"/) }
     end
     context 'the last page' do
       before do


### PR DESCRIPTION
I would like to propose that the SEO tags outputted in the `rel_next_prev_link_tags` helper skip the page parameter when referencing the first page, e.g. instead of
`<link rel="prev" href="/users?page=1">`
it should instead output
`<link rel="prev" href="/users">`
to conform with how the Kaminari paginator works when referencing the first page, as per this [line](https://github.com/amatsuda/kaminari/blob/master/lib/kaminari/helpers/tags.rb#L28)
