### PR TITLE
Fixing I18n problems with foreign languages and support for downcase option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -192,6 +192,12 @@ Run the following generator command, then edit the generated file.
     <%= page_entries_info @posts, :entry_name => 'item' %>
     #-> Displaying items 6 - 10 of 26 in total
 
+  By default, the message will downcase the object name.
+  Override this with the <tt>:downcase</tt> parameter:
+    
+    <%= page_entries_info @posts, :downcase => false %>
+    #-> Displaying Items 6 - 10 of 26 in total
+
 * the +rel_next_prev_link_tags+ helper method
 
     <%= rel_next_prev_link_tags @users %>

--- a/README.rdoc
+++ b/README.rdoc
@@ -196,7 +196,7 @@ Run the following generator command, then edit the generated file.
   Override this with the <tt>:downcase</tt> parameter:
     
     <%= page_entries_info @posts, :downcase => false %>
-    #-> Displaying Items 6 - 10 of 26 in total
+    #-> Displaying Posts 6 - 10 of 26 in total
 
 * the +rel_next_prev_link_tags+ helper method
 

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,8 +88,7 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = options[:entry_name] || collection.entry_name(options.merge(count: collection.total_count))
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)

--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -88,7 +88,10 @@ module Kaminari
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name(options.merge(count: collection.total_count))
+      total_count = collection.total_count == 1 ? 1 : 2
+      default_entry_name = options[:entry_name]
+      default_entry_name = default_entry_name.pluralize unless default_entry_name.blank? || collection.total_count == 1
+      entry_name = default_entry_name || collection.entry_name(options.merge(:count => total_count))
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,8 +1,11 @@
 module Kaminari
   module ActiveRecordRelationMethods
-    def entry_name
-      model_name.human.downcase
-    end
+    def entry_name( options = {} )
+      count = options.fetch(:count, 1) # back compatibility where default was singular humanized model name
+      downcase = options.fetch(:downcase, true) # back compatibility where default was to downcase entry_name
+      entry_name = model_name.human(count: count)
+      downcase ? entry_name.downcase : entry_name
+     end
 
     def reset #:nodoc:
       @total_count = nil

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,11 +1,8 @@
+require 'kaminari/models/entry_methods'
+
 module Kaminari
   module ActiveRecordRelationMethods
-    def entry_name( options = {} )
-      count = options.fetch(:count, 1) # back compatibility where default was singular humanized model name
-      downcase = options.fetch(:downcase, true) # back compatibility where default was to downcase entry_name
-      entry_name = model_name.human(count: count)
-      downcase ? entry_name.downcase : entry_name
-     end
+    include Kaminari::EntryMethods
 
     def reset #:nodoc:
       @total_count = nil

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -28,8 +28,8 @@ module Kaminari
       super(original_array || [])
     end
 
-    def entry_name
-      "entry"
+    def entry_name( options = {} )
+      options.fetch(:count, 1) == 1 ? "entry" : "entries"
     end
 
     # items at the specified "page"

--- a/lib/kaminari/models/entry_methods.rb
+++ b/lib/kaminari/models/entry_methods.rb
@@ -1,0 +1,15 @@
+module Kaminari
+  module EntryMethods
+    def entry_name( options = {} )
+      count = options.fetch(:count, 1) # back compatibility where default was singular humanized model name
+      downcase = options.fetch(:downcase, true) # back compatibility where default was to downcase entry_name
+      if model_name.respond_to?(:lookup_ancestors) || model_name.respond_to?(:i18n_scope)
+        entry_name = model_name.human(count: count)
+      else
+        entry_name = model_name.human
+        entry_name = entry_name.pluralize if count != 1
+      end
+      downcase ? entry_name.downcase : entry_name
+    end
+  end
+end

--- a/lib/kaminari/models/mongoid_criteria_methods.rb
+++ b/lib/kaminari/models/mongoid_criteria_methods.rb
@@ -1,12 +1,12 @@
+require 'kaminari/models/entry_methods'
+
 module Kaminari
   module MongoidCriteriaMethods
+    include Kaminari::EntryMethods
+
     def initialize_copy(other) #:nodoc:
       @total_count = nil
       super
-    end
-
-    def entry_name
-      model_name.human.downcase
     end
 
     def limit_value #:nodoc:

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -145,6 +145,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
           it      { should == 'No members found' }
         end
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @users, :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'No Users found' }
+
+          context 'setting the entry name option to "member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'No members found' }
+          end
+
+          context 'setting the entry name option to "Member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'Member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'No Members found' }
+          end
+        end
       end
 
       context 'having 1 entry' do
