### PR TITLE
Pass ActiveSupport::JSON.decode a string and not an IO when interfacing with GitHub API

### DIFF
--- a/lib/generators/kaminari/views_generator.rb
+++ b/lib/generators/kaminari/views_generator.rb
@@ -96,10 +96,10 @@ BANNER
     module GitHubApiHelper
       def get_files_in_master
         master_tree_sha = open('https://api.github.com/repos/amatsuda/kaminari_themes/git/refs/heads/master') do |json|
-          ActiveSupport::JSON.decode(json)['object']['sha']
+          ActiveSupport::JSON.decode(json.read)['object']['sha']
         end
         open('https://api.github.com/repos/amatsuda/kaminari_themes/git/trees/' + master_tree_sha + '?recursive=1') do |json|
-          blobs = ActiveSupport::JSON.decode(json)['tree'].find_all {|i| i['type'] == 'blob' }
+          blobs = ActiveSupport::JSON.decode(json.read)['tree'].find_all {|i| i['type'] == 'blob' }
           blobs.map do |blob|
             [blob['path'], blob['sha']]
           end
@@ -109,7 +109,7 @@ BANNER
 
       def get_content_for(path)
         open('https://api.github.com/repos/amatsuda/kaminari_themes/contents/' + path) do |json|
-          Base64.decode64(ActiveSupport::JSON.decode(json)['content'])
+          Base64.decode64(ActiveSupport::JSON.decode(json.read)['content'])
         end
       end
       module_function :get_content_for


### PR DESCRIPTION
In older versions (< 4.1) of ActiveSupport, this worked because ActiveSupport used MultiJSON, which would invoke #read if it responded to it (https://github.com/intridea/multi_json/blob/v1.8.4/lib/multi_json/adapters/json_common.rb#L9).  However, newer versions of ActiveSupport, starting in 4.1, use ruby's standard JSON gem (https://github.com/rails/rails/commit/ce4456fde6f45f1abd020cbdeb520d401299e01f), which expects a String. Reading the IO that #open returns to us and passing the resulting String to JSON.decode ensures compatibility with all versions of ActiveSupport.
