### PR TITLE
Fix for failing rbx test dependencies

### DIFF
--- a/gemfiles/active_record_32.gemfile
+++ b/gemfiles/active_record_32.gemfile
@@ -26,7 +26,7 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'rubysl-test-unit', github: 'rubysl/rubysl-test-unit', branch: '2.0'
   gem 'rubinius-developer_tools'
 end
 

--- a/gemfiles/active_record_40.gemfile
+++ b/gemfiles/active_record_40.gemfile
@@ -18,7 +18,7 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'rubysl-test-unit', github: 'rubysl/rubysl-test-unit', branch: '2.0'
   gem 'rubinius-developer_tools'
 end
 

--- a/gemfiles/mongoid_30.gemfile
+++ b/gemfiles/mongoid_30.gemfile
@@ -14,7 +14,7 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'rubysl-test-unit', github: 'rubysl/rubysl-test-unit', branch: '2.0'
   gem 'rubinius-developer_tools'
 end
 

--- a/gemfiles/mongoid_31.gemfile
+++ b/gemfiles/mongoid_31.gemfile
@@ -13,7 +13,7 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'rubysl-test-unit', github: 'rubysl/rubysl-test-unit', branch: '2.0'
   gem 'rubinius-developer_tools'
 end
 

--- a/gemfiles/sinatra_14.gemfile
+++ b/gemfiles/sinatra_14.gemfile
@@ -35,7 +35,7 @@ end
 platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'racc'
-  gem 'rubysl-test-unit'
+  gem 'rubysl-test-unit', github: 'rubysl/rubysl-test-unit', branch: '2.0'
   gem 'rubinius-developer_tools'
 end
 


### PR DESCRIPTION
There's a couple of failing tests because of the conflicting dependencies on `minitest` gem between `activerecord` and `rubysl-test-unit`.

Seems like this was already fixed in `rubysl-test-unit` (https://github.com/rubysl/rubysl-test-unit/commit/c0950b4e96545767ab0e2e542ac797f383268326), but was never released. Not to mention that gem looks pretty much dead and unmaintainable…

So temporary using github's version of the gem should fix the conflicts and hopefully lead to passing tests.
