### PR TITLE
adds html option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -162,7 +162,12 @@ Run the following generator command, then edit the generated file.
 * Ajax links (crazy simple, but works perfectly!)
 
     <%= paginate @users, :remote => true %>
-  This would add <tt>data-remote="true"</tt> to all the links inside.
+  This would add <tt>data-remote="true"</tt> to all the links inside. It's a shortcut for <tt>:html => {:remote => true}<tt>.
+
+* Custom link html attributes
+
+    <%= paginate @users, :html => {:data => {:push => true}} %>
+  This would add <tt>data-push="true"</tt> to all the links inside.
 
 * specifying an alternative views directory (default is <tt>kaminari/</tt>)
 

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -4,8 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
+    html:          options passed to the link_to helper
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, (html||={}) %>
 </span>

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -4,6 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
+-#    html:          options passed to the link_to helper
 %span.first
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote
+  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, html||={}

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -4,7 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
+    html        : options passed to the link_to helper
 span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote
+  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, html||={}
 '

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -3,6 +3,5 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
 -%>
 <span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -3,6 +3,5 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
 %span.page.gap
   = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -3,7 +3,6 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
 span.page.gap
   == t('views.pagination.truncate').html_safe
 '

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -4,8 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
+    html:          options passed to the link_to helper
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, html||={} %>
 </span>

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -4,6 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
+-#    html:          options passed to the link_to helper
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
+  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, html||={}

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -4,7 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
+    html         : options passed to the link_to helper
 span.last
-	== link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
+	== link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, html||={}
 '

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -4,8 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
+    html:          options passed to the link_to helper
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, (html||={}).merge(:rel => 'next') %>
 </span>

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -4,6 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
+-#    html:          options passed to the link_to helper
 %span.next
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, (html||={}).merge(:rel => 'next')

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,10 +1,10 @@
 / Link to the "Next" page
-	- available local variables
+  - available local variables
     url          : url to the next page
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
+    html         : options passed to the link_to helper
 span.next
-  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote
+  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, (html||={}).merge(:rel => 'next')
 '

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -5,8 +5,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
+    html:          options passed to the link_to helper
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to_unless page.current?, page, url, (html||={}).merge(:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil) %>
 </span>

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -5,6 +5,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
+-#    html:          options passed to the link_to helper
 %span{:class => "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to_unless page.current?, page, url, (html||={}).merge(:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil)

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -5,7 +5,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
+    html         : options passed to the link_to helper
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  == link_to_unless page.current?, page, url, (html||={}).merge(:rel => page.next? ? 'next' : page.prev? ? 'prev' : nil)
 '

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -3,8 +3,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
+    html:          options passed to the link_to helper
 -%>
 <%= paginator.render do -%>
   <nav class="pagination">

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -3,8 +3,8 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
 -#    paginator:     the paginator that renders the pagination tags inside
+-#    html:          options passed to the link_to helper
 = paginator.render do
   %nav.pagination
     = first_page_tag unless current_page.first?

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -3,9 +3,8 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
     paginator    : the paginator that renders the pagination tags inside
-
+    html         : options passed to the link_to helper
 == paginator.render do
   nav.pagination
     == first_page_tag unless current_page.first?

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -4,8 +4,8 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
+    html:          options passed to the link_to helper
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, (html||={}).merge(:rel => 'prev') %>
 </span>

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -4,6 +4,6 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
--#    remote:        data-remote
+-#    html:          options passed to the link_to helper
 %span.prev
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, (html||={}).merge(:rel => 'prev')

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -4,7 +4,7 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
-    remote       : data-remote
+    html         : options passed to the link_to helper
 span.prev
-  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote
+  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, (html||={}).merge(:rel => 'prev')
 '

--- a/gemfiles/sinatra_14.gemfile
+++ b/gemfiles/sinatra_14.gemfile
@@ -4,10 +4,11 @@ gem 'activerecord', '~> 3.2.0', :require => 'active_record'
 gem 'sinatra', '~> 1.4.0'
 gem 'rspec', '~> 2.14.1'
 
+# keep :require => false until https://github.com/haml/haml/issues/814 is fixed
 if RUBY_VERSION <= "1.8.7"
-  gem 'padrino-helpers', '~> 0.11.0'
+  gem 'padrino-helpers', '~> 0.11.0', :require => false
 else
-  gem 'padrino-helpers', '~> 0.12.0'
+  gem 'padrino-helpers', '~> 0.12.0', :require => false
 end
 
 gem 'rack-test', '>= 0'

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', ['>= 1.0']
   s.add_development_dependency 'database_cleaner', ['~> 1.2.0']
   s.add_development_dependency 'rdoc', ['>= 0']
+  s.add_development_dependency 'haml', ['>= 4']
+  s.add_development_dependency 'slim', ['>= 2']
 end

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -17,7 +17,7 @@ module Kaminari
     def paginate(scope, options = {}, &block)
       options[:total_pages] ||= options[:num_pages] || scope.total_pages
 
-      paginator = Kaminari::Helpers::Paginator.new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :remote => false))
+      paginator = Kaminari::Helpers::Paginator.new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :html => {:remote => options[:remote]}))
       paginator.to_s
     end
 

