### PR TITLE
Specify path prefix for views generator

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -229,6 +229,13 @@ Kaminari includes a handy template generator.
 
     % rails g kaminari:views default -e haml
 
+* multiple templates
+
+  In case you need different templates for your paginator (for example public and admin), you can pass <tt>--views-prefix directory</tt> like this:
+    % rails g kaminari:views default --views-prefix admin
+
+  that will generate partials in <tt>app/views/admin/kaminari/</tt> directory.
+
 * themes
 
   The generator has the ability to fetch several sample template themes from

--- a/lib/generators/kaminari/views_generator.rb
+++ b/lib/generators/kaminari/views_generator.rb
@@ -5,6 +5,7 @@ module Kaminari
       source_root File.expand_path('../../../../app/views/kaminari', __FILE__)
 
       class_option :template_engine, :type => :string, :aliases => '-e', :desc => 'Template engine for the views. Available options are "erb", "haml", and "slim".'
+      class_option :views_prefix, :type => :string, :desc => 'Prefix for path to put views in.'
 
       def self.banner #:nodoc:
         <<-BANNER.chomp
@@ -47,15 +48,23 @@ BANNER
       def download_templates(theme)
         theme.templates_for(template_engine).each do |template|
           say "      downloading #{template.name} from kaminari_themes..."
-          create_file template.name, GitHubApiHelper.get_content_for("#{theme.name}/#{template.name}")
+          create_file view_path_for(template.name), GitHubApiHelper.get_content_for("#{theme.name}/#{template.name}")
         end
       end
 
       def copy_default_views
         filename_pattern = File.join self.class.source_root, "*.html.#{template_engine}"
         Dir.glob(filename_pattern).map {|f| File.basename f}.each do |f|
-          copy_file f, "app/views/kaminari/#{f}"
+          copy_file f, view_path_for(f)
         end
+      end
+
+      def view_path_for(file)
+        ['app', 'views', views_prefix, 'kaminari', File.basename(file)].compact.join('/')
+      end
+
+      def views_prefix
+        options[:views_prefix].try(:to_s)
       end
 
       def template_engine


### PR DESCRIPTION
I needed 2 different sets of templates for my projects (a custom one at a default path and a newly introduces bootstrap for admin). In order to achieve this I had to move existing templates to a temporary location, generate new ones, move them to the right location and then move back the original templates.

Since kaminari already supports `:views_prefix` option for rendering paginators, it also makes sense for the generators to support it in order to create templates at the right location.
