### PR TITLE
PageEntriesInfo: Numbers with delimiter

### DIFF
--- a/config/locales/kaminari.yml
+++ b/config/locales/kaminari.yml
@@ -14,6 +14,6 @@ en:
         display_entries:
           zero: "No %{entry_name} found"
           one: "Displaying <b>1</b> %{entry_name}"
-          other: "Displaying <b>all %{count}</b> %{entry_name}"
+          other: "Displaying <b>all %{count_formatted}</b> %{entry_name}"
       more_pages:
         display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -99,12 +99,18 @@ module Kaminari
       end
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
+      count_str = number_with_delimiter(collection.total_count)
+
       if collection.total_pages < 2
-        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)
+        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => count_str)
       else
         first = collection.offset_value + 1
+        first_str = number_with_delimiter(first)
+
         last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first, :last => last, :total => collection.total_count)
+        last_str = number_with_delimiter(last)
+
+        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first_str, :last => last_str, :total => count_str)
       end.html_safe
     end
 

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -99,18 +99,18 @@ module Kaminari
       end
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
-      count_str = number_with_delimiter(collection.total_count)
+      count_formatted = number_with_delimiter(collection.total_count)
 
       if collection.total_pages < 2
-        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => count_str)
+        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => count_formatted)
       else
         first = collection.offset_value + 1
-        first_str = number_with_delimiter(first)
+        first_formatted = number_with_delimiter(first)
 
         last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-        last_str = number_with_delimiter(last)
+        last_formatted = number_with_delimiter(last)
 
-        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first_str, :last => last_str, :total => count_str)
+        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first_formatted, :last => last_formatted, :total => count_formatted)
       end.html_safe
     end
 

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -100,16 +100,18 @@ module Kaminari
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
       count = collection.total_count
-      count_formatted = number_with_delimiter(count)
+
+      options[:count_number_formatter] ||= ->(page_number){ page_number }
+      count_formatted = options[:count_number_formatter].call(count)
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :count => count, :entry_name => entry_name, :count_formatted => count_formatted)
       else
         first = collection.offset_value + 1
-        first_formatted = number_with_delimiter(first)
+        first_formatted = options[:count_number_formatter].call(first)
 
         last = collection.last_page? ? count : collection.offset_value + collection.limit_value
-        last_formatted = number_with_delimiter(last)
+        last_formatted = options[:count_number_formatter].call(last)
 
         t('helpers.page_entries_info.more_pages.display_entries', :count => count, :entry_name => entry_name, :first => first_formatted, :last => last_formatted, :total => count_formatted)
       end.html_safe

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -97,17 +97,13 @@ module Kaminari
           collection.model_name.human.downcase
         end
       end
+      entry_name = entry_name.pluralize unless collection.total_count == 1
 
       count = collection.total_count
       count_formatted = number_with_delimiter(count)
-      entry_name = entry_name.pluralize unless collection.total_count == 1
 
-      if count == 0
-        t('helpers.page_entries_info.one_page.display_entries.zero', :entry_name => entry_name)
-      elsif count == 1
-        t('helpers.page_entries_info.one_page.display_entries.one', :entry_name => entry_name)
-      elsif collection.total_pages < 2
-        t('helpers.page_entries_info.one_page.display_entries.other', :entry_name => entry_name, :count => count_formatted)
+      if collection.total_pages < 2
+        t('helpers.page_entries_info.one_page.display_entries', :count => count, :entry_name => entry_name, :count_formatted => count_formatted)
       else
         first = collection.offset_value + 1
         first_formatted = number_with_delimiter(first)
@@ -115,7 +111,7 @@ module Kaminari
         last = collection.last_page? ? count : collection.offset_value + collection.limit_value
         last_formatted = number_with_delimiter(last)
 
-        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first_formatted, :last => last_formatted, :total => count_formatted)
+        t('helpers.page_entries_info.more_pages.display_entries', :count => count, :entry_name => entry_name, :first => first_formatted, :last => last_formatted, :total => count_formatted)
       end.html_safe
     end
 

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -97,17 +97,22 @@ module Kaminari
           collection.model_name.human.downcase
         end
       end
+
+      count = collection.total_count
+      count_formatted = number_with_delimiter(count)
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
-      count_formatted = number_with_delimiter(collection.total_count)
-
-      if collection.total_pages < 2
-        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => count_formatted)
+      if count == 0
+        t('helpers.page_entries_info.one_page.display_entries.zero', :entry_name => entry_name)
+      elsif count == 1
+        t('helpers.page_entries_info.one_page.display_entries.one', :entry_name => entry_name)
+      elsif collection.total_pages < 2
+        t('helpers.page_entries_info.one_page.display_entries.other', :entry_name => entry_name, :count => count_formatted)
       else
         first = collection.offset_value + 1
         first_formatted = number_with_delimiter(first)
 
-        last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
+        last = collection.last_page? ? count : collection.offset_value + collection.limit_value
         last_formatted = number_with_delimiter(last)
 
         t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first_formatted, :last => last_formatted, :total => count_formatted)

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -144,6 +144,15 @@ describe 'Kaminari::ActionViewExtension' do
           end
         end
       end
+      
+      context 'format numbers' do
+        it 'should format numbers' do
+          50.times {|i| User.create! :name => "user#{i}"}
+          @users = User.page(1).per(25)
+          res = helper.page_entries_info @users, :count_number_formatter => ->(page_number){ "#{page_number}asd" }
+          res.should eq 'Displaying users <b>1asd&nbsp;-&nbsp;25asd</b> of <b>50asd</b> in total'
+        end
+      end
     end
     context 'on a model with namespace' do
       before do


### PR DESCRIPTION
Using "number_with_delimiter" to make large numbers easier to read. Especially when we are talking millions of results, which is the case in our application.
