### PR TITLE
do not have page=1 in rel url, or urls generated by previous_page helper

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -39,7 +39,7 @@ module Kaminari
     def link_to_previous_page(scope, name, options = {}, &block)
       params = options.delete(:params) || {}
       param_name = options.delete(:param_name) || Kaminari.config.param_name
-      link_to_unless scope.first_page?, name, params.merge(param_name => scope.prev_page), options.reverse_merge(:rel => 'previous') do
+      link_to_unless scope.first_page?, name, params.merge(param_name => (scope.prev_page.to_i <= 1 ? nil : scope.prev_page)), options.reverse_merge(:rel => 'previous') do
         block.call if block
       end
     end
@@ -132,7 +132,7 @@ module Kaminari
 
       output = ""
       output << '<link rel="next" href="' + url_for(params.merge(param_name => scope.next_page, :only_path => true)) + '"/>' if scope.next_page
-      output << '<link rel="prev" href="' + url_for(params.merge(param_name => scope.prev_page, :only_path => true)) + '"/>' if scope.prev_page
+      output << '<link rel="prev" href="' + url_for(params.merge(param_name => (scope.prev_page <= 1 ? nil : scope.prev_page), :only_path => true)) + '"/>' if scope.prev_page
 
       output.html_safe
     end


### PR DESCRIPTION
Cleans up the urls generated by previous page helper, and rel prev/next helper.
