### PR TITLE
Fix Coveralls API internal error

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-service_name: travis
+service_name: travis-ci


### PR DESCRIPTION
Previously submission to Coveralls was generating `[Coveralls] API internal error occured, we're on it!` which had to do with the service name not being properly set in the Coveralls config file. This was incorrectly set in pull request #467, and this pull request should fix it.

I'll confirm with a comment after the Travis build completes.
