### PR TITLE
Support unpaged method in activerecord relation

### DIFF
--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -28,14 +28,12 @@ module Kaminari
     def total_count(column_name = :all, options = {}) #:nodoc:
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
       @total_count ||= begin
-        c = unpaged
-
         # Rails 4.1 removes the `options` argument from AR::Relation#count
         args = [column_name]
         args << options if ActiveRecord::VERSION::STRING < '4.1.0'
 
         # .group returns an OrderdHash that responds to #count
-        c = c.count(*args)
+        c = unpaged.count(*args)
         if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
           c.count
         else

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -9,13 +9,26 @@ module Kaminari
       super
     end
 
+    # return the relation without any pagination
+    #
+    #
+    # Example:
+    #   user.books_authored.page(1).unpaged
+    # => return user's all books without pagination
+    #
+    def unpaged
+      _unpaged = except(:offset, :limit, :order)
+
+      # Remove includes only if they are irrelevant
+      _unpaged.except(:includes) unless references_eager_loaded_tables?
+
+      _unpaged
+    end
+
     def total_count(column_name = :all, options = {}) #:nodoc:
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
       @total_count ||= begin
-        c = except(:offset, :limit, :order)
-
-        # Remove includes only if they are irrelevant
-        c = c.except(:includes) unless references_eager_loaded_tables?
+        c = unpaged
 
         # Rails 4.1 removes the `options` argument from AR::Relation#count
         args = [column_name]

--- a/spec/models/active_record/active_record_relation_methods_spec.rb
+++ b/spec/models/active_record/active_record_relation_methods_spec.rb
@@ -73,5 +73,19 @@ if defined? ActiveRecord
         end
       end
     end
+
+    describe '#unpaged' do
+      it 'should return a relation' do
+        User.page.unpaged.should be_a(ActiveRecord::Relation)
+      end
+
+      it 'should include pagination related keys in the valuess of the relation using page' do
+        User.page.values.keys.should include(:offset, :limit)
+      end
+
+      it 'should not include any pagination related key in the values of the relation using unpaged' do
+        User.page.unpaged.values.keys.should_not include(:offset, :limit)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes we need to retrieve a subset of unpaged collection, and we need to calculate the counts of each subset, but unfortunately in some special situations, we can only access a collection paged. I think it is necessary to extract such a new method `#unpaged` and we can make codes more flexible and useful. The below shows an example in an grape based api service:

``` ruby
# api/users/1/books.rb
get :books do
  books = user.books.page(2)
  present books, with: ::Entities::Books     # `books` will be passed in the entity
end
```

``` ruby
# entities/books.rb
expose :total_count
expose :total_authored_count do |books, options|
  # in this entity, we can only access books[:entries] which references to the books variable in the above code
  books[:entries].unpaged.where(authored: true).count # calculate the user's total authored books without any pagination
end
```