--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -81,6 +81,7 @@ module Kaminari::Helpers
       # * <tt>:right</tt> - The "right outer window" size (0 by default).
       # * <tt>:params</tt> - url_for parameters for the links (:id, :locale, etc.)
       # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
+      # * <tt>:html</tt> - custom link attributes, e.g data-push, class
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, options = {}, &block)
@@ -88,7 +89,7 @@ module Kaminari::Helpers
         current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
         paginator = Kaminari::Helpers::Paginator.new(
           ActionViewTemplateProxy.new(:current_params => current_params, :current_path => current_path, :param_name => options[:param_name] || Kaminari.config.param_name),
-          options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :remote => false)
+          options.reverse_merge(:current_page => scope.current_page, :total_pages => scope.total_pages, :per_page => scope.limit_value, :param_name => Kaminari.config.param_name, :html => {:remote => options[:remote]})
         )
         paginator.to_s
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ Bundler.require
 require 'capybara/rspec'
 require 'database_cleaner'
 
+require "slim"
+require "haml"
+
 # Simulate a gem providing a subclass of ActiveRecord::Base before the Railtie is loaded.
 require 'fake_gem' if defined? ActiveRecord
 

--- a/spec/spec_helper_for_sinatra.rb
+++ b/spec/spec_helper_for_sinatra.rb
@@ -6,6 +6,21 @@ require 'capybara/rspec'
 
 require 'fake_app/sinatra_app'
 
+# keep this until https://github.com/haml/haml/issues/814 is fixed
+module Haml::Helpers::XssMods
+  def self.included(base)
+    unless base.respond_to?(:html_escape_without_haml_xss)
+      %w[html_escape find_and_preserve preserve list_of surround
+         precede succeed capture_haml haml_concat haml_indent
+         haml_tag escape_once].each do |name|
+        base.send(:alias_method, "#{name}_without_haml_xss", name)
+        base.send(:alias_method, name, "#{name}_with_haml_xss")
+      end
+    end
+  end
+end
+require "haml/template"
+
 Capybara.app = SinatraApp
 
 module HelperMethodForHelperSpec
@@ -21,11 +36,34 @@ module HelperMethodForHelperSpec
   end
 end
 
+module RenderMethodForViewSpec
+  include HelperMethodForHelperSpec
+
+  def self.included(config)
+    config.after(:each) do
+      @rendered = ""
+    end
+  end
+
+  def view_template_proxy
+    @view_template_proxy ||= helper
+  end
+
+  def render args
+    @rendered = view_template_proxy.render args
+  end
+
+  def rendered
+    @rendered
+  end
+end
+
 RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.include Sinatra::TestHelpers
-  config.include HelperMethodForHelperSpec
-#   config.include HelperMethodForHelperSpec, :type => :helper
+  config.include HelperMethodForHelperSpec, :example_group => {:file_path => %r(spec/helpers)}
+  config.include RenderMethodForViewSpec, :example_group => {:file_path => %r(spec/views)}
+  config.include Capybara::RSpecMatchers, :example_group => {:file_path => %r(spec/views)}
 end
 
 require 'nokogiri'

