### PR TITLE
use the mongoid criteria #length method to cache the count of the collection per criteria

### DIFF
--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -9,7 +9,7 @@ module Kaminari
     end
 
     def total_count #:nodoc:
-      embedded? ? unpage.count : count
+      embedded? ? unpage.length : length
     end
 
     private


### PR DESCRIPTION
Fixes slow pagination into large mongoid collections as the criteria method doesn't cache the count. `ActionViewExtension#page_entries_info` calls total_count 3 or 4 times (depending on execution path), slowing the view render.

http://mongoid.org/en/mongoid/docs/querying.html
`Criteria#length`, Also size. Get a count of persisted documents. After being called once for the criteria, will cache subsequent calls and not hit the database.
