### PR TITLE
Don't calculate total_pages if one is provided in options

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,7 +15,8 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
-      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+      options[:total_pages] ||= scope.total_pages
+      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
       paginator.to_s
     end
 

--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -86,9 +86,10 @@ module Kaminari::Helpers
       def paginate(scope, options = {}, &block)
         current_path = env['PATH_INFO'] rescue nil
         current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
+        options[:total_pages] ||= scope.total_pages
         paginator = Kaminari::Helpers::Paginator.new(
           ActionViewTemplateProxy.new(:current_params => current_params, :current_path => current_path, :param_name => options[:param_name] || Kaminari.config.param_name),
-          options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+          options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
         )
         paginator.to_s
       end


### PR DESCRIPTION
In some cases, `scope.total_pages` (and therefore `scope.total_count`) is calculated without a `COUNT` query, resulting in an additional (potentially expensive) query. In this case, using a `distinct` scope causes the entire collection to be loaded.

**Example:** Rails 4.0.0, Ruby 2.0.0-p247

``` ruby
@scope = Post.where(tag: 'test').distinct
@total_count = @scope.count # 17,294,103
```

``` haml
= paginate @scope.page(params[:page]), total_pages: (@total_count / 25.0).ceil
```

**Without patch:**

``` log
(7.1ms)  SELECT COUNT(`post`.`id`) FROM `post` WHERE (post.tag = 'test')
(170.0ms)  SELECT `post`.* FROM `post` WHERE (post.tag = 'test')
(2.8ms)  SELECT `post`.* FROM `post` WHERE (post.tag = 'test') LIMIT 25 OFFSET 0
```

**With patch:**

``` log
(7.1ms)  SELECT COUNT(`post`.`id`) FROM `post` WHERE (post.tag = 'test')
(2.8ms)  SELECT `post`.* FROM `post` WHERE (post.tag = 'test') LIMIT 25 OFFSET 0
```
