### PR TITLE
Allow max per to be overridden when scoping.

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -2,12 +2,14 @@ module Kaminari
   module PageScopeMethods
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
-    def per(num)
+    def per(num, override_max: nil)
       if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
         self
       elsif n.zero?
         limit(n)
-      elsif max_per_page && max_per_page < n
+      elsif override_max && override_max < n
+        limit(override_max).offset(offset_value / limit_value * override_max)
+      elsif !override_max && max_per_page && max_per_page < n
         limit(max_per_page).offset(offset_value / limit_value * max_per_page)
       else
         limit(n).offset(offset_value / limit_value * n)

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -2,15 +2,13 @@ module Kaminari
   module PageScopeMethods
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
-    def per(num, override_max: nil)
+    def per(num, options={})
       if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
         self
       elsif n.zero?
         limit(n)
-      elsif override_max && override_max < n
-        limit(override_max).offset(offset_value / limit_value * override_max)
-      elsif !override_max && max_per_page && max_per_page < n
-        limit(max_per_page).offset(offset_value / limit_value * max_per_page)
+      elsif (max_per = options.fetch(:override_max, max_per_page)) && max_per < n
+        limit(max_per).offset(offset_value / limit_value * max_per)
       else
         limit(n).offset(offset_value / limit_value * n)
       end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -91,6 +91,24 @@ if defined? ActiveRecord
             subject { model_class.page(1).per(0) }
             it { should have(0).users }
           end
+
+          context "page 1 per 5 override_max 2" do
+            subject { model_class.page(1).per(5, override_max: 2) }
+            it { should have(2).users }
+          end
+
+          context "with override_max > default_max and per is between" do
+            before do
+              model_class.max_paginates_per 50
+            end
+
+            subject { model_class.page(1).per(55, override_max: 60) }
+            it { should have(55).users }
+
+            after do
+              model_class.max_paginates_per nil
+            end
+          end
         end
 
         describe '#padding' do


### PR DESCRIPTION
This allows the default or model defined max_per_page to be overridden when using per.

In my case, I wanted different max_per_pages for different controller actions. For example, a HTML view or JSON controller may only be allowed to get a maximum of 50, whereas an API might want to be able to get a maximum of 100:

``` ruby
class Model
  max_paginates_per 50
end

# In HTML View Controller
Model.page(params[:page]).per(params[:per_page]) #=> Max of 50

# In API Controller
Model.page(params[:page]).per(params[:per_page], override_max: 100) #=> Max of 100
```

Fixes #735 
