### PR TITLE
Added page_limit method on an individual request

### DIFF
--- a/gemfiles/active_record_32.gemfile
+++ b/gemfiles/active_record_32.gemfile
@@ -9,6 +9,7 @@ gem 'capybara', '< 2.1'
 gem 'nokogiri', '< 1.6'
 gem 'rubyzip', '< 1'
 gem 'mime-types', '< 2'
+gem 'test-unit' if RUBY_VERSION > "2.1.0"
 
 platforms :ruby do
   if RUBY_VERSION > "2.1.0"

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -30,5 +30,9 @@ module Kaminari
         end
       end
     end
+
+    def empty_instance
+      self.where('1 = 0')
+    end
   end
 end

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -29,10 +29,20 @@ module Kaminari
           c.respond_to?(:count) ? c.count(*args) : c
         end
       end
+
+      if @_max_num_pages.present? && @_max_num_pages < @total_count
+        self.count * @_max_num_pages
+      else
+        @total_count
+      end
     end
 
     def empty_instance
-      self.where('1 = 0')
+      if defined? self.model
+        self.model.none
+      else
+        self.where('1 = 0')
+      end
     end
   end
 end

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -11,7 +11,11 @@ module Kaminari
     # * <tt>:offset</tt> - offset
     # * <tt>:total_count</tt> - total_count
     def initialize(original_array = [], options = {})
-      @_original_array, @_limit_value, @_offset_value, @_total_count, @_padding = original_array, (options[:limit] || default_per_page).to_i, options[:offset].to_i, options[:total_count], options[:padding].to_i
+      @_original_array, @_limit_value, @_offset_value, @_total_count, @_padding, @_max_num_pages = original_array, (options[:limit] || default_per_page).to_i, options[:offset].to_i, options[:total_count], options[:padding].to_i, (options[:page_limit] || Kaminari.config.max_pages)
+
+      if @_max_num_pages.present?
+        original_array = original_array[0, @_limit_value * @_max_num_pages.to_i]
+      end
 
       if options[:limit] && options[:offset]
         extend Kaminari::PageScopeMethods
@@ -41,7 +45,7 @@ module Kaminari
 
     # returns another chunk of the original array
     def limit(num)
-      self.class.new @_original_array, :limit => num, :offset => @_offset_value, :total_count => @_total_count, :padding => @_padding
+      self.class.new @_original_array, :limit => num, :offset => @_offset_value, :total_count => @_total_count, :padding => @_padding, :page_limit => @_max_num_pages
     end
 
     # total item numbers of the original array
@@ -51,7 +55,11 @@ module Kaminari
 
     # returns another chunk of the original array
     def offset(num)
-      self.class.new @_original_array, :limit => @_limit_value, :offset => num, :total_count => @_total_count, :padding => @_padding
+      self.class.new @_original_array, :limit => @_limit_value, :offset => num, :total_count => @_total_count, :padding => @_padding, :page_limit => @_max_num_pages
+    end
+
+    def max_page_number(num)
+      self.class.new @_original_array, :limit => @_limit_value, :offset => @_offset_value, :total_count => @_total_count, :padding => @_padding, :page_limit => num
     end
   end
 

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -58,8 +58,8 @@ module Kaminari
       self.class.new @_original_array, :limit => @_limit_value, :offset => num, :total_count => @_total_count, :padding => @_padding, :page_limit => @_max_num_pages
     end
 
-    def max_page_number(num)
-      self.class.new @_original_array, :limit => @_limit_value, :offset => @_offset_value, :total_count => @_total_count, :padding => @_padding, :page_limit => num
+    def empty_instance
+      self.class.new([])
     end
   end
 

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -13,10 +13,6 @@ module Kaminari
     def initialize(original_array = [], options = {})
       @_original_array, @_limit_value, @_offset_value, @_total_count, @_padding, @_max_num_pages = original_array, (options[:limit] || default_per_page).to_i, options[:offset].to_i, options[:total_count], options[:padding].to_i, (options[:page_limit] || Kaminari.config.max_pages)
 
-      if @_max_num_pages.present?
-        original_array = original_array[0, @_limit_value * @_max_num_pages.to_i]
-      end
-
       if options[:limit] && options[:offset]
         extend Kaminari::PageScopeMethods
       end
@@ -27,6 +23,10 @@ module Kaminari
 
       if @_total_count.nil?
         original_array = original_array[@_offset_value, @_limit_value]
+      end
+
+      if @_max_num_pages.present?
+        original_array = original_array[0, @_limit_value * @_max_num_pages.to_i]
       end
 
       super(original_array || [])
@@ -50,7 +50,11 @@ module Kaminari
 
     # total item numbers of the original array
     def total_count
-      @_total_count || @_original_array.count
+      if @_max_num_pages
+        @_max_num_pages * @_limit_value
+      else
+        @_total_count || @_original_array.count
+      end
     end
 
     # returns another chunk of the original array

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -29,6 +29,10 @@ module Kaminari
       end
     end
 
+    def empty_instance
+      self.where(id: nil)
+    end
+
     private
     def unpage
       clone.tap do |crit|

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -27,6 +27,12 @@ module Kaminari
           size
         end
       end
