### PR TITLE
Enable lazy evaluation of `paginate`'s options

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,7 +15,12 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
-      paginator = Kaminari::Helpers::Paginator.new self, options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :remote => false)
+      options[:current_page] ||= scope.current_page
+      options[:total_pages]  ||= scope.total_pages
+      options[:per_page]     ||= scope.limit_value
+      options[:remote]       ||= false
+
+      paginator = Kaminari::Helpers::Paginator.new self, options
       paginator.to_s
     end
 


### PR DESCRIPTION
Fixes https://github.com/amatsuda/kaminari/issues/545

By lazy evaluating the expression for defaults, and allows to skip the call to the `scope` methods. I was referring to the https://github.com/amatsuda/kaminari/issues/545#issuecomment-40663427 for this fix. 
