### PR TITLE
Use internationalization in ActiveRecord and pluralize for others

### DIFF
--- a/config/locales/kaminari.yml
+++ b/config/locales/kaminari.yml
@@ -10,6 +10,10 @@ en:
       truncate: "&hellip;"
   helpers:
     page_entries_info:
+      entry:
+        zero: "entries"
+        one: "entry"
+        other: "entries"
       one_page:
         display_entries:
           zero: "No %{entry_name} found"

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,8 +88,12 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = options.delete(:entry_name)
+      entry_name = if entry_name
+                     collection.length == 1 ? entry_name : entry_name.pluralize
+                   else
+                     collection.entry_name
+                   end
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -90,9 +90,9 @@ module Kaminari
     def page_entries_info(collection, options = {})
       entry_name = options.delete(:entry_name)
       entry_name = if entry_name
-                     collection.length == 1 ? entry_name : entry_name.pluralize
+                     collection.size == 1 ? entry_name : entry_name.pluralize
                    else
-                     collection.entry_name
+                     collection.entry_name.downcase
                    end
 
       if collection.total_pages < 2

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -92,7 +92,7 @@ module Kaminari
       entry_name = if entry_name
                      collection.size == 1 ? entry_name : entry_name.pluralize
                    else
-                     collection.entry_name.downcase
+                     collection.entry_name(:count => collection.total_count).downcase
                    end
 
       if collection.total_pages < 2

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,7 +88,7 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options.delete(:entry_name)
+      entry_name = options[:entry_name]
       entry_name = if entry_name
                      collection.size == 1 ? entry_name : entry_name.pluralize
                    else

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -9,7 +9,7 @@ module Kaminari
     end
 
     def entry_name(options = {})
-      count = options.fetch(:count, 1)
+      count = options[:count] || 1
       default = if ActiveRecord::VERSION::STRING >= '3.2.0'
                   model_name.human.pluralize(count)
                 else

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,6 +1,7 @@
 module Kaminari
   module ActiveRecordRelationMethods
-    def entry_name
+    def entry_name(options = {})
+      count = options[:count] || 1
       default = count == 1 ? model_name.human : model_name.human.pluralize
       model_name.human(:count => count, :default => default)
     end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,7 +1,8 @@
 module Kaminari
   module ActiveRecordRelationMethods
     def entry_name
-      model_name.human.downcase
+      default = count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+      model_name.human(:count => count, :default => default).downcase
     end
 
     def reset #:nodoc:

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,8 +1,8 @@
 module Kaminari
   module ActiveRecordRelationMethods
     def entry_name
-      default = count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
-      model_name.human(:count => count, :default => default).downcase
+      default = count == 1 ? model_name.human : model_name.human.pluralize
+      model_name.human(:count => count, :default => default)
     end
 
     def reset #:nodoc:

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -9,8 +9,8 @@ module Kaminari
     end
 
     def entry_name
-      default = count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
-      model_name.human(:count => count, :default => default).downcase
+      default = count == 1 ? model_name.human : model_name.human.pluralize
+      model_name.human(:count => count, :default => default)
     end
 
     def reset #:nodoc:

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -8,8 +8,13 @@ module Kaminari
       end
     end
 
-    def entry_name
-      default = count == 1 ? model_name.human : model_name.human.pluralize
+    def entry_name(options = {})
+      count = options.fetch(:count, 1)
+      default = if ActiveRecord::VERSION::STRING >= '3.2.0'
+                  model_name.human.pluralize(count)
+                else
+                  count == 1 ? model_name.human : model_name.human.pluralize
+                end
       model_name.human(:count => count, :default => default)
     end
 

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -9,7 +9,8 @@ module Kaminari
     end
 
     def entry_name
-      model_name.human.downcase
+      default = count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+      model_name.human(:count => count, :default => default).downcase
     end
 
     def reset #:nodoc:

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -29,7 +29,7 @@ module Kaminari
     end
 
     def entry_name
-      "entry"
+      I18n.t('helpers.page_entries_info.entry', :count => length)
     end
 
     # items at the specified "page"

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -29,8 +29,7 @@ module Kaminari
     end
 
     def entry_name(options = {})
-      count = options.fetch(:count, 1)
-      I18n.t('helpers.page_entries_info.entry', :count => count)
+      I18n.t('helpers.page_entries_info.entry', :count => (options[:count] || 1))
     end
 
     # items at the specified "page"

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -28,8 +28,9 @@ module Kaminari
       super(original_array || [])
     end
 
-    def entry_name
-      I18n.t('helpers.page_entries_info.entry', :count => length)
+    def entry_name(options = {})
+      count = options.fetch(:count, 1)
+      I18n.t('helpers.page_entries_info.entry', :count => count)
     end
 
     # items at the specified "page"

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -1,7 +1,7 @@
 module Kaminari
   module DataMapperCollectionMethods
     def entry_name
