### PR TITLE
Fixes for out of range next/prev links and tags

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -15,6 +15,8 @@ module Kaminari
     # * <tt>:remote</tt> - Ajax? (false by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
+      return nil if scope.out_of_range?
+
       options[:total_pages] ||= scope.total_pages
 
       paginator = Kaminari::Helpers::Paginator.new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :remote => false))
@@ -41,7 +43,7 @@ module Kaminari
     def link_to_previous_page(scope, name, options = {}, &block)
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
-      link_to_unless scope.first_page? || (scope.current_page - 1 > scope.total_pages), name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
+      link_to_unless scope.first_page? || scope.out_of_range?, name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
         block.call if block
       end
     end
@@ -124,7 +126,7 @@ module Kaminari
 
       output = ""
       output << tag(:link, :rel => "next", :href => next_page.url) unless scope.last_page?  || scope.out_of_range?
-      output << tag(:link, :rel => "prev", :href => prev_page.url) unless scope.first_page? || (scope.current_page - 1 > scope.total_pages)
+      output << tag(:link, :rel => "prev", :href => prev_page.url) unless scope.first_page? || scope.out_of_range?
       output.html_safe
     end
   end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -41,7 +41,7 @@ module Kaminari
     def link_to_previous_page(scope, name, options = {}, &block)
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
-      link_to_unless scope.first_page?, name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
+      link_to_unless scope.first_page? || (scope.current_page - 1 > scope.total_pages), name, prev_page.url, options.except(:params, :param_name).reverse_merge(:rel => 'prev') do
         block.call if block
       end
     end
@@ -123,8 +123,8 @@ module Kaminari
       prev_page = Kaminari::Helpers::PrevPage.new self, options.reverse_merge(:current_page => scope.current_page)
 
       output = ""
-      output << tag(:link, :rel => "next", :href => next_page.url) if scope.next_page
-      output << tag(:link, :rel => "prev", :href => prev_page.url) if scope.prev_page
+      output << tag(:link, :rel => "next", :href => next_page.url) unless scope.last_page?  || scope.out_of_range?
+      output << tag(:link, :rel => "prev", :href => prev_page.url) unless scope.first_page? || (scope.current_page - 1 > scope.total_pages)
       output.html_safe
     end
   end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -28,6 +28,14 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       subject { helper.paginate @users, :views_prefix => "alternative/", :params => {:controller => 'users', :action => 'index'} }
       it { should eq("  <b>1</b>\n") }
     end
+
+    context 'out of range' do
+      before do
+        @users = User.page(1000)
+      end
+      subject { helper.paginate @users, :params => {:controller => 'users', :action => 'index', :page => 1000} }
+      it { should_not be }
+    end
   end
 
   describe '#link_to_previous_page' do
@@ -68,16 +76,6 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} }
       it { should_not be }
-    end
-
-    context 'page after last page' do
-      before do
-        @users = User.page(61).per(1)
-      end
-
-      subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index', :page => 61} }
-      it { should match(/page=60/) }
-      it { should match(/rel="prev"/) }
     end
 
     context 'out of range page' do
@@ -334,13 +332,6 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       it { should match(/rel="prev"/) }
       it { should match(/\?page=3"/) }
-      it { should_not match(/rel="next"/) }
-    end
-
-    context 'page after last page' do
-      let(:users) { User.page(32).per(1) }
-
-      it { should match(/rel="prev"/) } # On the 32nd page, we still have prev page of 31.
       it { should_not match(/rel="next"/) }
     end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -69,6 +69,25 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index'} }
       it { should_not be }
     end
+
+    context 'page after last page' do
+      before do
+        @users = User.page(61).per(1)
+      end
+
+      subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index', :page => 61} }
+      it { should match(/page=60/) }
+      it { should match(/rel="prev"/) }
+    end
+
+    context 'out of range page' do
+      before do
+        @users = User.page(1000)
+      end
+
+      subject { helper.link_to_previous_page @users, 'Previous', :params => {:controller => 'users', :action => 'index', :page => 1000} }
+      it { should_not be }
+    end
   end
 
   describe '#link_to_next_page' do
@@ -108,6 +127,15 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       end
 
       subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index'} }
+      it { should_not be }
+    end
+
+    context 'out of range page' do
+      before do
+        @users = User.page(1000)
+      end
+
+      subject { helper.link_to_next_page @users, 'More', :params => {:controller => 'users', :action => 'index', :page => 1000} }
       it { should_not be }
     end
   end
@@ -306,6 +334,20 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       it { should match(/rel="prev"/) }
       it { should match(/\?page=3"/) }
+      it { should_not match(/rel="next"/) }
+    end
+
+    context 'page after last page' do
+      let(:users) { User.page(32).per(1) }
+
+      it { should match(/rel="prev"/) } # On the 32nd page, we still have prev page of 31.
+      it { should_not match(/rel="next"/) }
+    end
+
+    context 'out of range page' do
+      let(:users) { User.page(1000).per(1) }
+
+      it { should_not match(/rel="prev"/) }
       it { should_not match(/rel="next"/) }
     end
   end


### PR DESCRIPTION
Add additional checks to not generate paginator, next and prev links, or rel next/prev tags if the current page out of range (greater than last page).

Added specs for all changes (paginator, next and prev links, rel next/prev tags).

We were seeing that on a particular page, we might only have 3 pages, but for some reason GoogleBot was coming along and indexing /page/100, /page/101, etc.  This might seem harmless at first, but what ends up happening is that when the page number is out of range, then GoogleBot gets stuck infinitely traversing the next links.

This bug fix should stop crawlers from infinitely crawling your website when the page is out of range.
