### PR TITLE
MongoidCriteriaMethods#total_count uses :size instead of :count

### DIFF
--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -19,12 +19,12 @@ module Kaminari
 
     def total_count #:nodoc:
       @total_count ||= if embedded?
-        unpage.count
+        unpage.size
       else
-        if options[:max_scan] && options[:max_scan] < count
+        if options[:max_scan] && options[:max_scan] < size
           options[:max_scan]
         else
-          count
+          size
         end
       end
     end


### PR DESCRIPTION
Mongoid's `count` method always hits the database for the same queries, but `size` and `length` methods will not hit the database. It is useful when `query.size` is also called in application.

`Criteria#count`
Get a count of persisted documents. Note this will always hit the database for the count.

`Criteria#length`
Also `size`. Get a count of persisted documents. After being called once for the criteria, will cache subsequent calls and not hit the database.
