### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -241,10 +241,10 @@ Kaminari includes a handy template generator.
 Kaminari provides an Array wrapper class that adapts a generic Array object to the <tt>paginate</tt> view helper.
 However, the <tt>paginate</tt> helper doesn't automatically handle your Array object (this is intentional and by design).
 <tt>Kaminari::paginate_array</tt> method converts your Array object into a paginatable Array that accepts <tt>page</tt> method.
-  Kaminari.paginate_array(my_array_object).page(params[:page]).per(10)
+  paginatable_array = Kaminari.paginate_array(my_array_object).page(params[:page]).per(10)
 
 You can specify the +total_count+ value through options Hash. This would be helpful when handling an Array-ish object that has a different +count+ value from actual +count+ such as RSolr search result or when you need to generate a custom pagination. For example:
-  Kaminari.paginate_array([], total_count: 145).page(params[:page]).per(10)
+  paginatable_array = Kaminari.paginate_array([], total_count: 145).page(params[:page]).per(10)
 
 == Creating friendly URLs and caching
 


### PR DESCRIPTION
clarify that paginate_array does not work on the array inline, but instead returns a new PaginatableArray.
