### PR TITLE
Add possibility to set `total_count` for a scope

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -19,6 +19,11 @@ module Kaminari
       offset(offset_value + num.to_i)
     end
 
+    def set_total_count(total_count)
+      @total_count = total_count.to_i
+      self
+    end
+
     # Total number of pages
     def total_pages
       count_without_padding = total_count

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -272,6 +272,11 @@ if defined? ActiveRecord
           end
         end
 
+        describe '#set_total_count' do
+          subject { model_class.page(1).set_total_count(123) }
+          its(:total_count) { should == 123 }
+        end
+
         context 'chained with .group' do
           subject { model_class.group('age').page(2).per 5 }
           # 0..10


### PR DESCRIPTION
Counting can be slow with large DB sets. Especially in PostgreSQL, because it returns a precise result and therefore it needs to read all the resulting rows to verify that they exists.

But sometimes it is better to have a fast but not so precise result. In that case we can tell `kaminari` what the approximate total count is, so it doesn't need to calculate it with SQL `count`.
#### Usage

``` ruby
Model.page(1).set_total_count(my_very_fast_count_method)
```
#### Pros
- This solution is simple and works well with all the view helpers out of the box.
#### Cons
- It doesn't work well with the `ActiveRecord::Relation#reset`. Possible solution might be to set a `proc` which would be called instead of `Kaminari::ActiveRecordRelationMethods#total_count` method.

Related issues: #545, #681.
