### PR TITLE
Add support for mongoid max_scan option

### DIFF
--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -9,7 +9,17 @@ module Kaminari
     end
 
     def total_count #:nodoc:
-      embedded? ? unpage.length : length
+      @total_count ||=
+        if embedded?
+          unpage.count
+        else
+          counter_result = count
+          if options[:max_scan] and options[:max_scan] < counter_result
+            options[:max_scan]
+          else
+            counter_result
+          end
+        end
     end
 
     private

--- a/spec/models/mongoid/mongoid_spec.rb
+++ b/spec/models/mongoid/mongoid_spec.rb
@@ -8,6 +8,60 @@ if defined? Mongoid
       end
     end
 
+    describe 'max_scan', if: Mongoid::VERSION >= '3' do
+      context 'less than total' do
+        context 'page 1' do
+          subject { User.max_scan(20).page 1 }
+          it { should be_a Mongoid::Criteria }
+          its(:current_page) { should == 1   }
+          its(:prev_page)    { should be_nil }
+          its(:next_page)    { should be_nil }
+          its(:limit_value)  { should == 25  }
+          its(:total_pages)  { should == 1   }
+          its(:total_count)  { should == 20  }
+          it { should skip(0) }
+        end
+
+        context 'page 2' do
+          subject { User.max_scan(30).page 2 }
+          it { should be_a Mongoid::Criteria }
+          its(:current_page) { should == 2   }
+          its(:prev_page)    { should == 1   }
+          its(:next_page)    { should be_nil }
+          its(:limit_value)  { should == 25  }
+          its(:total_pages)  { should == 2   }
+          its(:total_count)  { should == 30  }
+          it { should skip 25 }
+        end
+      end
+
+      context 'more than total' do
+        context 'page 1' do
+          subject { User.max_scan(60).page 1 }
+          it { should be_a Mongoid::Criteria }
+          its(:current_page) { should == 1   }
+          its(:prev_page)    { should be_nil }
+          its(:next_page)    { should == 2   }
+          its(:limit_value)  { should == 25  }
+          its(:total_pages)  { should == 2   }
+          its(:total_count)  { should == 41  }
+          it { should skip(0) }
+        end
+
+        context 'page 2' do
+          subject { User.max_scan(60).page 2 }
+          it { should be_a Mongoid::Criteria }
+          its(:current_page) { should == 2   }
+          its(:prev_page) { should == 1      }
+          its(:next_page) { should be_nil    }
+          its(:limit_value) { should == 25   }
+          its(:total_pages) { should == 2    }
+          its(:total_count)  { should == 41  }
+          it { should skip 25 }
+        end
+      end
+    end
+
     describe '#page' do
 
       context 'page 1' do


### PR DESCRIPTION
When we have a lot of records, for example, more then 20k topics. We can paginate them in a index page, 48 topics for each page, and then there would be about 400 pages.  But in practice user does not need that many pages, most people will stop before reaching 20th page. 

So I this is a reason good enougth to support the `max_scan` option in mongoid which tells mongodb to query records not more than specific count

This patch also cache the total_count result to avoid generating identical query when we read the pagination info in same controller action 

```
  MOPED: 127.0.0.1:27017 COMMAND      database=staging command={:count=>"u", :query=>{}} runtime: 0.3679ms 
  MOPED: 127.0.0.1:27017 COMMAND      database=staging command={:count=>"u", :query=>{}} runtime: 0.2494ms 
  MOPED: 127.0.0.1:27017 COMMAND      database=staging command={:count=>"u", :query=>{}} runtime: 0.2818ms 
```
