### PR TITLE
Add i18n to page_entries_info helper method and use count param in human method to pluralize correctly

### DIFF
--- a/config/locales/kaminari.yml
+++ b/config/locales/kaminari.yml
@@ -10,6 +10,10 @@ en:
       truncate: "&hellip;"
   helpers:
     page_entries_info:
+      entry:
+        zero: "entries"
+        one: "entry"
+        other: "entries"
       one_page:
         display_entries:
           zero: "No %{entry_name} found"

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -89,15 +89,14 @@ module Kaminari
       entry_name = if options[:entry_name]
         options[:entry_name]
       elsif collection.is_a?(::Kaminari::PaginatableArray)
-        'entry'
+        t('helpers.page_entries_info.entry', :count => collection.count)
       else
         if collection.respond_to? :model  # DataMapper
-          collection.model.model_name.human.downcase
+          collection.model.model_name.human(:count => collection.count).downcase
         else  # AR
-          collection.model_name.human.downcase
+          collection.model_name.human(:count => collection.count).downcase
         end
       end
-      entry_name = entry_name.pluralize unless collection.total_count == 1
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)


### PR DESCRIPTION
Hi, I just change some lines of page_entries_info for fix to problems with translations.

By one side, `pluralize` is for calculate names by rails conventions, not for translations. For i18n I've used the `count` parameter: http://guides.rubyonrails.org/i18n.html#pluralization

By other side, it's better put "entry" name in locale file (en.yml), then it can be translated for other locales. Of course, using the `count` parameter too, for pluralize if necessary.

I hope you find these changes usefull. Cheers.
