### PR TITLE
Better page URL generation.

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -25,7 +25,24 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for @params.merge(@param_name => (page <= 1 ? nil : page))
+        url = @template.url_for @params.merge(@param_name => page)
+        url = strip_page_param_for(url, page) if strip_page_param_for?(page)
+        url
+      end
+
+      private
+
+      def strip_page_param_for?(page)
+        page <= 1
+      end
+
+      def strip_page_param_for(url, page)
+        uri = URI(url)
+        query = Rack::Utils.parse_query(uri.query)
+        query.delete('page')
+        uri.query = nil
+        uri.query = Rack::Utils.build_query(query) if query.count > 0
+        url = uri.to_s
       end
     end
 

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -20,6 +20,8 @@ app.initialize!
 # routes
 app.routes.draw do
   resources :users
+  # the remaining routes are specific to rails testing
+  get 'users/:var1/:var2/page/:page', to: 'users#index'
 end
 
 #models

--- a/spec/requests/rails_routing_spec.rb
+++ b/spec/requests/rails_routing_spec.rb
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+if defined?(ActiveRecord) && !defined?(Sinatra)
+  feature 'Users' do
+    background do
+      1.upto(100) {|i| User.create! :name => "user#{'%03d' % i}" }
+    end
+    scenario 'navigating by pagination links with extra params' do
+      def find_page(page)
+        # Rails 3.2 and later are able to create the URL from the routes
+        # without simply converting everything to parameters, so we can locate
+        # links based on their fully formed URL. Earlier versions will simply
+        # append the params at the end of the URL (generating more ugly results
+        # that we don't want to check here).
+        if ActiveRecord::VERSION::STRING >= "3.2.0"
+          find(".page a[href='/users/hello/world/page/#{page}']")
+        else
+          find(".page a", :text => page.to_s)
+        end
+      end
+
+      visit '/users/hello/world/page/1'
+      find_page(4).click
+      find_page(1).click
+    end
+  end
+end


### PR DESCRIPTION
This may be a bit controversial, but I figured it was worth sharing. I was looking at a few of the open issues, and this minor change seems like it may address some older outstanding issues. The change should definitely have someone review it to see if it's something that would be good to move forward with.

One major change is for people creating friendly URLs, this will change the links that Kaminari generates for the first page. This would probably only impact a small percentage of people, but it's worth nothing here (and if this change is taken, maybe in release notes as well).

From the commit:

> This adds tests for #197 and may also address issue #182. It does so by changing the URL generation to remove the page query parameter when present. If the generated URL uses the page number in the URL directly, it will always be present. This also leads to a possible resolution for #44.
