### PR TITLE
Add support for specifying a custom Paginator

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -13,11 +13,13 @@ module Kaminari
     # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
     # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
     # * <tt>:remote</tt> - Ajax? (false by default)
+    # * <tt>:paginator_class</tt> - Specify a custom Paginator (Kaminari::Helpers::Paginator by default)
     # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
     def paginate(scope, options = {}, &block)
       options[:total_pages] ||= options[:num_pages] || scope.total_pages
+      options[:paginator_class] ||= Kaminari::Helpers::Paginator
 
-      paginator = Kaminari::Helpers::Paginator.new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :remote => false))
+      paginator = options[:paginator_class].new(self, options.reverse_merge(:current_page => scope.current_page, :per_page => scope.limit_value, :remote => false))
       paginator.to_s
     end
 

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -29,6 +29,19 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       it { should eq("  <b>1</b>\n") }
     end
 
+    context 'accepts :paginator_class option' do
+      let(:custom_paginator) do
+        Class.new(Kaminari::Helpers::Paginator) do
+          def to_s
+            "CUSTOM PAGINATION"
+          end
+        end
+      end
+
+      subject { helper.paginate @users, :paginator_class => custom_paginator, :params => {:controller => 'users', :action => 'index'} }
+      it { should eq("CUSTOM PAGINATION") }
+    end
+
     context "num_pages: 3" do
       subject { helper.paginate @users, :num_pages => 3, :params => {:controller => 'users', :action => 'index'} }
       it { should match(/<a href="\/users\?page=3">Last/) }


### PR DESCRIPTION
I'd like to be able to replace the default pagination logic with the following which outputs pages at 10 page intervals:

``` ruby
class IntervalPaginator < Kaminari::Helpers::Paginator
  PAGE_INTERVAL = 10

  def relevant_pages(options)
    left_intervals = intervals_within(1..options[:current_page].to_i)
    right_intervals = intervals_within(options[:current_page].to_i..options[:total_pages])

    start_page = options[:current_page].to_i/PAGE_INTERVAL*PAGE_INTERVAL
    consecutive = (start_page..(start_page + PAGE_INTERVAL - 1)).to_a

    within_range = (1..options[:total_pages]).method(:include?)
    ([1] + left_intervals + consecutive + right_intervals).uniq.sort.select(&within_range)
  end

  private

  def intervals_within(range, interval = PAGE_INTERVAL)
    range.select { |v| v % interval == 0 }
  end
end
```

If you do merge in this change, I'd be happy to add this customization example to the docs too.
