### PR TITLE
Fixes page_entries_info to display the correct number for the last page.

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -95,7 +95,7 @@ module Kaminari
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)
       else
         first = collection.offset_value + 1
-        last = collection.last_page? ? collection.total_count : collection.offset_value + collection.limit_value
+        last = [collection.offset_value + collection.limit_value, collection.total_count].min
         t('helpers.page_entries_info.more_pages.display_entries', :entry_name => entry_name, :first => first, :last => last, :total => collection.total_count)
       end.html_safe
     end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -179,7 +179,7 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       context 'having more than one page of entries' do
         before do
-          50.times {|i| User.create! :name => "user#{i}"}
+          60.times {|i| User.create! :name => "user#{i}"}
         end
 
         describe 'the first page' do
@@ -188,11 +188,11 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           end
 
           subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+          it      { should == 'Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>60</b> in total' }
 
           context 'setting the entry name option to "member"' do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-            it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>60</b> in total' }
           end
         end
 
@@ -202,11 +202,25 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           end
 
           subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying users <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+          it      { should == 'Displaying users <b>26&nbsp;-&nbsp;50</b> of <b>60</b> in total' }
 
           context 'setting the entry name option to "member"' do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-            it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>60</b> in total' }
+          end
+        end
+
+        describe 'the last page' do
+          before do
+            @users = User.page(3).per(25)
+          end
+
+          subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'Displaying users <b>51&nbsp;-&nbsp;60</b> of <b>60</b> in total' }
+
+          context 'setting the entry name option to "member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying members <b>51&nbsp;-&nbsp;60</b> of <b>60</b> in total' }
           end
         end
       end
@@ -253,7 +267,7 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       context 'having more than one page of entries' do
         before do
-          50.times {|i| User::Address.create!}
+          60.times {|i| User::Address.create!}
         end
 
         describe 'the first page' do
@@ -262,11 +276,11 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           end
 
           subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying addresses <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+          it      { should == 'Displaying addresses <b>1&nbsp;-&nbsp;25</b> of <b>60</b> in total' }
 
           context 'setting the entry name option to "place"' do
             subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-            it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>60</b> in total' }
           end
         end
 
@@ -276,11 +290,25 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           end
 
           subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying addresses <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+          it      { should == 'Displaying addresses <b>26&nbsp;-&nbsp;50</b> of <b>60</b> in total' }
 
           context 'setting the entry name option to "place"' do
             subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-            it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>60</b> in total' }
+          end
+        end
+
+        describe 'the last page' do
+          before do
+            @addresses = User::Address.page(3).per(25)
+          end
+
+          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying addresses <b>51&nbsp;-&nbsp;60</b> of <b>60</b> in total' }
+
+          context 'setting the entry name option to "place"' do
+           subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying places <b>51&nbsp;-&nbsp;60</b> of <b>60</b> in total' }
           end
         end
       end


### PR DESCRIPTION
So it displays the correct number when the user sees the last page.
Previously, on the last page, it displayed the total_count instead of the total of the current page.

e.g (with 4 pages max with 50 per page):
Firsts pages were correct showing: `1-50 of 275`, `51-100 of 275`, etc..
but the last page displayed: `151-275 of 275`

The correct behavior is now applied, displaying  `151-200 of 275` on the last page.

The behavior when the last entry is reached is still the same as before, displaying `251-275 of 275`.
