### PR TITLE
Fix a bug when paginating pre-paginated arrays with total_count

### DIFF
--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -17,11 +17,13 @@ module Kaminari
         extend Kaminari::PageScopeMethods
       end
 
-      if @_total_count && (@_total_count <= original_array.count)
-        original_array = original_array.first(@_total_count)[@_offset_value, @_limit_value]
-      end
-
-      unless @_total_count
+      if @_total_count
+        if @_total_count > original_array.count # pre-paginated array, let's just make sure the limit is respected
+          original_array = original_array.first(@_limit_value)
+        else
+          original_array = original_array.first(@_total_count)[@_offset_value, @_limit_value]
+        end
+      else
         original_array = original_array[@_offset_value, @_limit_value]
       end
 

--- a/spec/models/array_spec.rb
+++ b/spec/models/array_spec.rb
@@ -170,6 +170,15 @@ describe Kaminari::PaginatableArray do
       its(:total_count) { should == 9999 }
     end
 
+    context "array 1..10, page 5, per 5, total_count 9999" do
+      subject { Kaminari::PaginatableArray.new((1..10).to_a, :total_count => 9999).page(5).per(5) }
+
+      it { should have(5).items }
+      its(:first) { should == 1 }
+      its(:current_page) { should == 5 }
+      its(:total_count) { should == 9999 }
+    end
+
     context "array 1..15, page 1, per 10, total_count 15" do
       subject { Kaminari.paginate_array((1..15).to_a, :total_count => 15).page(1).per(10) }
 


### PR DESCRIPTION
Fixes a bug described in #716.

When paginating an array with total count and page size is smaller than the array length, we should truncate array to respect `per` parameter.
