### PR TITLE
Get specs running under Rubinius

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,13 +30,17 @@ namespace :spec do
   end
 end
 
-require 'rdoc/task'
+begin
+  require 'rdoc/task'
 
-Rake::RDocTask.new do |rdoc|
-  require 'kaminari/version'
+  Rake::RDocTask.new do |rdoc|
+    require 'kaminari/version'
 
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "kaminari #{Kaminari::VERSION}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title = "kaminari #{Kaminari::VERSION}"
+    rdoc.rdoc_files.include('README*')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
+rescue LoadError
+  puts 'RDocTask is not supported on this VM and platform combination.'
 end

--- a/gemfiles/active_record_30.gemfile
+++ b/gemfiles/active_record_30.gemfile
@@ -16,5 +16,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/active_record_31.gemfile
+++ b/gemfiles/active_record_31.gemfile
@@ -16,5 +16,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/active_record_32.gemfile
+++ b/gemfiles/active_record_32.gemfile
@@ -16,5 +16,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/active_record_40.gemfile
+++ b/gemfiles/active_record_40.gemfile
@@ -10,5 +10,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/active_record_edge.gemfile
+++ b/gemfiles/active_record_edge.gemfile
@@ -14,6 +14,12 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gem 'rspec-rails', '>= 2.0'
 

--- a/gemfiles/data_mapper_12.gemfile
+++ b/gemfiles/data_mapper_12.gemfile
@@ -21,5 +21,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 1.2.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/mongo_mapper.gemfile
+++ b/gemfiles/mongo_mapper.gemfile
@@ -10,4 +10,11 @@ gem 'nokogiri', '< 1.6'
 gem 'rubyzip', '< 1'
 gem 'mime-types', '< 2'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec :path => '../'

--- a/gemfiles/mongoid_24.gemfile
+++ b/gemfiles/mongoid_24.gemfile
@@ -11,4 +11,11 @@ gem 'rubyzip', '< 1'
 gem 'mime-types', '< 2'
 gem 'database_cleaner', '< 1.0.0'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec :path => '../'

--- a/gemfiles/mongoid_30.gemfile
+++ b/gemfiles/mongoid_30.gemfile
@@ -6,4 +6,11 @@ gem 'rspec-rails', '>= 2.0'
 gem 'origin'
 gem 'moped'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec :path => '../'

--- a/gemfiles/mongoid_31.gemfile
+++ b/gemfiles/mongoid_31.gemfile
@@ -6,4 +6,11 @@ gem 'rspec-rails', '>= 2.0'
 gem 'origin'
 gem 'moped'
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec :path => '../'

--- a/gemfiles/sinatra_13.gemfile
+++ b/gemfiles/sinatra_13.gemfile
@@ -21,5 +21,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'

--- a/gemfiles/sinatra_14.gemfile
+++ b/gemfiles/sinatra_14.gemfile
@@ -21,5 +21,11 @@ end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0'
 end
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'racc'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
 
 gemspec :path => '../'


### PR DESCRIPTION
1. Added Rubinius gems to Gemfiles.  
2. Updated Rakefile to handle Rubinius/Rails 4 case where RDocTask is not available.

Almost all of the test matrix is green with this PR.  There is still one failure - ActiveRecord edge + Rubinius.  This appears to be the result of a recently introduced incompatibility.  I'm not sure how to fix it.  But the remaining Rubinius specs all run as expected now.
