### PR TITLE
replace PATH_INFO with REQUEST_PATH in padrino helper

### DIFF
--- a/lib/kaminari/helpers/sinatra_helpers.rb
+++ b/lib/kaminari/helpers/sinatra_helpers.rb
@@ -85,7 +85,7 @@ module Kaminari::Helpers
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, options = {}, &block)
-        current_path = env['PATH_INFO'] rescue nil
+        current_path = env['REQUEST_PATH'] rescue nil
         current_params = Rack::Utils.parse_query(env['QUERY_STRING']).symbolize_keys rescue {}
         paginator = Kaminari::Helpers::Paginator.new(
           ActionViewTemplateProxy.new(:current_params => current_params, :current_path => current_path, :param_name => options[:param_name] || Kaminari.config.param_name),
@@ -120,7 +120,7 @@ module Kaminari::Helpers
           placeholder.to_s.html_safe
         else
           query = params.merge(param_name => scope.prev_page)
-          link_to name, env['PATH_INFO'] + (query.empty? ? '' : "?#{query.to_query}"), options.reverse_merge(:rel => 'previous')
+          link_to name, env['REQUEST_PATH'] + (query.empty? ? '' : "?#{query.to_query}"), options.reverse_merge(:rel => 'previous')
         end
       end
 
@@ -150,7 +150,7 @@ module Kaminari::Helpers
           placeholder.to_s.html_safe
         else
           query = params.merge(param_name => scope.next_page)
-          link_to name, env['PATH_INFO'] + (query.empty? ? '' : "?#{query.to_query}"), options.reverse_merge(:rel => 'next')
+          link_to name, env['REQUEST_PATH'] + (query.empty? ? '' : "?#{query.to_query}"), options.reverse_merge(:rel => 'next')
         end
       end
     end


### PR DESCRIPTION
Replace PATH_INFO with REQUEST_PATH in padrino helper to determine the current path. 
The environment variable PATH_INFO would lose the path to the mount point of a specific sinatra app.
