### PR TITLE
Fix wrong code in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,7 +65,7 @@ Then bundle:
 
   Keep in mind that +per+ utilizes internally +limit+ and so it will override any +limit+ that was set previously
     User.count                  # => 1000
-    a = User.limit(5).count     # => 5
+    a = User.limit(5); a.count  # => 5
     b = a.page(1).per(20).size  # => 20
 
 * the +padding+ scope


### PR DESCRIPTION
You were setting `a` to a `Fixnum` instead of an ActiveRecord Relation:

``` ruby
b = a.page(1).per(20).size
NoMethodError: undefined method `page' for 5:Fixnum
```
