### PR TITLE
Better check for Railtie.

### DIFF
--- a/lib/kaminari.rb
+++ b/lib/kaminari.rb
@@ -34,7 +34,7 @@ require 'kaminari/models/configuration_methods'
 require 'kaminari/hooks'
 
 # if not using Railtie, call `Kaminari::Hooks.init` directly
-if defined? Rails
+if defined? Rails::Raltie
   require 'kaminari/railtie'
   require 'kaminari/engine'
 end


### PR DESCRIPTION
This narrows the Rails::Railties check in the startup loader.
Fixes include problems on "non-rails+railties" apps, like ActiveRecordOnlyTM CLI converters etc.
