### PR TITLE
fix #672

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.1
+  - 2.2.2
   - ruby-head
   - jruby
   - jruby-head
@@ -37,7 +37,7 @@ matrix:
       gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.1
       gemfile: gemfiles/active_record_edge.gemfile
-    - rvm: 2.2.1
+    - rvm: 2.2.2
       gemfile: gemfiles/active_record_32.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/active_record_32.gemfile

--- a/lib/kaminari/hooks.rb
+++ b/lib/kaminari/hooks.rb
@@ -1,5 +1,12 @@
 module Kaminari
   class Hooks
+    def self.before_init
+      ActiveSupport.on_load(:active_record) do
+        require 'kaminari/models/active_record_config_extension'
+        ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordConfigExtension
+      end
+    end
+
     def self.init
       ActiveSupport.on_load(:active_record) do
         require 'kaminari/models/active_record_extension'

--- a/lib/kaminari/models/active_record_config_extension.rb
+++ b/lib/kaminari/models/active_record_config_extension.rb
@@ -1,0 +1,22 @@
+require 'kaminari/models/active_record_model_extension'
+
+module Kaminari
+  module ActiveRecordConfigExtension
+    extend ActiveSupport::Concern
+    
+    module ClassMethods
+      # Future subclasses will pick up the model extension
+      def inherited(kls) #:nodoc:
+        super
+        kls.send(:include, Kaminari::ActiveRecordModelConfigExtension) if kls.superclass == ::ActiveRecord::Base
+      end
+    end
+
+    included do
+      # Existing subclasses pick up the model extension as well
+      self.descendants.each do |kls|
+        kls.send(:include, Kaminari::ActiveRecordModelConfigExtension) if kls.superclass == ::ActiveRecord::Base
+      end
+    end
+  end
+end

--- a/lib/kaminari/models/active_record_model_extension.rb
+++ b/lib/kaminari/models/active_record_model_extension.rb
@@ -1,6 +1,14 @@
 require 'kaminari/models/active_record_relation_methods'
 
 module Kaminari
+  module ActiveRecordModelConfigExtension
+    extend ActiveSupport::Concern
+
+    included do
+      self.send(:include, Kaminari::ConfigurationMethods)
+    end
+  end
+
   module ActiveRecordModelExtension
     extend ActiveSupport::Concern
 

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,7 +1,15 @@
 module Kaminari
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'kaminari' do |_app|
-      Kaminari::Hooks.init
+      if Rails.env.test?
+        ActiveSupport.on_load(:active_record) do
+          ::ActiveRecord::Base.send :include, Kaminari::ConfigurationMethods
+        end
+      end
+
+      config.after_initialize do
+        Kaminari::Hooks.init
+      end
     end
   end
 end

--- a/lib/kaminari/railtie.rb
+++ b/lib/kaminari/railtie.rb
@@ -1,12 +1,12 @@
 module Kaminari
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'kaminari' do |_app|
-      if Rails.env.test?
-        ActiveSupport.on_load(:active_record) do
-          ::ActiveRecord::Base.send :include, Kaminari::ConfigurationMethods
-        end
-      end
+      # load static non-evaluated extensions methods before they are called
+      # (devised to load the Rails testing environment correctly)
+      Kaminari::Hooks.before_init
 
+      # evaluate dynamic extensions after Rails initialization 
+      # to enable custom configuration for gem defined models
       config.after_initialize do
         Kaminari::Hooks.init
       end


### PR DESCRIPTION
Load the correct `page_method_name` for gem defined models (such as [Delayed::Job](https://github.com/collectiveidea/delayed_job_active_record/blob/master/lib/delayed/backend/active_record.rb)) when it is not the default.

This is due to Rails loading those classes before initialization, hence they would always load the page method with its default name instead of the custom one.

fixing issue #672 
