### PR TITLE
Add views_prefix Option For Alternative Views Directory

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -168,6 +168,11 @@ Run the following generator command, then edit the generated file.
     <%= paginate @users, :remote => true %>
   This would add <tt>data-remote="true"</tt> to all the links inside.
 
+* specifying an alternative views directory (default is <tt>kaminari/</tt>)
+
+    <%= paginate @users, :views_prefix => '../templates/pagination' %>
+  This would search for partials in <tt>app/views/../templates/pagination</tt>.
+
 * the +link_to_next_page+ and +link_to_previous_page+ helper method
 
     <%= link_to_next_page @items, 'Next Page' %>

--- a/app/views/alternative/kaminari/_paginator.erb
+++ b/app/views/alternative/kaminari/_paginator.erb
@@ -1,0 +1,1 @@
+<p><%= current_page %></p>

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -25,7 +25,7 @@ module Kaminari
           h[:right] = outer_window if h[:right] == 0
         end
         @template, @options = template, options
-        @theme = @options[:theme] ? "#{@options[:theme]}/" : ''
+        @theme = @options.delete(:theme)
         @window_options.merge! @options
         @window_options[:current_page] = @options[:current_page] = PageProxy.new(@window_options, @options[:current_page], nil)
 

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -18,12 +18,12 @@ module Kaminari
       def initialize(template, options = {}) #:nodoc:
         @template, @options = template, options.dup
         @param_name = @options.delete(:param_name) || Kaminari.config.param_name
-        @theme = @options[:theme] ? "#{@options.delete(:theme)}/" : ''
+        @theme = @options.delete(:theme)
         @params = template.params.except(*PARAM_KEY_BLACKLIST).merge(@options.delete(:params) || {})
       end
 
       def to_s(locals = {}) #:nodoc:
-        @template.render :partial => "#{@options[:views_prefix]}kaminari/#{@theme}#{self.class.name.demodulize.underscore}", :locals => @options.merge(locals), :formats => [:html]
+        @template.render :partial => partial_path, :locals => @options.merge(locals), :formats => [:html]
       end
 
       def page_url_for(page)
@@ -49,6 +49,13 @@ module Kaminari
         end
 
         page_params
+      end
+
+      def partial_path
+        [@options[:views_prefix] || "kaminari",
+         @theme,
+         self.class.name.demodulize.underscore
+        ].compact.join("/")
       end
     end
 

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -23,7 +23,7 @@ module Kaminari
       end
 
       def to_s(locals = {}) #:nodoc:
-        @template.render :partial => "kaminari/#{@theme}#{self.class.name.demodulize.underscore}", :locals => @options.merge(locals), :formats => [:html]
+        @template.render :partial => "#{@options[:views_prefix]}kaminari/#{@theme}#{self.class.name.demodulize.underscore}", :locals => @options.merge(locals), :formats => [:html]
       end
 
       def page_url_for(page)

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -17,7 +17,7 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
     end
 
     context 'accepts :view_prefixes option' do
-      subject { helper.paginate @users, :views_prefix => "alternative/" }
+      subject { helper.paginate @users, :views_prefix => "alternative/kaminari" }
       it { should eq("<p>1</p>") }
     end
   end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -15,6 +15,11 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
         lambda { helper.escape_javascript(helper.paginate @users, :params => {:controller => 'users', :action => 'index'}) }.should_not raise_error
       end
     end
+
+    context 'accepts :view_prefixes option' do
+      subject { helper.paginate @users, :views_prefix => "alternative/" }
+      it { should eq("<p>1</p>") }
+    end
   end
 
   describe '#link_to_previous_page' do


### PR DESCRIPTION
# Summary

This PR adds a new option for `#paginate` and friends to specify an alternative views directory. While the default points to `app/views/kaminari`, users can now specify their own.

``` ruby
paginate @users, views_prefix: "../pagination"
```

Partials are now searched in `app/pagination/`. This is especially useful in the Cells gem.
# Implementation

I extracted partial path logic into `Tag#partial_path`.

During my work I found some more places where we could remove redundant code (e.g. as found in `Tag#initialize` and its successor `Paginator#initialize`. I'll submit a separate PR for that :heart: 
