### PR TITLE
Rails 5 requires ruby 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2
+  - 2.2.1
   - ruby-head
   - jruby
   - jruby-head
@@ -37,7 +37,7 @@ matrix:
       gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.1
       gemfile: gemfiles/active_record_edge.gemfile
-    - rvm: 2.2
+    - rvm: 2.2.1
       gemfile: gemfiles/active_record_32.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/active_record_32.gemfile


### PR DESCRIPTION
Rails 5 now requires ruby 2.2.1. This PR should fix the failing rails edge tests.
