### PR TITLE
Use class method '.themes' in ViewGenerator#copy_or_fetch

### DIFF
--- a/lib/generators/kaminari/views_generator.rb
+++ b/lib/generators/kaminari/views_generator.rb
@@ -29,7 +29,7 @@ BANNER
             say %Q[template_engine: #{template_engine} is not available for theme: #{file_name}]
           end
         else
-          say %Q[no such theme: #{file_name}\n  avaliable themes: #{themes.map(&:name).join ", "}]
+          say %Q[no such theme: #{file_name}\n  avaliable themes: #{self.class.themes.map(&:name).join ", "}]
         end
       end
 


### PR DESCRIPTION
Just a small fix for the case when theme is not found:

```
❯ rails generate kaminari:views bootstrap                                                                                                                                                     
/Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/kaminari-b206d8992237/lib/generators/kaminari/views_generator.rb:32:in `copy_or_fetch': undefined local variable or method `themes' for #<Kaminari::Generators::ViewsGenerator:0x007fdd5f1f2518> (NameError)
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/generators.rb:157:in `invoke'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/commands/generate.rb:11:in `<top (required)>'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:247:in `require'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:247:in `block in require'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:232:in `load_dependency'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:247:in `require'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/commands/commands_tasks.rb:135:in `generate_or_destroy'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/commands/commands_tasks.rb:51:in `generate'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
        from /Users/max/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/commands.rb:17:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```
