### PR TITLE
Still getting - NameError: undefined method 'render_partial_with_logging' for class 'ActionView::LogSubscriber'

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -6,7 +6,8 @@ require 'kaminari/helpers/tags'
 
 module Kaminari
   module Helpers
-    module LogSubscriberWithoutLogging
+
+    module ControllableLogSubscriber
       extend ActiveSupport::Concern
       included do
         # redefine the render_partial method but make it check the current thread
@@ -93,13 +94,13 @@ module Kaminari
 
         # There is at least 1 view logging subscriber
         # and we don't want any to log render_partial
-        # so unless we have already, include the LogSubscriberWithoutLogging
+        # so unless we have already, include the ControllableLogSubscriber
         # module on the eigenclass of each subscriber
         # which seems to be threadsafe and idempotent
         subscribers.each do |subscriber|
-          next if subscriber.is_a?(LogSubscriberWithoutLogging)
+          next if subscriber.is_a?(ControllableLogSubscriber)
           class << subscriber
-            include LogSubscriberWithoutLogging
+            include ControllableLogSubscriber
           end
         end
 

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -86,6 +86,7 @@ module Kaminari
 
       def to_s #:nodoc:
         subscribers = ActionView::LogSubscriber.log_subscribers.select {|ls| ls.kind_of? ActionView::LogSubscriber}
+
         if subscribers.size == 0
           return super @window_options.merge(@options).merge :paginator => self
         end

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -6,6 +6,17 @@ require 'kaminari/helpers/tags'
 
 module Kaminari
   module Helpers
+    module LogSubscriberWithoutLogging
+      extend ActiveSupport::Concern
+      included do
+        # redefine the render_partial method but make it check the current thread
+        def render_partial(event)
+          return if Thread.current[:kaminari_render_without_logging]
+          super
+        end
+      end
+    end
+
     # The main container tag
     class Paginator < Tag
       # so that this instance can actually "render"
@@ -74,33 +85,28 @@ module Kaminari
       end
 
       def to_s #:nodoc:
-        subscriber = ActionView::LogSubscriber.log_subscribers.detect {|ls| ls.is_a? ActionView::LogSubscriber}
-
-        # There is a logging subscriber
-        # and we don't want it to log render_partial
-        # It is threadsafe, but might not repress logging
-        # consistently in a high-load environment
-        if subscriber
-          unless defined? subscriber.render_partial_with_logging
-            class << subscriber
-              alias_method :render_partial_with_logging, :render_partial
-              attr_accessor :render_without_logging
-              # ugly hack to make a renderer where
-              # we can turn logging on or off
-              def render_partial(event)
-                render_partial_with_logging(event) unless render_without_logging
-              end
-            end
-          end
-
-          subscriber.render_without_logging = true
-          ret = super @window_options.merge(@options).merge :paginator => self
-          subscriber.render_without_logging = false
-
-          ret
-        else
-          super @window_options.merge(@options).merge :paginator => self
+        subscribers = ActionView::LogSubscriber.log_subscribers.select {|ls| ls.kind_of? ActionView::LogSubscriber}
+        if subscribers.size == 0
+          return super @window_options.merge(@options).merge :paginator => self
         end
+
+        # There is at least 1 view logging subscriber
+        # and we don't want any to log render_partial
+        # so unless we have already, include the LogSubscriberWithoutLogging
+        # module on the eigenclass of each subscriber
+        # which seems to be threadsafe and idempotent
+        subscribers.each do |subscriber|
+          next if subscriber.is_a?(LogSubscriberWithoutLogging)
+          class << subscriber
+            include LogSubscriberWithoutLogging
+          end
+        end
+
+        Thread.current[:kaminari_render_without_logging] = true
+        super @window_options.merge(@options).merge :paginator => self
+
+      ensure
+        Thread.current[:kaminari_render_without_logging] = false
       end
 
       # Wraps a "page number" and provides some utility methods


### PR DESCRIPTION
```
/vendor/bundle/ruby/2.0.0/gems/kaminari-0.14.1/lib/kaminari/helpers/paginator.rb:89 in "alias_method"
/vendor/bundle/ruby/2.0.0/gems/kaminari-0.14.1/lib/kaminari/helpers/paginator.rb:89 in "singleton class"
/vendor/bundle/ruby/2.0.0/gems/kaminari-0.14.1/lib/kaminari/helpers/paginator.rb:88 in "to_s"
/vendor/bundle/ruby/2.0.0/gems/kaminari-0.14.1/lib/kaminari/helpers/action_view_extension.rb:19 in "paginate"
```

Refactored the to_s method.

Is there any reason why the part that sets the singleton class on the subscriber cannot be moved to the initialize method (I tried this - seemed to work, but I decided not to change too much)?

I tried to cater for the case where there may be multiple LogSubscribers and subclasses of ActionView::LogSubscriber

I also used Thread.current to convey the "render_without_logging" intent and ensure to reinstate logging.

To test this patch I switched between the gem and our github fork in our Gemfile - gem raises the exception and fork does not.

I could not run the specs, sorry.

```
rails (3.2.12)
mongoid (3.1.5)
```
