### PR TITLE
Count rows returned by the query instead of keys in #count hash

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -11,15 +11,19 @@ module Kaminari
     def total_count(column_name = nil, options = {}) #:nodoc:
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
       @total_count ||= begin
-        c = except(:offset, :limit, :order)
+        relation = except(:offset, :limit, :order)
 
         # Remove includes only if they are irrelevant
-        c = c.except(:includes) unless references_eager_loaded_tables?
+        relation = relation.except(:includes) unless references_eager_loaded_tables?
 
         # .group returns an OrderdHash that responds to #count
-        c = c.count(column_name, options)
+        c = relation.count(column_name, options)
+
         if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-          c.count
+          sm = Arel::SelectManager.new relation.engine
+          select_value = "count(*) as count"
+          counting_subquery = sm.project(select_value).from(relation.arel.as("subquery_for_count"))
+          connection.select_one(counting_subquery)['count']
         else
           c.respond_to?(:count) ? c.count(column_name, options) : c
         end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -41,6 +41,14 @@ if defined? ActiveRecord
             @author.readers.by_read_count.page(1).total_count(:name, :distinct => true)
           }.should_not raise_exception
         end
+
+        it "should count the number of rows, not the number of keys" do
+          @books.each {|book| book.readers << @readers[0..1] }
+
+          readerships = Readership.select('user_id, count(user_id) as read_count, book_id').group('user_id, book_id')
+          readerships.count.count.should_not == readerships.page(1).total_count
+          readerships.page(1).total_count.should == 8
+        end
       end
     end
   end


### PR DESCRIPTION
I added a test case and code to fix the issue we discussed in #373.

Essentially:

When you use `group` on a relation, its `count` returns a hash of results. Sometimes (as in the demonstrated test case), the number of keys in that hash is not the correct count of the number of rows, as kaminari was previously assuming.

This patch fixes that by taking the original query and counting it's rows via a subquery, and avoids doing it using interpolation (as @zzak already mentioned would be unacceptable).
