### PR TITLE
Test against the newset version of ruby 2.1 (2.1.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1
+  - 2.1.8
   - 2.2.4
   - 2.3.0
   - ruby-head


### PR DESCRIPTION
I know the discussion about how to write .travis.yml
(https://github.com/amatsuda/kaminari/issues/520), but
now Travis CI runs against ruby 2.1.5 and I think which is not
we indend to test against.
I know it is boring work to update the file along with
every 2.1.x patch release, but it is necessary to keep
test environments to be latest :(
