### PR TITLE
Add optional :use_page_one_param option for paginate() helper method

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -36,7 +36,7 @@ module Kaminari
         page_params = Rack::Utils.parse_nested_query("#{@param_name}=#{page}")
         page_params = @params.with_indifferent_access.deep_merge(page_params)
 
-        if page <= 1
+        if page <= 1 && !@options[:use_page_one_param]
           # This converts a hash:
           #   from: {other: "params", page: 1}
           #     to: {other: "params"}

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -28,7 +28,7 @@ describe 'Kaminari::Helpers' do
             it { should match(/user%5Bscope%5D=active/) } #     match user[scope]=active
           end
         end
-
+        
         context "for other page" do
           subject { Tag.new(helper, :param_name => "user[page]").page_url_for(2) }
           if ActiveSupport::VERSION::STRING < "3.1.0"
@@ -36,6 +36,17 @@ describe 'Kaminari::Helpers' do
             it { should match(/user\[scope\]=active/) }
           else
             it { should match(/user%5Bpage%5D=2/) }       # match user[page]=2
+            it { should match(/user%5Bscope%5D=active/) } # match user[scope]=active
+          end
+        end
+        
+        context "for first page with use_page_one_param option set" do
+          subject { Tag.new(helper, :param_name => "user[page]", :use_page_one_param => true).page_url_for(1) }
+          if ActiveSupport::VERSION::STRING < "3.1.0"
+            it { should match(/user\[page\]=1/) }
+            it { should match(/user\[scope\]=active/) }
+          else
+            it { should match(/user%5Bpage%5D=1/) }       # match user[page]=1
             it { should match(/user%5Bscope%5D=active/) } # match user[scope]=active
           end
         end

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -50,6 +50,7 @@ describe 'Kaminari::Helpers' do
             it { should match(/user%5Bscope%5D=active/) } # match user[scope]=active
           end
         end
+
       end
     end
   end


### PR DESCRIPTION
Added an optional parameter that can be passed to the paginate() helper that will force the navigation links to use the page=1 parameter instead of not including the page parameter at all. For most implementations, the default behavior works well. But if page 1 is not the default page when the parameter is not present, navigation to page 1 doesn't work. This small edit seems to do the trick. I'm using it like this in my current implementation:

`<%= paginate audit_transactions, use_page_one_param: true %>`
