### PR TITLE
Delimit numbers in display_entries when necessary

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,13 +88,14 @@ module Kaminari
     def page_entries_info(collection, options = {})
       entry_name = options[:entry_name] || collection.entry_name
       entry_name = entry_name.pluralize unless collection.total_count == 1
+      total = collection.total_count > 1 ? number_with_delimiter(collection.total_count) : collection.total_count
 
       if collection.total_pages < 2
-        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)
+        t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => total)
       else
         first = collection.offset_value + 1
         last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
-        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first, :last => last, :total => collection.total_count)
+        t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => number_with_delimiter(first), :last => number_with_delimiter(last), :total => total)
       end.html_safe
     end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -179,6 +179,28 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
         end
       end
     end
+    context 'having more than 999 entries' do
+      before do
+        1000.times {|i| User.create! :name => "user#{i}"}
+      end
+
+      describe 'the last page' do
+        before do
+          @users = User.page(1000).per(1)
+        end
+
+        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying users <b>1,000&nbsp;-&nbsp;1,000</b> of <b>1,000</b> in total' }
+      end
+      describe 'the only page' do
+        before do
+          @users = User.page(1000).per(1000)
+        end
+
+        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying <b>all 1,000</b> users' }
+      end
+    end
     context 'on a model with namespace' do
       before do
         @addresses = User::Address.page(1).per(25)


### PR DESCRIPTION
This change automatically delimits the numbers in the summary to increase readability with larger collections.
