### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= Kaminari
+= Kaminari {<img src="https://travis-ci.org/amatsuda/kaminari.png"/>}[http://travis-ci.org/amatsuda/kaminari] {<img src="https://codeclimate.com/github/amatsuda/kaminari.png" />}[https://codeclimate.com/github/amatsuda/kaminari]
 
 A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs
 
@@ -280,9 +280,6 @@ More features are coming, and again, this is still experimental. Please let us k
 
 Check out Kaminari recipes on the GitHub Wiki for more advanced tips and techniques.
 https://github.com/amatsuda/kaminari/wiki/Kaminari-recipes
-
-
-== Build Status {<img src="https://travis-ci.org/amatsuda/kaminari.png"/>}[http://travis-ci.org/amatsuda/kaminari]
 
 
 == Questions, Feedback


### PR DESCRIPTION
Hello,

Just wanted to drop you a note to let you know that someone added Kaminari to Code Climate a while back.

Code Climate is a tool I helped to build that does automated code reviews for Ruby using static analysis. It's free for OSS, and your metrics live here:

https://codeclimate.com/github/amatsuda/kaminari

We use Kaminari at Code Climate for paging through Mongo records and it works very nicely. Thank you.

This PR just adds a Code Climate badge to the README (similar to Travis CI). I also moved your two badges to the top of the README since it's kind of summary information that seemed better served at the top.

If you have any questions, let me know. Hope it proves useful!

Best,

Noah
