### PR TITLE
add #repaginate_out_of_range method

### DIFF
--- a/lib/kaminari/config.rb
+++ b/lib/kaminari/config.rb
@@ -26,6 +26,7 @@ module Kaminari
     config_accessor :page_method_name
     config_accessor :max_pages
     config_accessor :params_on_first_page
+    config_accessor :when_out_of_range
 
     def param_name
       config.param_name.respond_to?(:call) ? config.param_name.call : config.param_name
@@ -49,5 +50,6 @@ module Kaminari
     config.param_name = :page
     config.max_pages = nil
     config.params_on_first_page = false
+    config.when_out_of_range = :default
   end
 end

--- a/lib/kaminari/models/configuration_methods.rb
+++ b/lib/kaminari/models/configuration_methods.rb
@@ -43,6 +43,20 @@ module Kaminari
       def max_pages
         (defined?(@_max_pages) && @_max_pages) || Kaminari.config.max_pages
       end
+
+      # Overrides the default + when_out_of_range+ value per model
+      #   class Article < ActiveRecord::Base
+      #     when_page_is_out_of_range_set :first
+      #   end
+      def when_page_is_out_of_range_set(fallback)
+        @_when_out_of_range = fallback
+      end
+
+      # This model's +when_out_of_range+ value
+      # returns +when_out_of_range+ value unless explicitly overridden via <tt>when_page_is_out_of_range_set</tt>
+      def when_out_of_range
+        (defined?(@_when_out_of_range) && @_when_out_of_range) || Kaminari.config.when_out_of_range
+      end
     end
   end
 end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -19,6 +19,17 @@ module Kaminari
       offset(offset_value + num.to_i)
     end
 
+    # Change current_page if page is out of range of the collection
+    def repaginate_out_of_range
+      return self unless out_of_range?
+
+      case when_out_of_range
+        when :first then page(1).per(limit_value)
+        when :last  then page(total_pages).per(limit_value)
+        else self
+      end
+    end
+
     # Total number of pages
     def total_pages
       count_without_padding = total_count

--- a/spec/config/config_spec.rb
+++ b/spec/config/config_spec.rb
@@ -106,4 +106,20 @@ describe Kaminari::Configuration do
       its(:params_on_first_page) { should be_true }
     end
   end
+
+  describe 'when_out_of_range' do
+    context 'by default' do
+      its(:when_out_of_range) { should == :default }
+    end
+    context 'configure via config block' do
+      before do
+        Kaminari.configure {|c| c.when_out_of_range = :first}
+      end
+      its(:when_out_of_range) { should == :first }
+      after do
+        Kaminari.configure {|c| c.when_out_of_range = :default}
+      end
+    end
+  end
+
 end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -260,6 +260,23 @@ if defined? ActiveRecord
           end
         end
 
+        describe '#repaginate_out_of_range' do
+          subject { model_class.page(1000).repaginate_out_of_range }
+          it_should_behave_like 'blank page'
+
+          context 'when when_out_of_range config is :first' do
+            before { model_class.when_page_is_out_of_range_set :first }
+            after { model_class.when_page_is_out_of_range_set nil }
+            it_should_behave_like 'the first page'
+          end
+
+          context 'when when_out_of_range config is :last' do
+            before { model_class.when_page_is_out_of_range_set :last }
+            after { model_class.when_page_is_out_of_range_set nil }
+            its(:offset_value) { should == 75 }
+          end
+        end
+
         describe '#count' do
           context 'page 1' do
             subject { model_class.page }

--- a/spec/models/configuration_methods_spec.rb
+++ b/spec/models/configuration_methods_spec.rb
@@ -122,4 +122,42 @@ describe "configuration methods" do
       model.max_pages_per nil
     end
   end
+
+  describe "#when_out_of_range" do
+    if defined? ActiveRecord
+      describe 'AR::Base' do
+        subject { ActiveRecord::Base }
+        it { should_not respond_to :when_page_is_out_of_range_set }
+      end
+    end
+
+    subject { model.page(11).per(10) }
+
+    context "by default" do
+      its(:when_out_of_range){ should == :default }
+    end
+
+    context "when configuring both on global and model-level" do
+      before do
+        Kaminari.configure {|c| c.when_out_of_range = :first }
+        model.when_page_is_out_of_range_set :first
+      end
+
+      its(:when_out_of_range){ should == :first }
+    end
+
+    context "when configuring multiple times" do
+      before do
+        Kaminari.configure {|c| c.when_out_of_range = :last }
+        Kaminari.configure {|c| c.when_out_of_range = :first }
+      end
+
+      its(:when_out_of_range){ should == :first }
+    end
+
+    after do
+      Kaminari.configure {|c| c.when_out_of_range = :default }
+      model.when_page_is_out_of_range_set nil
+    end
+  end
 end


### PR DESCRIPTION
This allows to define a custom behavior when #page is called with a value out of
range.

For example, when setting

``` ruby
  # given there are 100 articles
  Article.page(10).per(25).all
  # => []

  Article.when_page_is_out_of_range_set :first
  Article.page(10).per(25).all
  # => # the first 25 articles

  Article.when_page_is_out_of_range_set :last
  Article.page(10).per(25).all
  # => # the last 25 articles
```

This behavior is useful when you are deleting resources from a list and you are
on the last page. If the last page has only one resource, after deleting it you
can redirect the user to the previous (last) page or force the first page.
