### PR TITLE
ActionView check for NilClass & unextended models

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,6 +15,7 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
+      return "" if scope.nil? || scope.try(:current_page).nil?
       paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :remote => false)
       paginator.to_s
     end
@@ -37,6 +38,7 @@ module Kaminari
     #     <span>At the Beginning</span>
     #   <% end %>
     def link_to_previous_page(scope, name, options = {}, &block)
+      return "" if scope.nil? || scope.try(:current_page).nil?
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
       link_to_unless scope.first_page?, name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
@@ -62,6 +64,7 @@ module Kaminari
     #     <span>No More Pages</span>
     #   <% end %>
     def link_to_next_page(scope, name, options = {}, &block)
+      return "" if scope.nil? || scope.try(:current_page).nil?
       next_page = Kaminari::Helpers::NextPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
       link_to_unless scope.last_page?, name, next_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'next') do
@@ -86,7 +89,9 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name
+      return "" if collection.nil?
+      entry_name = options[:entry_name] || collection.try(:entry_name)
+      return "" if entry_name.nil?
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
       if collection.total_pages < 2
@@ -117,6 +122,7 @@ module Kaminari
     #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
     #
     def rel_next_prev_link_tags(scope, options = {})
+      return "" if scope.nil? || scope.try(:current_page).nil?
       next_page = Kaminari::Helpers::NextPage.new self, options.reverse_merge(:current_page => scope.current_page)
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,7 +15,7 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
-      return "" if scope.nil? || scope.try(:current_page).nil?
+      return '' if scope.try(:current_page).nil?
       paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :remote => false)
       paginator.to_s
     end
@@ -38,7 +38,7 @@ module Kaminari
     #     <span>At the Beginning</span>
     #   <% end %>
     def link_to_previous_page(scope, name, options = {}, &block)
-      return "" if scope.nil? || scope.try(:current_page).nil?
+      return '' if scope.try(:current_page).nil?
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
       link_to_unless scope.first_page?, name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
@@ -64,7 +64,7 @@ module Kaminari
     #     <span>No More Pages</span>
     #   <% end %>
     def link_to_next_page(scope, name, options = {}, &block)
-      return "" if scope.nil? || scope.try(:current_page).nil?
+      return '' if scope.try(:current_page).nil?
       next_page = Kaminari::Helpers::NextPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
       link_to_unless scope.last_page?, name, next_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'next') do
@@ -89,9 +89,8 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      return "" if collection.nil?
       entry_name = options[:entry_name] || collection.try(:entry_name)
-      return "" if entry_name.nil?
+      return '' if entry_name.nil?
       entry_name = entry_name.pluralize unless collection.total_count == 1
 
       if collection.total_pages < 2
@@ -122,11 +121,11 @@ module Kaminari
     #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
     #
     def rel_next_prev_link_tags(scope, options = {})
-      return "" if scope.nil? || scope.try(:current_page).nil?
+      return '' if scope.try(:current_page).nil?
       next_page = Kaminari::Helpers::NextPage.new self, options.reverse_merge(:current_page => scope.current_page)
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
-      output = ""
+      output = ''
       output << tag(:link, :rel => "next", :href => next_page.url) if scope.next_page
       output << tag(:link, :rel => "prev", :href => prev_page.url) if scope.prev_page
       output.html_safe

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -18,13 +18,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'having empty payload' do
       it 'should call model extensions to NilClass' do
-        lambda {helper.paginate nil}.should_not raise_error
+        lambda { helper.paginate nil }.should_not raise_error
       end
     end
 
     context 'calling methods on unexposed model extensions' do
       it 'should not call unexposed models wrapped in an Array' do
-        lambda {helper.paginate []}.should_not raise_error
+        lambda { helper.paginate [] }.should_not raise_error
       end
     end
 
@@ -72,13 +72,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'having empty payload' do
       it 'should call model extensions to NilClass' do
-        lambda {helper.link_to_previous_page nil, 'Previous'}.should_not raise_error
+        lambda { helper.link_to_previous_page nil, 'Previous' }.should_not raise_error
       end
     end
 
     context 'calling methods on unexposed model extensions' do
       it 'should not call unexposed models wrapped in an Array' do
-        lambda {helper.link_to_previous_page [], 'Previous'}.should_not raise_error
+        lambda { helper.link_to_previous_page [], 'Previous' }.should_not raise_error
       end
     end
   end
@@ -125,13 +125,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'having empty payload' do
       it 'should call model extensions to NilClass' do
-        lambda {helper.link_to_next_page nil, 'Next'}.should_not raise_error
+        lambda { helper.link_to_next_page nil, 'Next' }.should_not raise_error
       end
     end
 
     context 'calling methods on unexposed model extensions' do
       it 'should not call unexposed models wrapped in an Array' do
