### PR TITLE
Switched build to use ruby 2.2.2 instead of 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.1
+  - 2.2.2
   - ruby-head
   - jruby
   - jruby-head
@@ -37,7 +37,7 @@ matrix:
       gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.1
       gemfile: gemfiles/active_record_edge.gemfile
-    - rvm: 2.2.1
+    - rvm: 2.2.2
       gemfile: gemfiles/active_record_32.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/active_record_32.gemfile


### PR DESCRIPTION
Fixes build error: 

```
Rails 5 requires Ruby 2.2.2 or newer.

You're running
  ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-linux]

Please upgrade to Ruby 2.2.2 or newer to continue.
```
