### PR TITLE
Fix mangled params in pagination links

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -21,9 +21,9 @@ module Kaminari
         @theme = @options.delete(:theme)
         @views_prefix = @options.delete(:views_prefix)
         @params = template.params.except(*PARAM_KEY_BLACKLIST).merge(@options.delete(:params) || {})
-        # @params in Rails 5 does no more inherits from Hash but composes a Hash
-        if @params.instance_variable_defined?(:@parameters) && !@params.respond_to?(:deep_merge)
-          @params = @params.instance_variable_get :@parameters
+        # @params in Rails 5 no longer inherits from Hash
+        if @params.respond_to?(:to_unsafe_h)
+          @params = @params.to_unsafe_h
         else
           @params = @params.with_indifferent_access
         end


### PR DESCRIPTION
In Rails 5, [`ActionController::Parameters` no longer inherits from Hash](https://github.com/rails/rails/pull/20868).
However, [now that `ActionController:Parameters#to_unsafe_h` has been fixed](https://github.com/rails/rails/issues/22841), we can use it to bypass Strong Parameters and retrieve the raw params hash we need.

Fixes https://github.com/amatsuda/kaminari/issues/765
