### PR TITLE
Get specs green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ matrix:
     - rvm: 1.8.7
       gemfile: gemfiles/mongoid_31.gemfile
   allow_failures:
-    - rvm: rbx
+    - rvm: jruby 
       gemfile: gemfiles/active_record_edge.gemfile

--- a/gemfiles/active_record_edge.gemfile
+++ b/gemfiles/active_record_edge.gemfile
@@ -17,10 +17,10 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'minitest'
   gem 'rubinius-developer_tools'
 end
 
-gem 'rspec-rails', '>= 2.0'
+gem 'rspec-rails', '2.99.0.beta1'
 
 gemspec :path => '../'


### PR DESCRIPTION
1. Updated ActiveRecord edge to use Minitest rather than TestUnit, and use a more recent version of RSpec without the TestUnit dependencies.
2. Updated Travis config to exclude JRuby / ActiveRecord edge until ActiveRecord JDBC driver issue is resolved
3. Moved rbx / ActiveRecord edge out of allowed failures now that it's passing.
