### PR TITLE
removing the count(*) when no column assigned or :all #240

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -12,20 +12,23 @@ module Kaminari
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
       @total_count ||= begin
         c = except(:offset, :limit, :order)
-
-        # Remove includes only if they are irrelevant
-        c = c.except(:includes) unless references_eager_loaded_tables?
-
-        # Rails 4.1 removes the `options` argument from AR::Relation#count
-        args = [column_name]
-        args << options if ActiveRecord::VERSION::STRING < '4.1.0'
-
-        # .group returns an OrderdHash that responds to #count
-        c = c.count(*args)
-        if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-          c.count
+        if column_name == :all
+          c.length
         else
-          c.respond_to?(:count) ? c.count(*args) : c
+          # Remove includes only if they are irrelevant
+          c = c.except(:includes) unless references_eager_loaded_tables?
+
+          # Rails 4.1 removes the `options` argument from AR::Relation#count
+          args = [column_name]
+          args << options if ActiveRecord::VERSION::STRING < '4.1.0'
+
+          # .group returns an OrderdHash that responds to #count
+          c = c.count(*args)
+          if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
+            c.count
+          else
+            c.respond_to?(:count) ? c.count(*args) : c
+          end
         end
       end
     end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -11,6 +11,7 @@ if defined? ActiveRecord
         @books2 = 3.times.map {|i| @author2.books_authored.create!(:title => "title%03d" % i) }
         @books3 = 4.times.map {|i| @author3.books_authored.create!(:title => "subject%03d" % i) }
         @readers = 4.times.map { User.create! :name => 'reader' }
+        @many_books = 1000.times.map { Book.create! :title => "random_title_#{rand(1000)}"}
         @books.each {|book| book.readers << @readers }
       end
 
@@ -64,6 +65,16 @@ if defined? ActiveRecord
           lambda {
             @author.readers.by_read_count.page(1).total_count(:name, :distinct => true)
           }.should_not raise_exception
+        end
+      end
+
+      context "when there are thousands of records" do
+        it "should NOT do count(*) when no column is specified" do
+          Book.where("books.title LIKE 'random_title%'").page(1).total_count.should == 1000
+        end
+
+        it "should do a count(*) when a column is specified" do
+          Book.where("books.title LIKE 'random_title%'").page(1).total_count(:title).should == 1000
         end
       end
     end


### PR DESCRIPTION
Trying again from a different branch I was getting errors and I started over.
Originally this one #462
Hi @zzak this is a silly change but it will make a huge difference to not do an extra select count(*) when is not required. This change can help us to solve this issue gregbell/active_admin#2638 in Active Admin gem cc @seanlinsley