@@ -160,6 +175,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
           it      { should == 'Displaying <b>1</b> member' }
         end
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @users, :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'Displaying <b>1</b> User' }
+
+          context 'setting the entry name option to "member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying <b>1</b> member' }
+          end
+
+          context 'setting the entry name option to "Member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'Member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying <b>1</b> Member' }
+          end
+        end
       end
 
       context 'having more than 1 but less than a page of entries' do
@@ -174,6 +204,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
         context 'setting the entry name option to "member"' do
           subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
           it      { should == 'Displaying <b>all 10</b> members' }
+        end
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @users, :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'Displaying <b>all 10</b> Users' }
+
+          context 'setting the entry name option to "member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying <b>all 10</b> members' }
+          end
+
+          context 'setting the entry name option to "Member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'Member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying <b>all 10</b> Members' }
+          end
         end
       end
 
@@ -194,6 +239,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
             it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
           end
+
+          context 'setting downcase option to false' do
+            subject { helper.page_entries_info @users, :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying Users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+
+            context 'setting the entry name option to "Member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'Member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying Members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+          end
         end
 
         describe 'the next page' do
@@ -208,6 +268,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
             it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
           end
+
+          context 'setting downcase option to false' do
+            subject { helper.page_entries_info @users, :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying Users <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+
+            context 'setting the entry name option to "Member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'Member', :downcase => false, :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying Members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+          end
         end
       end
     end
@@ -219,6 +294,11 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
       context 'having no entries' do
         subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
         it      { should == 'No addresses found' }
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @addresses, :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'No Addresses found' }
+        end
       end
 
       context 'having 1 entry' do
@@ -234,6 +314,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
           subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
           it      { should == 'Displaying <b>1</b> place' }
         end
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @addresses, :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying <b>1</b> Address' }
+
+          context 'setting the entry name option to "place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>1</b> place' }
+          end
+
+          context 'setting the entry name option to "Place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'Place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>1</b> Place' }
+          end
+        end
       end
 
       context 'having more than 1 but less than a page of entries' do
@@ -248,6 +343,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
         context 'setting the entry name option to "place"' do
           subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
           it      { should == 'Displaying <b>all 10</b> places' }
+        end
+
+        context 'setting downcase option to false' do
+          subject { helper.page_entries_info @addresses, :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying <b>all 10</b> Addresses' }
+
+          context 'setting the entry name option to "place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>all 10</b> places' }
+          end
+
+          context 'setting the entry name option to "Place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'Place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>all 10</b> Places' }
+          end
         end
       end
 
@@ -268,6 +378,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
             subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
             it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
           end
+
+          context 'setting downcase option to false' do
+            subject { helper.page_entries_info @addresses, :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying Addresses <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+
+            context 'setting the entry name option to "Place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'Place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying Places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+          end
         end
 
         describe 'the next page' do
@@ -282,6 +407,21 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
             subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
             it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
           end
+
+          context 'setting downcase option to false' do
+            subject { helper.page_entries_info @addresses, :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying Addresses <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+
+            context 'setting the entry name option to "Place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'Place', :downcase => false, :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying Places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+          end
         end
       end
     end
@@ -293,6 +433,26 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
 
       subject { helper.page_entries_info @numbers }
       it      { should == 'Displaying <b>all 3</b> entries' }
+
+      context 'setting the entry name option to "item"' do
+        subject { helper.page_entries_info @numbers, :entry_name => 'item' }
+        it      { should == 'Displaying <b>all 3</b> items' }
+      end
+
+      context 'setting downcase option to false' do
+        subject { helper.page_entries_info @numbers, :downcase => false }
+        it      { should == 'Displaying <b>all 3</b> entries' }
+
+        context 'setting the entry name option to "item"' do
+          subject { helper.page_entries_info @numbers, :entry_name => 'item', :downcase => false }
+          it      { should == 'Displaying <b>all 3</b> items' }
+        end
+
+        context 'setting the entry name option to "Item"' do
+          subject { helper.page_entries_info @numbers, :entry_name => 'Item', :downcase => false }
+          it      { should == 'Displaying <b>all 3</b> Items' }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Using "page_entries_info" with I18n was not working correctly with foreign languages, as it was not using the model name correctly when pluralizing the object name.

Also the downcase force of object name could be tricky as sentences are not always formed in the same way in all languages. So a option to avoid the default downcase could be useful.

The fixes are back-compatible, so users will not find any difference in their existing projects, once updated the gem.
