### PR TITLE
add always_display option to #render

### DIFF
--- a/lib/kaminari/helpers/paginator.rb
+++ b/lib/kaminari/helpers/paginator.rb
@@ -36,7 +36,9 @@ module Kaminari
 
       # render given block as a view template
       def render(&block)
-        instance_eval(&block) if @options[:total_pages] > 1
+        if @options[:total_pages] > 1 || @options[:always_display]
+          instance_eval(&block)
+        end
         @output_buffer
       end
 

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -21,6 +21,17 @@ describe 'Kaminari::Helpers::Paginator' do
     it { should == "<a href='#'>link</a>" }
   end
 
+  describe '#render' do
+    context 'when always_display is on' do
+      before do
+        @paginator = Paginator.new(template, total_pages: 1, always_display: true)
+        @paginator.render { @non_exist = :called }
+      end
+      subject { @paginator.instance_variable_get('@non_exist') }
+      it { should == :called }
+    end
+  end
+
   describe '#params' do
     before do
       @paginator = Paginator.new(template, :params => {:controller => 'foo', :action => 'bar'})


### PR DESCRIPTION
if "always_display" is passed to #paginate, the paginator will be shown even though the number of total pages is not larger than 1.

Usage:

``` Haml
= paginate @users, always_display: true
```

Related Issue:  https://github.com/amatsuda/kaminari/issues/275
Patch: https://github.com/amatsuda/kaminari/pull/785.patch
