### PR TITLE
Add a relationship helper to PageProxy

### DIFF
--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,5 +8,5 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.rel} %>
 </span>

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -7,4 +7,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span{:class => "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  = link_to_unless page.current?, page, url, {:remote => remote, :rel => page.rel}

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -7,5 +7,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}
+  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.rel}
 '

--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -150,6 +150,15 @@ module Kaminari
           @page == @options[:current_page] + 1
         end
 
+        # relationship with the current page
+        def rel
+          if next?
+            'next'
+          elsif prev?
+            'prev'
+          end
+        end
+
         # within the left outer window or not
         def left_outer?
           @page <= @options[:left]

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -139,6 +139,21 @@ describe 'Kaminari::Helpers' do
         end
       end
 
+      describe '#rel' do
+        context 'page == current_page - 1' do
+          subject { Paginator::PageProxy.new({:current_page => 77}, 76, nil) }
+          its(:rel) { should eq 'prev' }
+        end
+        context 'page == current_page' do
+          subject { Paginator::PageProxy.new({:current_page => 78}, 78, nil) }
+          its(:rel) { should be_nil }
+        end
+        context 'page == current_page + 1' do
+          subject { Paginator::PageProxy.new({:current_page => 52}, 53, nil) }
+          its(:rel) { should eq 'next' }
+        end
+      end
+
       describe '#left_outer?' do
         context 'current_page == left' do
           subject { Paginator::PageProxy.new({:left => 3}, 3, nil) }


### PR DESCRIPTION
With this new helper, we can use page.rel instead of a nested
ternary operator in order to determine the relationship between a page
and the current page.
