### PR TITLE
Fix #281

### DIFF
--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -11,7 +11,7 @@ module Kaminari
       #   Model.page(5)
       eval <<-RUBY
         def self.#{Kaminari.config.page_method_name}(num = nil)
-          limit(default_per_page).offset(default_per_page * ([num.try(:to_i) || 0, 1].max - 1)).extending do
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -11,7 +11,7 @@ module Kaminari
       #   Model.page(5)
       eval <<-RUBY
         def self.#{Kaminari.config.page_method_name}(num = nil)
-          limit(default_per_page).offset(default_per_page * ([num.try(:to_i).to_i, 1].max - 1)).extending do
+          limit(default_per_page).offset(default_per_page * ([num.try(:to_i) || 0, 1].max - 1)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -11,7 +11,7 @@ module Kaminari
       #   Model.page(5)
       eval <<-RUBY
         def self.#{Kaminari.config.page_method_name}(num = nil)
-          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1)).extending do
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0), 1].max - 1)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -11,7 +11,7 @@ module Kaminari
       #   Model.page(5)
       eval <<-RUBY
         def self.#{Kaminari.config.page_method_name}(num = nil)
-          limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1)).extending do
+          limit(default_per_page).offset(default_per_page * ([num.try(:to_i).to_i, 1].max - 1)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -35,7 +35,7 @@ module Kaminari
     # items at the specified "page"
     class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def #{Kaminari.config.page_method_name}(num = 1)
-        offset(limit_value * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
+        offset(limit_value * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0), 1].max - 1))
       end
     RUBY
 

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -35,7 +35,7 @@ module Kaminari
     # items at the specified "page"
     class_eval <<-RUBY, __FILE__, __LINE__ + 1
       def #{Kaminari.config.page_method_name}(num = 1)
-        offset(limit_value * ([num.to_i, 1].max - 1))
+        offset(limit_value * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
       end
     RUBY
 

--- a/lib/kaminari/models/data_mapper_extension.rb
+++ b/lib/kaminari/models/data_mapper_extension.rb
@@ -7,7 +7,7 @@ module Kaminari
         def #{Kaminari.config.page_method_name}(num = 1)
           model = self
           model = self.model if self.is_a? DataMapper::Collection
-          num = [(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1
+          num = [(num.class.public_method_defined?(:to_i) ? num.to_i : 0), 1].max - 1
           all(:limit => model.default_per_page, :offset => model.default_per_page * num).extend Paginating
         end
       RUBY

--- a/lib/kaminari/models/data_mapper_extension.rb
+++ b/lib/kaminari/models/data_mapper_extension.rb
@@ -7,7 +7,7 @@ module Kaminari
         def #{Kaminari.config.page_method_name}(num = 1)
           model = self
           model = self.model if self.is_a? DataMapper::Collection
-          num = [num.to_i, 1].max - 1
+          num = [(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1
           all(:limit => model.default_per_page, :offset => model.default_per_page * num).extend Paginating
         end
       RUBY

--- a/lib/kaminari/models/mongo_mapper_extension.rb
+++ b/lib/kaminari/models/mongo_mapper_extension.rb
@@ -10,7 +10,7 @@ module Kaminari
         # Fetch the values at the specified page number
         #   Model.page(5)
         scope Kaminari.config.page_method_name, Proc.new {|num|
-          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0), 1].max - 1))
         }
       end
     end

--- a/lib/kaminari/models/mongo_mapper_extension.rb
+++ b/lib/kaminari/models/mongo_mapper_extension.rb
@@ -10,7 +10,7 @@ module Kaminari
         # Fetch the values at the specified page number
         #   Model.page(5)
         scope Kaminari.config.page_method_name, Proc.new {|num|
-          limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
         }
       end
     end

--- a/lib/kaminari/models/mongoid_extension.rb
+++ b/lib/kaminari/models/mongoid_extension.rb
@@ -10,7 +10,7 @@ module Kaminari
         # Fetch the values at the specified page number
         #   Model.page(5)
         scope Kaminari.config.page_method_name, Proc.new {|num|
-          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0), 1].max - 1))
         } do
           include Kaminari::MongoidCriteriaMethods
           include Kaminari::PageScopeMethods

--- a/lib/kaminari/models/mongoid_extension.rb
+++ b/lib/kaminari/models/mongoid_extension.rb
@@ -10,7 +10,7 @@ module Kaminari
         # Fetch the values at the specified page number
         #   Model.page(5)
         scope Kaminari.config.page_method_name, Proc.new {|num|
-          limit(default_per_page).offset(default_per_page * ([num.to_i, 1].max - 1))
+          limit(default_per_page).offset(default_per_page * ([(num.class.public_method_defined?(:to_i) ? num.to_i : 0)].max - 1))
         } do
           include Kaminari::MongoidCriteriaMethods
           include Kaminari::PageScopeMethods


### PR DESCRIPTION
(From the readme:)

> Typically, your controller code will look like this:
> `@users = User.order(:name).page params[:page]`

When someone uses `?page[]=` in the url, rails will convert `params[:page]` to an Array, which does not have `to_i`.

This PR will try to use `to_i` (if possible) or default to 0.

For more info + previous discussion refer to #281.
