### PR TITLE
hide Next & Last buttons if page is out of range

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -17,7 +17,9 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>
-    <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? %>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
   </nav>
 <% end -%>

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -33,6 +33,13 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       subject { helper.paginate @users, :num_pages => 3, :params => {:controller => 'users', :action => 'index'} }
       it { should match(/<a href="\/users\?page=3">Last/) }
     end
+
+    context "page: 20 (out of range)" do
+      before  { @users = User.page(20) }
+      subject { helper.paginate @users, :params => {:controller => 'users', :action => 'index'} }
+      it { should_not match(/Last/) }
+      it { should_not match(/Next/) }
+    end
   end
 
   describe '#link_to_previous_page' do


### PR DESCRIPTION
For example, we had a situation when we have 10 pages with 10 users per page.
We removing 10 users. Now we have 9 pages.
BUT, last page was indexed with Google Bot (or any other).
Not google bot will try to access /users?page=10 and will get an empty page. 
And `paginator` helper will show link to "Next" page, e.g. page=11.
And more and more....

Expected:
If I'm trying to open page which is out of range, I should not see link to Next and Previous pages.