+
+      if @_max_num_pages.present? && @_max_num_pages < @total_count
+        limit_value * @_max_num_pages
+      else
+        @total_count
+      end
     end
 
     def empty_instance

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -26,7 +26,9 @@ module Kaminari
       count_without_padding = 0 if count_without_padding < 0
 
       total_pages_count = (count_without_padding.to_f / limit_value).ceil
-      if max_pages.present? && max_pages < total_pages_count
+      if @_max_num_pages.present? && @_max_num_pages < total_pages_count
+        @_max_num_pages
+      elsif max_pages.present? && max_pages < total_pages_count
         max_pages
       else
         total_pages_count
@@ -71,6 +73,10 @@ module Kaminari
     # Out of range of the collection?
     def out_of_range?
       current_page > total_pages
+    end
+
+    def page_limit num
+      self.max_page_number(num)
     end
   end
 end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -76,7 +76,12 @@ module Kaminari
     end
 
     def page_limit num
-      self.max_page_number(num)
+      @_max_num_pages = num
+      if num < current_page
+        empty_instance
+      else
+        self
+      end
     end
   end
 end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -283,6 +283,25 @@ if defined? ActiveRecord
           subject { ActiveRecord::Base.descendants }
           its(:length) { should_not == 0 }
         end
+
+        describe "#page_limit" do
+          context 'page 1 max_pages 1' do
+            subject { model_class.page(1).per(5).page_limit(1) }
+            its(:count) { should == 5 }
+            its('first.name') { should == 'user001' }
+          end
+
+          context "page 2 max_pages 1" do
+            subject { model_class.page(2).per(5).page_limit(1) }
+            its(:count) { should == 0 }
+          end
+
+          context "page 2 max_pages 2" do
+            subject { model_class.page(2).per(5).page_limit(2) }
+            its(:count) { should == 5 }
+            its('first.name') { should == 'user006' }
+          end
+        end
       end
     end
   end

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -98,6 +98,11 @@ describe Kaminari::PaginatableArray do
       subject { array.page(1).padding(25) }
       its(:total_pages) { should == 3 }
     end
+
+    context 'per 25, page_limit 2' do
+      subject { array.page(1).page_limit(2) }
+      its(:total_pages) { should == 2 }
+    end
   end
 
   describe '#current_page' do
@@ -186,6 +191,25 @@ describe Kaminari::PaginatableArray do
       its(:first) { should == 11 }
       its(:current_page) { should == 2 }
       its(:total_count) { should == 15 }
+    end
+  end
+
+  describe "#page_limit" do
+    context 'page 1 max_pages 1' do
+      subject { array.page(1).per(5).page_limit(1) }
+      it { should have(5).users }
+      its(:first) { should == 1 }
+    end
+
+    context "page 2 max_pages 1" do
+      subject { array.page(2).per(5).page_limit(1) }
+      it { should have(0).users }
+    end
+
+    context "page 2 max_pages 2" do
+      subject { array.page(2).per(5).page_limit(2) }
+      it { should have(5).users }
+      its(:first) { should == 6 }
     end
   end
 end

--- a/spec/models/mongoid/mongoid_spec.rb
+++ b/spec/models/mongoid/mongoid_spec.rb
@@ -224,5 +224,40 @@ if defined? Mongoid
         its(:limit_value) { should == 200 }
       end
     end
+
+    describe "#page_limit" do
+      context 'page 1 max_pages 1' do
+        subject { User.page(1).per(5).page_limit(1) }
+        it { should be_a Mongoid::Criteria }
+        its(:current_page) { should == 1 }
+        its(:prev_page) { should be_nil }
+        its(:next_page) { should be nil }
+        its(:limit_value) { should == 5 }
+        its(:total_pages) { should == 1 }
+        it { should skip(0) }
+      end
+
+      context "page 2 max_pages 1" do
+        subject { User.page(2).per(5).page_limit(1) }
+        it { should be_a Mongoid::Criteria }
+        its(:total_count) { should == 0 }
+        #its(:current_page) { should be nil }
+        its(:prev_page) { should be nil }
+        its(:next_page) { should be nil }
+        its(:limit_value) { should == 5 }
+        its(:total_pages) { should == 0 }
+      end
+
+      context "page 2 max_pages 2" do
+        subject { User.page(2).per(5).page_limit(2) }
+        it { should be_a Mongoid::Criteria }
+        its(:current_page) { should == 2 }
+        its(:prev_page) { should == 1 }
+        its(:next_page) { should be nil }
+        its(:limit_value) { should == 5 }
+        its(:total_pages) { should == 2 }
+        it { should skip(5) }
+      end
+    end
   end
 end


### PR DESCRIPTION
Added method <code>page_limit(num)</code>, which limits the total_pages and total_count methods.

It returns and empty instance if <code>current_page</code> is bigger than <code>page_limit</code>. In views, the max page showed is <code>page_limit</code> (if it's lower than <code>total_pages</code>), and total_count is limited too.

Implemented for Array, ActiveRecord and MongoID.
#### Usage

``` ruby
Model.page(params[:page]).per(per_page).page_limit(10)
```

In this case, if <code>params[:page]</code> is greater than 10, it returns an empty instance. If real <code>total_pages</code> is greater than <code>page_limit</code>, then <code>total_pages</code> will be 10 and <code>total_count</code> will be <code>10 \* params[:per_page]</code>.
