### PR TITLE
Do not alias_method_chain Class#inherited

### DIFF
--- a/lib/kaminari/models/active_record_extension.rb
+++ b/lib/kaminari/models/active_record_extension.rb
@@ -6,11 +6,10 @@ module Kaminari
     included do
       # Future subclasses will pick up the model extension
       class << self
-        def inherited_with_kaminari(kls) #:nodoc:
-          inherited_without_kaminari kls
+        def inherited(kls) #:nodoc:
+          super kls
           kls.send(:include, Kaminari::ActiveRecordModelExtension) if kls.superclass == ::ActiveRecord::Base
         end
-        alias_method_chain :inherited, :kaminari
       end
 
       # Existing subclasses pick up the model extension as well


### PR DESCRIPTION
If anohter module overrides Class#inherited after aliased,
the orverided inherited method is not called.

``` ruby
module FooConcern
  extend ActiveSupport::Concern

  module ClassMethods

    # this method is not called when subclass defined
    def inherited(subclass)
      puts "test"
      super subclass
    end
  end
end

class ActiveRecord::Base
  include FooConcern
end

class Foo < ActiveRecord::Base ; end
# => FooConcern's inherited is not called
```

I think it would simply overrides Class#inherited like other gems.

i.e) https://github.com/rails/rails-observers/blob/master/lib/rails/observers/active_model/observing.rb#L197
