### PR TITLE
Changed generated config file name to meet consistency

### DIFF
--- a/lib/generators/kaminari/config_generator.rb
+++ b/lib/generators/kaminari/config_generator.rb
@@ -9,8 +9,19 @@ Description:
 DESC
 
       def copy_config_file
-        template 'kaminari_config.rb', 'config/initializers/kaminari_config.rb'
+        warn_if_old_config_file_exists
+        template 'kaminari_config.rb', 'config/initializers/kaminari.rb'
       end
+
+      private
+
+      def warn_if_old_config_file_exists
+        if File.exists?('config/initializers/kaminari_config.rb')
+          warn <<MESSAGE
+Warning:
+    You already have kaminari_config.rb file inside initializers directory.
+MESSAGE
+        end
     end
   end
 end


### PR DESCRIPTION
My currently project has a couple of initialization files inside initializers folder. Something like this:

```
└── config
    └── initializers
        ├── devise.rb
        ├── dragonfly.rb
        ├── friendly_id.rb
        ├── kaminari_config.rb
        ├── simple_form.rb
        ├── statesman.rb
        └── ...
```

And it would be nice to follow naming convention, by kaminari, for initialization files, [considered](https://github.com/bbatsov/rails-style-guide#gem-initializers) as a good practice by community.
