### PR TITLE
Remove page parameter for first page in SEO rel prev tags

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -124,8 +124,9 @@ module Kaminari
 
       output = ""
       output << '<link rel="next" href="' + url_for(params.merge(param_name => scope.next_page, :only_path => true)) + '"/>' if scope.next_page
-      output << '<link rel="prev" href="' + url_for(params.merge(param_name => scope.prev_page, :only_path => true)) + '"/>' if scope.prev_page
-
+      prev_page = scope.prev_page
+      prev_page = nil if prev_page == 1
+      output << '<link rel="prev" href="' + url_for(params.merge(param_name => prev_page, :only_path => true)) + '"/>' if scope.prev_page
       output.html_safe
     end
   end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -280,6 +280,19 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails)do
       it { should match(/\?page=2/) }
     end
 
+    context 'the second page' do
+      before do
+        @users = User.page(2).per(25)
+      end
+
+      subject { helper.rel_next_prev_link_tags @users, :params => {:controller => 'users', :action => 'index'} }
+      it { should match(/rel="prev"/) }
+      it { should match(/"\/users"/) }
+      it { should_not match(/\?page=1/) }
+      it { should match(/rel="next"/) }
+      it { should match(/\?page=3/) }
+    end
+
     context 'the middle page' do
       before do
         @users = User.page(3).per(25)


### PR DESCRIPTION
In the current code,  when referring to the first page, `<a>`  has a link to "/users" as pagination, but rel_next_prev_link_tags create `<link rel = "prev" href = "/ users? page = 1">`.
Because of recognizing a risk of "duplicate content" from Google, it should be a `<link rel = "prev" href = "/ users">`.