--- a/spec/views/kaminari/_first_page.html_spec.rb
+++ b/spec/views/kaminari/_first_page.html_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe "first page partial" do
+
+  let(:page_number) { 2 }
+  let(:html) { {} }
+  let(:locals_hash) { {
+    :current_page => Kaminari::Helpers::Paginator::PageProxy.new(
+      {:current_page => 2, :total_pages => 3}, page_number, nil),
+    :html => html,
+    :url => "first"
+  } }
+
+  [:erb, :haml, :slim].each do |template_engine|
+    describe "(:#{template_engine})" do
+
+      context "when this page is the first page" do
+        let(:page_number) { 1 }
+        let(:html) { {:remote => true} }
+
+        it "renders the text without link" do
+          render :partial => "kaminari/first_page", :handlers => [template_engine], :locals => locals_hash
+          expect(rendered).to match(I18n.t('views.pagination.first'))
+          rendered.should_not have_link("First")
+        end
+      end
+
+      context "when this page is not the first page" do
+        let(:page_number) { 2 }
+
+        it "renders the link to the first page" do
+          render :partial => "kaminari/first_page", :handlers => [template_engine], :locals => locals_hash
+          rendered.should have_link("First", :href => "first")
+        end
+
+        context "with link_option remote=true" do
+          let(:html) { {:remote => true} }
+
+          it "contains data-remote" do
+            render :partial => "kaminari/first_page", :handlers => [template_engine], :locals => locals_hash
+            rendered.should have_xpath("//a[@data-remote='true']")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/views/kaminari/_last_page.html_spec.rb
+++ b/spec/views/kaminari/_last_page.html_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe "last page partial" do
+
+  let(:page_number) { 2 }
+  let(:html) { {} }
+  let(:locals_hash) { {
+    :current_page => Kaminari::Helpers::Paginator::PageProxy.new(
+      {:current_page => 2, :total_pages => 3}, page_number, nil),
+    :html => html,
+    :url => "last"
+  } }
+
+  [:erb, :haml, :slim].each do |template_engine|
+    describe "(:#{template_engine})" do
+
+      context "when this page is the last page" do
+        let(:page_number) { 3 }
+        let(:html) { {:remote => true} }
+
+        it "renders the text without link" do
+          render :partial => "kaminari/last_page", :handlers => [template_engine], :locals => locals_hash
+          expect(rendered).to match(I18n.t('views.pagination.last'))
+          rendered.should_not have_link("Last")
+        end
+      end
+
+      context "when this page is not the last page" do
+        let(:page_number) { 2 }
+
+        it "renders the link to the last page" do
+          render :partial => "kaminari/last_page", :handlers => [template_engine], :locals => locals_hash
+          rendered.should have_link("Last", :href => "last")
+        end
+
+        context "with link_option remote=true" do
+          let(:html) { {:remote => true} }
+
+          it "contains data-remote" do
+            render :partial => "kaminari/last_page", :handlers => [template_engine], :locals => locals_hash
+            rendered.should have_xpath("//a[@data-remote='true']")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/views/kaminari/_next_page.html_spec.rb
+++ b/spec/views/kaminari/_next_page.html_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe "next page partial" do
+
+  let(:page_number) { 2 }
+  let(:html) { {} }
+  let(:locals_hash) { {
+    :current_page => Kaminari::Helpers::Paginator::PageProxy.new(
+      {:current_page => 2, :total_pages => 3}, page_number, nil),
+    :html => html,
+    :url => "next"
+  } }
+
+  [:erb, :haml, :slim].each do |template_engine|
+    describe "(:#{template_engine})" do
+
+      context "when this page is the next page" do
+        let(:page_number) { 3 }
+        let(:html) { {:remote => true} }
+
+        it "renders the text without link" do
+          render :partial => "kaminari/next_page", :handlers => [template_engine], :locals => locals_hash
+          expect(rendered).to match(I18n.t('views.pagination.next'))
+          rendered.should_not have_link("Next")
+        end
+      end
+
+      context "when this page is not the next page" do
+        let(:page_number) { 2 }
+
+        it "renders the link to the next page" do
+          render :partial => "kaminari/next_page", :handlers => [template_engine], :locals => locals_hash
+          rendered.should have_link("Next", :href => "next")
+        end
+
+        context "with link_option remote=true" do
+          let(:html) { {:remote => true} }
+
+          it "contains data-remote" do
+            render :partial => "kaminari/next_page", :handlers => [template_engine], :locals => locals_hash
+            rendered.should have_xpath("//a[@data-remote='true']")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/views/kaminari/_page.html_spec.rb
+++ b/spec/views/kaminari/_page.html_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe "page partial" do
+
+  let(:page_number) { 2 }
+  let(:html) { {} }
+  let(:locals_hash) { {
+    :page => Kaminari::Helpers::Paginator::PageProxy.new(
+      {:current_page => 2, :total_pages => 3}, page_number, nil),
+    :html => html,
+    :url => "prev"
+  } }
+
+  [:erb, :haml, :slim].each do |template_engine|
+    describe "(:#{template_engine})" do
+
+      context "when this page is the current page" do
+        let(:page_number) { 2 }
+        let(:html) { {:remote => true} }
+
+        it "renders the text without link" do
+          render :partial => "kaminari/page", :handlers => [template_engine], :locals => locals_hash
+          expect(rendered).to match(/>\s*2\s*</)
+          rendered.should_not have_link("2")
+        end
+      end
+
+      context "when this page is not the current page" do
+        let(:page_number) { 3 }
+
+        it "renders the link to the given page" do
+          render :partial => "kaminari/page", :handlers => [template_engine], :locals => locals_hash
+          rendered.should have_link("3", :href => "prev")
+        end
+
+        context "with link_option remote=true" do
+          let(:html) { {:remote => true} }
+
+          it "contains data-remote" do
+            render :partial => "kaminari/page", :handlers => [template_engine], :locals => locals_hash
+            rendered.should have_xpath("//a[@data-remote='true']")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/views/kaminari/_prev_page.html_spec.rb
+++ b/spec/views/kaminari/_prev_page.html_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe "prev page partial" do
+
+  let(:page_number) { 2 }
+  let(:html) { {} }
+  let(:locals_hash) { {
+    :current_page => Kaminari::Helpers::Paginator::PageProxy.new(
+      {:current_page => 2, :total_pages => 3}, page_number, nil),
+    :html => html,
+    :url => "prev"
+  } }
+
+  [:erb, :haml, :slim].each do |template_engine|
+    describe "(:#{template_engine})" do
+
+      context "when this page is the prev page" do
+        let(:page_number) { 1 }
+        let(:html) { {:remote => true} }
+
+        it "renders the text without link" do
+          render :partial => "kaminari/prev_page", :handlers => [template_engine], :locals => locals_hash
+          expect(rendered).to match(I18n.t('views.pagination.previous'))
+          rendered.should_not have_link("Prev")
+        end
+      end
+
+      context "when this page is not the prev page" do
+        let(:page_number) { 2 }
+
+        it "renders the link to the prev page" do
+          render :partial => "kaminari/prev_page", :handlers => [template_engine], :locals => locals_hash
+          rendered.should have_link("Prev", :href => "prev")
+        end
+
+        context "with link_option remote=true" do
+          let(:html) { {:remote => true} }
+
+          it "contains data-remote" do
+            render :partial => "kaminari/prev_page", :handlers => [template_engine], :locals => locals_hash
+            rendered.should have_xpath("//a[@data-remote='true']")
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This pull requests implements https://github.com/amatsuda/kaminari/pull/417#issuecomment-39007349 and adds tests as requested by https://github.com/amatsuda/kaminari/pull/417#issuecomment-20948295:
- Add html option that will be passed to any link tags(following form_for's convension)

``` ruby
    paginate @users, html: {remote: true, class: 'ajax_index', data: {pjax: true} }
```

Are you sure you still want to deprecate the remote (Ajax) option?
