### PR TITLE
Clear paginatable array if initialised with limit <= 0

### DIFF
--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -25,6 +25,10 @@ module Kaminari
         original_array = original_array[@_offset_value, @_limit_value]
       end
 
+      if @_limit_value <= 0
+        original_array.clear
+      end
+
       super(original_array || [])
     end
 

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,7 +3,7 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if (n = num.to_i) <= 0
+      if (n = num.to_i) <= 0 || limit_value <= 0
         self
       elsif max_per_page && max_per_page < n
         limit(max_per_page).offset(offset_value / limit_value * max_per_page)
@@ -23,6 +23,7 @@ module Kaminari
       count_without_padding -= @_padding if defined?(@_padding) && @_padding
       count_without_padding = 0 if count_without_padding < 0
 
+      return 1 if limit_value <= 0
       total_pages_count = (count_without_padding.to_f / limit_value).ceil
       if max_pages.present? && max_pages < total_pages_count
         max_pages
@@ -39,6 +40,7 @@ module Kaminari
       offset_without_padding -= @_padding if defined?(@_padding) && @_padding
       offset_without_padding = 0 if offset_without_padding < 0
 
+      return 1 if limit_value <= 0
       (offset_without_padding / limit_value) + 1
     end
 

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -8,9 +8,11 @@ describe Kaminari::PaginatableArray do
     its(:current_page) { should == 3 }
   end
 
-  context 'specifying limit of zero when initializing' do
+  context 'specifying limit of zero returns an empty array' do
     subject { Kaminari::PaginatableArray.new((1..100).to_a, :limit => 0, :offset => 0) }
     its(:current_page) { should == 1 }
+    its(:total_pages) { should == 1 }
+    its(:length) { should == 0 }
   end
 
   let(:array) { Kaminari::PaginatableArray.new((1..100).to_a) }

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -8,6 +8,11 @@ describe Kaminari::PaginatableArray do
     its(:current_page) { should == 3 }
   end
 
+  context 'specifying limit of zero when initializing' do
+    subject { Kaminari::PaginatableArray.new((1..100).to_a, :limit => 0, :offset => 0) }
+    its(:current_page) { should == 1 }
+  end
+
   let(:array) { Kaminari::PaginatableArray.new((1..100).to_a) }
   describe '#page' do
     shared_examples_for 'the first page of array' do


### PR DESCRIPTION
Previously, if you do that, calls to`#per`, `#total_pages` and `#current_page` blowed up with:

```
ZeroDivisionError: divided by 0
```

I had such an error in the template of a legacy application, which initialised a fallback paginatable array with zero limit, offset, etc. The zero devision error got thrown out in the view and tracking it down was quite troublesome.

The current solution tries to emulate the databases, which returns a null set when `LIMIT 0` is given. This leads to some tricky semantics about how much pages should we have, etc, so I just return 1 in `#total_pages` and `#current_page`.

I'm also fine with raising an early exception while initialising the paginatable array.
