### PR TITLE
Add #total_count=

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -30,5 +30,9 @@ module Kaminari
         end
       end
     end
+
+    def total_count=(count)
+      @total_count = count
+    end
   end
 end

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -72,6 +72,15 @@ if defined? ActiveRecord
           }.should_not raise_exception
         end
       end
+
+      context "when total_count is set" do
+        it "should be set total_count" do
+          relation = User.page(1)
+          relation.total_count.should_not == 100
+          relation.total_count = 100
+          relation.total_count.should == 100
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I added a method to set `total_count` from external to ActiveRecordRelation.
It is because I want to cache the record counts if SQL is slow.

Please merge if there is no problem. :bow: 
