### PR TITLE
Internationalization of entry name

### DIFF
--- a/kaminari-actionview/lib/kaminari/actionview/action_view_extension.rb
+++ b/kaminari-actionview/lib/kaminari/actionview/action_view_extension.rb
@@ -90,8 +90,11 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = if options[:entry_name]
+                     options[:entry_name].pluralize(collection.size)
+                   else
+                     collection.entry_name(:count => collection.size).downcase
+                   end
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -1,7 +1,7 @@
 module Kaminari
   module ActiveRecordRelationMethods
-    def entry_name
-      model_name.human.downcase
+    def entry_name(options = {})
+      model_name.human(options.reverse_merge(:default => model_name.human.pluralize(options[:count])))
     end
 
     def reset #:nodoc:

--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -10,6 +10,10 @@ en:
       truncate: "&hellip;"
   helpers:
     page_entries_info:
+      entry:
+        zero: "entries"
+        one: "entry"
+        other: "entries"
       one_page:
         display_entries:
           zero: "No %{entry_name} found"

--- a/kaminari-core/lib/kaminari/models/array_extension.rb
+++ b/kaminari-core/lib/kaminari/models/array_extension.rb
@@ -4,6 +4,8 @@ module Kaminari
   class PaginatableArray < Array
     include Kaminari::ConfigurationMethods::ClassMethods
 
+    ENTRY = 'entry'.freeze
+
     attr_internal_accessor :limit_value, :offset_value
 
     # ==== Options
@@ -28,8 +30,8 @@ module Kaminari
       super(original_array || [])
     end
 
-    def entry_name
-      "entry"
+    def entry_name(options = {})
+      I18n.t('helpers.page_entries_info.entry', options.reverse_merge(:default => ENTRY.pluralize(options[:count])))
     end
 
     # items at the specified "page"

--- a/kaminari-core/spec/helpers/action_view_extension_spec.rb
+++ b/kaminari-core/spec/helpers/action_view_extension_spec.rb
@@ -233,6 +233,23 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(::Rails::Railtie) && d
         end
       end
     end
+
+    context 'I18n' do
+      before do
+        50.times {|i| User.create! :name => "user#{i}"}
+        @users = User.page(1).per(25)
+        I18n.backend.store_translations(:en, { User.i18n_scope => { models: { user: { one: "person", other: "people" } } } })
+      end
+
+      after do
+        I18n.backend.reload!
+      end
+
+      context 'page_entries_info translates entry' do
+        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+        it      { should == 'Displaying people <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+      end
+    end
     context 'on a model with namespace' do
       before do
         @addresses = User::Address.page(1).per(25)


### PR DESCRIPTION
This PR is a more up to date version of https://github.com/amatsuda/kaminari/pull/309
Also, it adds support for internationalization of `entry_name` for ActiveRecord. I tried to implement it for DataMapper but failed, maybe someone else with more experience with DM can have a look?

This PR solves the issues I described in https://github.com/amatsuda/kaminari/pull/309 where only using `.pluralize` won't work for other languages than English. Instead we should make use of the I18n features.

Any thoughts about this?

FIxes #586 
Closes #309 
