### PR TITLE
Fix <=> for PageProxy

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -196,7 +196,7 @@ module Kaminari
         end
 
         def <=>(other)
-          to_i <=> other.to_i
+          other.is_a?(self.class) ? (to_i <=> other.to_i) : nil
         end
       end
     end

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -196,7 +196,7 @@ module Kaminari
         end
 
         def <=>(other)
-          other.is_a?(self.class) ? (to_i <=> other.to_i) : nil
+          other.respond_to?(:to_i) ? (to_i <=> other.to_i) : nil
         end
       end
     end


### PR DESCRIPTION
In ruby 2.3.0, exceptions in the <=> method of Comparable are no longer automatically rescued. This change updates <=> to return nil instead of raising for Kaminari::Helpers::Paginator::PageProxy when the thing being compared to isn't a Kaminari::Helpers::Paginator::PageProxy.
