### PR TITLE
add infinite_pages option 

### DIFF
--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote %>
+  <%= link_to_unless (current_page.last? || current_page.infinite?), t('views.pagination.last').html_safe, url, :remote => remote %>
 </span>

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
+  = link_to_unless (current_page.last? || current_page.infinite?), t('views.pagination.last').html_safe, url, :remote => remote

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-	== link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
+	== link_to_unless (current_page.last? || current_page.infinite?), t('views.pagination.last').html_safe, url, :remote => remote
 '

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -18,6 +18,6 @@
       <% end -%>
     <% end -%>
     <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.infinite? || current_page.last? %>
   </nav>
 <% end -%>

--- a/config/locales/kaminari.yml
+++ b/config/locales/kaminari.yml
@@ -17,3 +17,4 @@ en:
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
         display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+        display_entries_infinite: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b>"

--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -25,6 +25,7 @@ module Kaminari
     config_accessor :right
     config_accessor :page_method_name
     config_accessor :max_pages
+    config_accessor :infinite_pages
 
     def param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
@@ -47,5 +48,6 @@ module Kaminari
     config.page_method_name = :page
     config.param_name = :page
     config.max_pages = nil
+    config.infinite_pages = false
   end
 end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -99,12 +99,18 @@ module Kaminari
       end
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
-      if collection.total_pages < 2
+      if collection.total_count != :infinite && collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)
       else
         first = collection.offset_value + 1
-        last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first, :last => last, :total => collection.total_count)
+        last = collection.offset_value + collection.limit_value
+        if collection.total_count == :infinite
+          t('helpers.page_entries_info.more_pages.display_entries_infinite', :entry_name => entry_name, :first => first, :last => last)
+        else
+          last = collection.total_count if collection.last_page?
+          t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first, :last => last, :total => collection.total_count)
+        end
+
       end.html_safe
     end
 

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -33,7 +33,7 @@ module Kaminari
 
       # render given block as a view template
       def render(&block)
-        instance_eval(&block) if @options[:total_pages] > 1
+        instance_eval(&block) if @options[:total_pages] == :infinite || @options[:total_pages] > 1
         @output_buffer
       end
 
@@ -53,11 +53,13 @@ module Kaminari
       alias each_page each_relevant_page
 
       def relevant_pages(options)
+        tmp_total_pages = options[:total_pages]
+        tmp_total_pages = 100000000 if tmp_total_pages == :infinite
         left_window_plus_one = 1.upto(options[:left] + 1).to_a
-        right_window_plus_one = (options[:total_pages] - options[:right]).upto(options[:total_pages]).to_a
+        right_window_plus_one = (tmp_total_pages - options[:right]).upto(tmp_total_pages).to_a
         inside_window_plus_each_sides = (options[:current_page] - options[:window] - 1).upto(options[:current_page] + options[:window] + 1).to_a
 
-        (left_window_plus_one + inside_window_plus_each_sides + right_window_plus_one).uniq.sort.reject {|x| (x < 1) || (x > options[:total_pages])}
+        (left_window_plus_one + inside_window_plus_each_sides + right_window_plus_one).uniq.sort.reject {|x| (x < 1) || (x > tmp_total_pages)}
       end
       private :relevant_pages
 
@@ -128,7 +130,11 @@ module Kaminari
 
         # the last page or not
         def last?
-          @page == @options[:total_pages]
+          @options[:total_pages] == :infinite ? false : @page == @options[:total_pages]
+        end
+
+        def infinite?
+          @options[:total_pages] == :infinite
         end
 
         # the previous page or not
@@ -148,7 +154,7 @@ module Kaminari
 
         # within the right outer window or not
         def right_outer?
-          @options[:total_pages] - @page < @options[:right]
+          @options[:total_pages] == :infinite ? false : @options[:total_pages] - @page < @options[:right]
         end
 
         # inside the inner window or not

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -25,7 +25,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        @template.url_for @params.merge(@param_name => ((page != :infinite && page <= 1) ? nil : page))
       end
     end
 

--- a/lib/kaminari/models/configuration_methods.rb
+++ b/lib/kaminari/models/configuration_methods.rb
@@ -43,6 +43,14 @@ module Kaminari
       def max_pages
         (defined?(@_max_pages) && @_max_pages) || Kaminari.config.max_pages
       end
+
+      def infinite_pages(val)
+        @_infinite_pages = val
+      end
+
+      def infinite_pages?
+        (defined?(@_infinite_pages) && @_infinite_pages) || Kaminari.config.infinite_pages
+      end
     end
   end
 end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -19,15 +19,19 @@ module Kaminari
 
     # Total number of pages
     def total_pages
-      count_without_padding = total_count
-      count_without_padding -= @_padding if defined?(@_padding) && @_padding
-      count_without_padding = 0 if count_without_padding < 0
-
-      total_pages_count = (count_without_padding.to_f / limit_value).ceil
-      if max_pages.present? && max_pages < total_pages_count
-        max_pages
+      if infinite_pages?
+        :infinite
       else
-        total_pages_count
+        count_without_padding = total_count
+        count_without_padding -= @_padding if defined?(@_padding) && @_padding
+        count_without_padding = 0 if count_without_padding < 0
+
+        total_pages_count = (count_without_padding.to_f / limit_value).ceil
+        if max_pages.present? && max_pages < total_pages_count
+          max_pages
+        else
+          total_pages_count
+        end
       end
     end
     #FIXME for compatibility. remove num_pages at some time in the future
@@ -59,12 +63,12 @@ module Kaminari
 
     # Last page of the collection?
     def last_page?
-      current_page >= total_pages
+      total_pages == :infinite ? false : current_page >= total_pages
     end
 
     # Out of range of the collection?
     def out_of_range?
-      current_page > total_pages
+      total_pages == :infinite ? false : current_page > total_pages
     end
   end
 end


### PR DESCRIPTION
which does nt call sql count (useful for really large recordsets using complex sql statements)
it might take a long time to finish sql count operation 
drawback: you cannot identify last_page
