### PR TITLE
Translated pluralisation support.

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -92,12 +92,11 @@ module Kaminari
         'entry'
       else
         if collection.respond_to? :model  # DataMapper
-          collection.model.model_name.human.downcase
+          collection.model.model_name.human(:count => collection.total_count).downcase
         else  # AR
-          collection.model_name.human.downcase
+          collection.model_name.human(:count => collection.total_count).downcase
         end
       end
-      entry_name = entry_name.pluralize unless collection.total_count == 1
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)


### PR DESCRIPTION
Several model names gets a wrong pluralisation, even though they are are correctly translated. This PR fixes that by supplying the "count" parameter for the "AR::Base.model_name.human"-method.
