### PR TITLE
Fix a bug where :view_paths wouldn't be inherited to nested helpers. 

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -26,7 +26,7 @@ module Kaminari
         end
         @template, @options = template, options
         @theme = @options.delete(:theme)
-        @views_prefix = @options.delete(:views_prefix)
+        @views_prefix = @options[:views_prefix]
         @window_options.merge! @options
         @window_options[:current_page] = @options[:current_page] = PageProxy.new(@window_options, @options[:current_page], nil)
 

--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -19,7 +19,7 @@ module Kaminari
         @template, @options = template, options.dup
         @param_name = @options.delete(:param_name) || Kaminari.config.param_name
         @theme = @options.delete(:theme)
-        @views_prefix = @options.delete(:views_prefix)
+        @views_prefix = @options[:views_prefix]
         @params = template.params.except(*PARAM_KEY_BLACKLIST).merge(@options.delete(:params) || {})
       end
 

--- a/spec/fake_app/views/alternative/kaminari/_first_page.html.erb
+++ b/spec/fake_app/views/alternative/kaminari/_first_page.html.erb
@@ -1,0 +1,1 @@
+<b><%= current_page %></b>

--- a/spec/fake_app/views/alternative/kaminari/_paginator.html.erb
+++ b/spec/fake_app/views/alternative/kaminari/_paginator.html.erb
@@ -1,1 +1,3 @@
-<p><%= current_page %></p>
+<%= paginator.render do -%>
+  <%= first_page_tag %>
+<% end -%>

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -18,8 +18,8 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
     context 'accepts :view_prefix option' do
       before { helper.controller.append_view_path "spec/fake_app/views" }
-      subject { helper.paginate @users, :views_prefix => "alternative/" }
-      it { should eq("<p>1</p>") }
+      subject { helper.paginate @users, :views_prefix => "alternative/", :params => {:controller => 'users', :action => 'index'} }
+      it { should eq("  <b>1</b>\n") }
     end
   end
 


### PR DESCRIPTION
# Summary

My test sucked and `:view_paths` wasn't properly inherited to nested helper calls, e.g. `first_page`.

BTW - the fact that I had to fix it in two places reminded me of the other refactoring I wanted to suggest. More on that later.
