### PR TITLE
Arity on #count with rails 4.1.0

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -16,12 +16,16 @@ module Kaminari
         # Remove includes only if they are irrelevant
         c = c.except(:includes) unless references_eager_loaded_tables?
 
+        # Rails 4.1 removes the `options` argument from AR::Relation#count
+        args = [column_name]
+        args << options if ActiveRecord::VERSION::STRING < '4.1.0'
+
         # .group returns an OrderdHash that responds to #count
-        c = c.count(column_name, options)
+        c = c.count(*args)
         if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
           c.count
         else
-          c.respond_to?(:count) ? c.count(column_name, options) : c
+          c.respond_to?(:count) ? c.count(*args) : c
         end
       end
     end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -23,7 +23,11 @@ if defined? ActiveRecord
       context "when the scope use conditions on includes" do
         it "should keep includes and successfully count the results" do
           # Only @author and @author2 have books titled with the title00x partern
-          User.includes(:books_authored).where("books.title LIKE 'title00%'").page(1).total_count.should == 2
+          if ActiveRecord::VERSION::STRING >= "4.1.0"
+            User.includes(:books_authored).references(:books).where("books.title LIKE 'title00%'").page(1).total_count.should == 2
+          else
+            User.includes(:books_authored).where("books.title LIKE 'title00%'").page(1).total_count.should == 2
+          end
         end
       end
 
@@ -34,14 +38,24 @@ if defined? ActiveRecord
       end
 
       context "when total_count receives options" do
-        it "should return a distinct total count" do
-          User.page(1).total_count(:name, :distinct => true).should == 4
+        it "should return a distinct total count for rails ~> 4.0.0" do
+          if ActiveRecord::VERSION::STRING < "4.1.0"
+            User.page(1).total_count(:name, :distinct => true).should == 4
+          end
+        end
+
+        it "should ignore the options for rails 4.1+" do
+          if ActiveRecord::VERSION::STRING >= "4.1.0"
+            User.page(1).total_count(:name, :distinct => true).should == 7
+          end
         end
       end
 
       context "when count receives options" do
-        it "should return a distinct set by column" do
-          User.page(1).count(:name, :distinct => true).should == 4
+        it "should return a distinct set by column for rails ~> 4.0.0" do
+          if ActiveRecord::VERSION::STRING < "4.1.0"
+            User.page(1).count(:name, :distinct => true).should == 4
+          end
         end
       end
 


### PR DESCRIPTION
rails/rails@4ce643dbb5bd37e1f4662b37abc80a18078feba1 removed the `options` argument from its ActiveRecord `count` methods. This patch checks the arity of that methods before calling it.
