### PR TITLE
Add docs badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= Kaminari {<img src="https://travis-ci.org/amatsuda/kaminari.png"/>}[http://travis-ci.org/amatsuda/kaminari] {<img src="https://codeclimate.com/github/amatsuda/kaminari.png" />}[https://codeclimate.com/github/amatsuda/kaminari]
+= Kaminari {<img src="https://travis-ci.org/amatsuda/kaminari.png"/>}[http://travis-ci.org/amatsuda/kaminari] {<img src="https://codeclimate.com/github/amatsuda/kaminari.png" />}[https://codeclimate.com/github/amatsuda/kaminari] {<img src="http://inch-pages.github.io/github/amatsuda/kaminari.png" alt="Inline docs" />}[http://inch-pages.github.io/github/amatsuda/kaminari]
 
 A Scope & Engine based, clean, powerful, customizable and sophisticated paginator for modern web app frameworks and ORMs
 


### PR DESCRIPTION
Hi Akira,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/amatsuda/kaminari.png)](http://inch-pages.github.io/github/amatsuda/kaminari)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/amatsuda/kaminari/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
