### PR TITLE
Dropped Ruby 1.8, kaminari has unsupported syntax for Ruby 1.8

### DIFF
--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = 'A pagination engine plugin for Rails 3+ or other modern frameworks'
   s.description = 'Kaminari is a Scope & Engine based, clean, powerful, agnostic, customizable and sophisticated paginator for Rails 3+'
 
+  s.required_ruby_version = '>= 1.9.3'
   s.rubyforge_project = 'kaminari'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
kaminari uses follow syntax:

``` ruby
define_method(Kaminari.config.page_method_name) do |num = nil|
...
```

Ruby 1.8 couldn't used above syntax. 0.15.0 is already released. I think dropped version of Ruby 1.8 better.
