### PR TITLE
Use SVG for status badges in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= Kaminari {<img src="https://travis-ci.org/amatsuda/kaminari.png"/>}[http://travis-ci.org/amatsuda/kaminari] {<img src="https://codeclimate.com/github/amatsuda/kaminari.png" />}[https://codeclimate.com/github/amatsuda/kaminari]
+= Kaminari {<img src="https://img.shields.io/travis/amatsuda/kaminari/master.svg "/>}[https://travis-ci.org/amatsuda/kaminari] {<img src="https://img.shields.io/codeclimate/github/amatsuda/kaminari.svg" />}[https://codeclimate.com/github/amatsuda/kaminari]
 
 A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the images currently used, but the SVG versions added here are more legible on high pixel density displays.
