### PR TITLE
Pagination without having to SELECT COUNT(*).

### DIFF
--- a/app/views/kaminari/_paginator_without_count.html.erb
+++ b/app/views/kaminari/_paginator_without_count.html.erb
@@ -1,0 +1,14 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination">
+    <%= prev_page_tag unless current_page.first? %>
+    <%= next_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_paginator_without_count.html.haml
+++ b/app/views/kaminari/_paginator_without_count.html.haml
@@ -1,0 +1,11 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %nav.pagination
+    = prev_page_tag unless current_page.first?
+    = next_page_tag unless current_page.last?

--- a/app/views/kaminari/_paginator_without_count.html.slim
+++ b/app/views/kaminari/_paginator_without_count.html.slim
@@ -1,0 +1,12 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == prev_page_tag unless current_page.first?
+    == next_page_tag unless current_page.last?

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -21,6 +21,14 @@ module Kaminari
       paginator.to_s
     end
 
+    def paginate_without_count(scope, options = {}, &block)
+      options[:total_pages] = scope.current_page
+      options[:total_pages] += 1 if scope.length == scope.limit_value
+
+      paginator = Kaminari::Helpers::PaginatorWithoutCount.new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :remote => false))
+      paginator.to_s
+    end
+
     # A simple "Twitter like" pagination link that creates a link to the previous page.
     #
     # ==== Examples

--- a/lib/kaminari/helpers/paginator_without_count.rb
+++ b/lib/kaminari/helpers/paginator_without_count.rb
@@ -1,0 +1,6 @@
+module Kaminari
+  module Helpers
+    class PaginatorWithoutCount < Paginator
+    end
+  end
+end


### PR DESCRIPTION
This PR is unfinished (no specs), I just wanted to test the waters as to whether you would want it.

This is a tweak I've had to use on several projects so that Kaminari doesn't do a COUNT due to slow Postgres COUNT issues, as also described: #240, #545. I cannot use indexes due to where conditions, or any other fancy ways to get the count as the tables are just too big, so this PR adds the ability to use `paginate_without_count` to paginate using `next` and `previous` links that never call COUNT.

Instead of COUNTing the dataset, we assume that if the current paged set is equal to the limit value, there is another page. We only expose `next` and `previous` links, since we have no way of knowing the number of pages.  We override the Pagination class simply so we can change the partial class. Making the partial class configurable internally would alleviate that override if that is cleaner.

The only issue is if your count is exactly divisible by the per page limit, we'll show an erroneous next link on the last page... but to me this is a small price to pay for being able to page without timing out due to PG's sequential COUNT scan.

Thoughts?
