### PR TITLE
Issue #572: grouped count (with aliased columns) issues

### DIFF
--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "kaminari/version"
-
+ 
 Gem::Specification.new do |s|
   s.name        = 'kaminari'
   s.version     = Kaminari::VERSION

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -31,14 +31,20 @@ module Kaminari
         count_sql = c.to_sql.downcase
         group_with_alias = count_sql.include?(" group by ") && count_sql.include?(" as ")
         if group_with_alias
-          return self.connection.execute("select count(*) as full_count from (#{c.to_sql}) as rel").first.first.to_i
-        end
-        # .group returns an OrderdHash that responds to #count
-        c = c.count(*args)
-        if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-          c.count
+          c = self.connection.execute("select count(*) as full_count from (#{c.to_sql}) as rel").first
+          if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
+            c['full_count']
+          else
+            c.first.to_i
+          end
         else
-          c.respond_to?(:count) ? c.count(*args) : c
+          # .group returns an OrderdHash that responds to #count
+          c = c.count(*args)
+          if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
+            c.count
+          else
+            c.respond_to?(:count) ? c.count(*args) : c
+          end
         end
       end
     end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -24,49 +24,21 @@ module Kaminari
         args = [column_name]
         args << options if ActiveRecord::VERSION::STRING < '4.1.0'
 
-       # If group_by is used alongside column aliases, 'count' will destroy the select part of the
-       # query to construct the count. This will cause an exception
-       # Some group_by counts return hashes, which cannot be used to calculate the number of
-       # groups.
-       # In both these cases, using a sub-query to count groups resolves the issue.
-       is_group = c.to_sql.downcase.include?(" group by ")
-       if false#is_group
-         sm = Arel::SelectManager.new c.engine
-         select_value = "count(*) as count"
-         counting_subquery = sm.project(select_value).from(c.arel.as("subquery_for_count"))
-         connection.select_one(counting_subquery)['count']
-       else
-         # .group returns an OrderedHash that responds to #count
-         c = c.count(*args)
-         if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-           c.count
-         else
-           c.respond_to?(:count) ? c.count(*args) : c
-         end
-       end
+        # If group_by is used alongside column aliases, 'count' will destroy the select part of the
+        # query to construct the count. This will cause an exception
+        # Some group_by counts return hashes, which cannot be used to calculate the number of
+        # groups.
+        # In both these cases, using a sub-query to count groups resolves the issue.
+        is_group = c.to_sql.downcase.include?(" group by ")
+        if is_group
+          sm = Arel::SelectManager.new c.engine
+          select_value = "count(*) as count"
+          counting_subquery = sm.project(select_value).from(c.arel.as("subquery_for_count"))
+          connection.select_one(counting_subquery)['count']
+        else
+          c.respond_to?(:count) ? c.count(*args) : c
+        end
       end
     end
   end
 end
-
-
-# # If group_by is used alongside column aliases, 'count' will destroy the select part of the
-# # query to construct the count. This will cause an exception
-# # Some group_by counts return hashes, which cannot be used to calculate the number of
-# # groups.
-# # In both these cases, using a sub-query to count groups resolves the issue.
-# is_group = c.to_sql.downcase.include?(" group by ")
-# if is_group
-#   sm = Arel::SelectManager.new c.engine
-#   select_value = "count(*) as count"
-#   counting_subquery = sm.project(select_value).from(c.arel.as("subquery_for_count"))
-#   connection.select_one(counting_subquery)['count']
-# else
-#   # # .group returns an OrderedHash that responds to #count
-#   # c = c.count(*args)
-#   # if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-#   #   c.count
-#   # else
-#     c.respond_to?(:count) ? c.count(*args) : c
-#   end
-# # end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -25,7 +25,7 @@ module Kaminari
         args << options if ActiveRecord::VERSION::STRING < '4.1.0'
 
         # If group_by is used alongside column aliases, 'count' will destroy the select part of the
-        # query to construct the count. This will cause an exception
+        # query to construct the count. This will cause an exception.
         # Some group_by counts return hashes, which cannot be used to calculate the number of
         # groups.
         # In both these cases, using a sub-query to count groups resolves the issue.

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -29,7 +29,8 @@ module Kaminari
         # Some group_by counts return hashes, which cannot be used to calculate the number of
         # groups.
         # In both these cases, using a sub-query to count groups resolves the issue.
-        is_group = c.to_sql.downcase.include?(" group by ")
+        sql = c.to_sql.downcase
+        is_group = sql =~ /\s(group\sby|having)\s/
         if is_group
           if ActiveRecord::VERSION::STRING >= '3.1'
             sm = Arel::SelectManager.new c.engine

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -70,7 +70,6 @@ if defined? ActiveRecord
           @books.each {|book| book.readers << @readers[0..1] }
 
           readerships = Readership.select('user_id, count(user_id) as read_count, book_id').group('user_id, book_id')
-          readerships.count.count.should_not == readerships.page(1).total_count
           readerships.page(1).total_count.should == 8
         end
 
@@ -78,7 +77,6 @@ if defined? ActiveRecord
           @books.each {|book| book.readers << @readers[0..1] }
 
           readerships = Readership.select('user_id, count(user_id), book_id').group('user_id, book_id')
-          readerships.count.count.should_not == readerships.page(1).total_count
           readerships.page(1).total_count.should == 8
         end
       end


### PR DESCRIPTION
ActiveRecord behaves problematically when an attempt is made to 'count' grouped queries. A hash is returned which doesn't contain the length of the returned set of groups, and an exception is thrown if the group clause uses any column aliases.

This is outlined in issue #572

This fix adds specs to highlight the issues and patches the total count functionality used for ActiveRecord. The fix has been tested against Travis for all supported AR versions.

Unfortunately, the desired fix (using Arel) isn't compatible with AR 3.0, so the code falls back to string interpolation in this case. I understand from reading other support tickets that the project collaborators are opposed to string interpolation. I'm happy to start a discussion on how to avoid it.