-        lambda {helper.link_to_next_page [], 'Next'}.should_not raise_error
+        lambda { helper.link_to_next_page [], 'Next' }.should_not raise_error
       end
     end
   end
@@ -302,13 +302,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'having empty payload' do
       it 'should call model extensions to NilClass' do
-        lambda {helper.page_entries_info nil}.should_not raise_error
+        lambda { helper.page_entries_info nil }.should_not raise_error
       end
     end
 
     context 'calling methods on unexposed model extensions' do
       it 'should not call unexposed models wrapped in an Array' do
-        lambda {helper.page_entries_info []}.should_not raise_error
+        lambda { helper.page_entries_info [] }.should_not raise_error
       end
     end
   end
@@ -347,13 +347,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'having empty payload' do
       it 'should call model extensions to NilClass' do
-        lambda {helper.rel_next_prev_link_tags nil}.should_not raise_error
+        lambda { helper.rel_next_prev_link_tags nil }.should_not raise_error
       end
     end
 
     context 'calling methods on unexposed model extensions' do
       it 'should not call unexposed models wrapped in an Array' do
-        lambda {helper.rel_next_prev_link_tags []}.should_not raise_error
+        lambda { helper.rel_next_prev_link_tags [] }.should_not raise_error
       end
     end
   end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -15,6 +15,19 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
         lambda { helper.escape_javascript(helper.paginate @users, :params => {:controller => 'users', :action => 'index'}) }.should_not raise_error
       end
     end
+
+    context 'having empty payload' do
+      it 'should call model extensions to NilClass' do
+        lambda {helper.paginate nil}.should_not raise_error
+      end
+    end
+
+    context 'calling methods on unexposed model extensions' do
+      it 'should not call unexposed models wrapped in an Array' do
+        lambda {helper.paginate []}.should_not raise_error
+      end
+    end
+
   end
 
   describe '#link_to_previous_page' do
@@ -56,6 +69,18 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} }
       it { should_not be }
     end
+
+    context 'having empty payload' do
+      it 'should call model extensions to NilClass' do
+        lambda {helper.link_to_previous_page nil, 'Previous'}.should_not raise_error
+      end
+    end
+
+    context 'calling methods on unexposed model extensions' do
+      it 'should not call unexposed models wrapped in an Array' do
+        lambda {helper.link_to_previous_page [], 'Previous'}.should_not raise_error
+      end
+    end
   end
 
   describe '#link_to_next_page' do
@@ -96,6 +121,18 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
       it { should_not be }
+    end
+
+    context 'having empty payload' do
+      it 'should call model extensions to NilClass' do
+        lambda {helper.link_to_next_page nil, 'Next'}.should_not raise_error
+      end
+    end
+
+    context 'calling methods on unexposed model extensions' do
+      it 'should not call unexposed models wrapped in an Array' do
+        lambda {helper.link_to_next_page [], 'Next'}.should_not raise_error
+      end
     end
   end
 
@@ -262,6 +299,18 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       subject { helper.page_entries_info @numbers }
       it      { should == 'Displaying <b>all 3</b> entries' }
     end
+
+    context 'having empty payload' do
+      it 'should call model extensions to NilClass' do
+        lambda {helper.page_entries_info nil}.should_not raise_error
+      end
+    end
+
+    context 'calling methods on unexposed model extensions' do
+      it 'should not call unexposed models wrapped in an Array' do
+        lambda {helper.page_entries_info []}.should_not raise_error
+      end
+    end
   end
 
   describe '#rel_next_prev_link_tags' do
@@ -294,6 +343,18 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       it { should match(/rel="prev"/) }
       it { should match(/\?page=3"/) }
       it { should_not match(/rel="next"/) }
+    end
+
+    context 'having empty payload' do
+      it 'should call model extensions to NilClass' do
+        lambda {helper.rel_next_prev_link_tags nil}.should_not raise_error
+      end
+    end
+
+    context 'calling methods on unexposed model extensions' do
+      it 'should not call unexposed models wrapped in an Array' do
+        lambda {helper.rel_next_prev_link_tags []}.should_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
I've added some checks for NilClass and Unextended models in an empty Array (missing methods: entry_name, limit_value, offset_value, total_count), which are used in `lib/kaminari/helpers/action_view_extension.rb` in helper methods: paginate, link_to_previous_page, link_to_next_page, page_entries_info, and rel_next_prev_link_tags.

This way I can safely use those helpers, without having to manually check their types in the views (reducing the chance of accidental issues). Below a sample code snippet: 

``` haml
# controller
unless current_user.nil?
  @posts = current_user.all_posts
end
# view
div.paginate
  = paginate @posts
  = link_to_previous_page @posts, "<< Previous"
  = link_to_next_page @posts, "Next >>"
  = page_entries_info @posts
  = rel_next_prev_link_tags @posts
```

PS. I've included tests for these altered helpers as well. All `action_view_extension.rb` tests are still successful. 
