### PR TITLE
Convert tabs to spaces

### DIFF
--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-	== link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
+  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote
 '

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,5 +1,5 @@
 / Link to the "Next" page
-	- available local variables
+  - available local variables
     url          : url to the next page
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages


### PR DESCRIPTION
I converted tabs to spaces.
`.slim` does include only spaces so `.slim` shouldn't include tabs.
It might become the cause of the error.