-      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+      count == 1 ? model_name.human : model_name.human.pluralize
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -1,0 +1,19 @@
+module Kaminari
+  module DataMapperCollectionMethods
+    def entry_name
+      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+    end
+
+    def limit_value #:nodoc:
+      query.options[:limit] || 0
+    end
+
+    def offset_value #:nodoc:
+      query.options[:offset] || 0
+    end
+
+    def total_count #:nodoc:
+      model.count(query.options.except(:limit, :offset, :order))
+    end
+  end
+end

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -1,8 +1,8 @@
 module Kaminari
   module DataMapperCollectionMethods
     def entry_name(options = {})
-      count = options.fetch(:count, 1)
-      count == 1 ? model_name.human : model_name.human.pluralize
+      count = options[:count] || 1
+      count == 1 ? model.model_name.human : model.model_name.human.pluralize
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -1,7 +1,7 @@
 module Kaminari
   module DataMapperCollectionMethods
     def entry_name
-      model.model_name.human.downcase
+      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/data_mapper_collection_methods.rb
+++ b/lib/kaminari/models/data_mapper_collection_methods.rb
@@ -1,6 +1,7 @@
 module Kaminari
   module DataMapperCollectionMethods
-    def entry_name
+    def entry_name(options = {})
+      count = options.fetch(:count, 1)
       count == 1 ? model_name.human : model_name.human.pluralize
     end
 

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -5,7 +5,8 @@ module Kaminari
       super
     end
 
-    def entry_name
+    def entry_name(options = {})
+      count = options.fetch(:count, 1)
       count == 1 ? model_name.human : model_name.human.pluralize
     end
 

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -6,8 +6,8 @@ module Kaminari
     end
 
     def entry_name(options = {})
-      count = options.fetch(:count, 1)
-      count == 1 ? model_name.human : model_name.human.pluralize
+      count == options[:count] || 1
+      count == 1 ? model.model_name.human : model.model_name.human.pluralize
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -6,7 +6,7 @@ module Kaminari
     end
 
     def entry_name
-      model_name.human.downcase
+      model_name.human.pluralize(count).downcase
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -6,7 +6,7 @@ module Kaminari
     end
 
     def entry_name
-      model_name.human.pluralize(count).downcase
+      count == 1 ? model_name.human : model_name.human.pluralize
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -7,7 +7,7 @@ module Kaminari
 
     def entry_name(options = {})
       count == options[:count] || 1
-      count == 1 ? model.model_name.human : model.model_name.human.pluralize
+      count == 1 ? model_name.human : model_name.human.pluralize
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -5,7 +5,7 @@ module Kaminari
     delegate :default_per_page, :max_per_page, :max_pages, :to => :model
 
     def entry_name(options = {})
-      count = options.fetch(:count, 1)
+      count = options[:count] || 1
       count == 1 ? model_name.human : model_name.human.pluralize
     end
 

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -4,7 +4,8 @@ module Kaminari
 
     delegate :default_per_page, :max_per_page, :max_pages, :to => :model
 
-    def entry_name
+    def entry_name(options = {})
+      count = options.fetch(:count, 1)
       count == 1 ? model_name.human : model_name.human.pluralize
     end
 

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -1,0 +1,23 @@
+module Kaminari
+  module PluckyCriteriaMethods
+    include Kaminari::PageScopeMethods
+
+    delegate :default_per_page, :max_per_page, :max_pages, :to => :model
+
+    def entry_name
+      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+    end
+
+    def limit_value #:nodoc:
+      options[:limit]
+    end
+
+    def offset_value #:nodoc:
+      options[:skip]
+    end
+
+    def total_count #:nodoc:
+      count
+    end
+  end
+end

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -5,7 +5,7 @@ module Kaminari
     delegate :default_per_page, :max_per_page, :max_pages, :to => :model
 
     def entry_name
-      model.model_name.human.downcase
+      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
     end
 
     def limit_value #:nodoc:

--- a/lib/kaminari/models/plucky_criteria_methods.rb
+++ b/lib/kaminari/models/plucky_criteria_methods.rb
@@ -5,7 +5,7 @@ module Kaminari
     delegate :default_per_page, :max_per_page, :max_pages, :to => :model
 
     def entry_name
-      count == 1 ? model_name.human.downcase : model_name.human.pluralize.downcase
+      count == 1 ? model_name.human : model_name.human.pluralize
     end
 
     def limit_value #:nodoc:


### PR DESCRIPTION
This PR is a more up to date version of https://github.com/amatsuda/kaminari/pull/309
Also, it adds support for internationalization of `entry_name` for ActiveRecord. I tried to implement it for DataMapper but failed, maybe someone else with more experience with DM can have a look?

This PR solves the issues I described in https://github.com/amatsuda/kaminari/pull/309 where only using `.pluralize` won't work for other languages than English. Instead we should make use of the I18n features.

Any thoughts about this?
