### PR TITLE
Allow model max_paginates_per to be overridden

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,20 +3,17 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
-        self
-      elsif n.zero?
-        limit(n)
-      elsif max_per_page && max_per_page < n
-        limit(max_per_page).offset(offset_value / limit_value * max_per_page)
-      else
-        limit(n).offset(offset_value / limit_value * n)
-      end
+      @_per = num
+      _per(num, max_per_page)
     end
 
     def padding(num)
       @_padding = num
       offset(offset_value + num.to_i)
+    end
+
+    def max_paginates_per(max_per)
+      _per(@_per, max_per)
     end
 
     # Total number of pages
@@ -71,6 +68,20 @@ module Kaminari
     # Out of range of the collection?
     def out_of_range?
       current_page > total_pages
+    end
+
+    private
+
+    def _per(num, max_per)
+      if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
+        self
+      elsif n.zero?
+        limit(n)
+      elsif max_per && max_per < n
+        limit(max_per).offset(offset_value / limit_value * max_per)
+      else
+        limit(n).offset(offset_value / limit_value * n)
+      end
     end
   end
 end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -93,6 +93,36 @@ if defined? ActiveRecord
           end
         end
 
+        describe '#max_paginates_per' do
+          before do
+            model_class.max_paginates_per 10
+          end
+
+          context 'max_paginates_per 20 per 15' do
+            subject { model_class.page(1).per(15).max_paginates_per(20) }
+            it { should have(15).users }
+          end
+
+          context 'max_paginates_per 20 per 30' do
+            subject { model_class.page(1).per(30).max_paginates_per(20) }
+            it { should have(20).users }
+          end
+
+          context 'max_paginates_per 20 per 5' do
+            subject { model_class.page(1).per(5).max_paginates_per(20) }
+            it { should have(5).users }
+          end
+
+          context 'max_paginates_per 20 per nil' do
+            subject { model_class.page(1).per(nil).max_paginates_per(20) }
+            it { should have(model_class.default_per_page).users }
+          end
+
+          after do
+            model_class.max_paginates_per nil
+          end
+        end
+
         describe '#padding' do
           context 'page 1 per 5 padding 1' do
             subject { model_class.page(1).per(5).padding(1) }


### PR DESCRIPTION
#736

``` ruby
Model.page(params[:page]).per(params[:per_page]).max_paginates_per(100)
```
