### PR TITLE
Use AR I18n for model in page_entries_info

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -82,14 +82,28 @@ module Kaminari
     #
     # By default, the message will use the humanized class name of objects
     # in collection: for instance, "project types" for ProjectType models.
-    # The namespace will be cutted out and only the last name will be used.
-    # Override this with the <tt>:entry_name</tt> parameter:
+    # The humanized class name can be pluralized in the locale file:
+    #
+    #   de:
+    #     activerecord:
+    #       models:
+    #         book:
+    #           one: Buch
+    #           other: Bücher
+    #   # -> Displaying Bücher 6-10 of 26 in total
+    #
+    # Override this with the <tt>:entry_name</tt> parameter. In that case,
+    # the name will be pluralized with String#pluralize, and this only works
+    # for English.
     #
     #   <%= page_entries_info @posts, :entry_name => 'item' %>
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
-      entry_name = options[:entry_name] || collection.entry_name
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = if options.has_key?(:entry_name)
+        options[:entry_name].pluralize(collection.total_count)
+      else
+        collection.entry_name
+      end
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)

--- a/lib/kaminari/models/active_record_relation_methods.rb
+++ b/lib/kaminari/models/active_record_relation_methods.rb
@@ -1,7 +1,17 @@
 module Kaminari
   module ActiveRecordRelationMethods
     def entry_name
-      model_name.human.downcase
+      # If the model has a translated name, #human will use that. We pass
+      # a manually pluralized default by using #element, which returns a
+      # downcased and demodulized version of the class name, so
+      # eg. User::Address becomes 'address'.
+      # This keeps the functionality backwards compatible with older versions
+      # of Kaminari.
+
+      default = model_name.element
+      default = ActiveSupport::Inflector.pluralize(default) if total_count != 1
+
+      model_name.human(count: total_count, default: default)
     end
 
     def reset #:nodoc:

--- a/lib/kaminari/models/array_extension.rb
+++ b/lib/kaminari/models/array_extension.rb
@@ -29,7 +29,7 @@ module Kaminari
     end
 
     def entry_name
-      "entry"
+      "entry".pluralize(total_count)
     end
 
     # items at the specified "page"

--- a/spec/fake_app/active_record/models.rb
+++ b/spec/fake_app/active_record/models.rb
@@ -41,6 +41,9 @@ end
 class User::Address < ActiveRecord::Base
   belongs_to :user
 end
+# a model for I18n testing
+class Automobile < ActiveRecord::Base
+end
 
 # a class that uses abstract class
 class Product < ActiveRecord::Base
@@ -58,6 +61,7 @@ class CreateAllTables < ActiveRecord::Migration
     create_table(:readerships) {|t| t.integer :user_id; t.integer :book_id }
     create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id }
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }
+    create_table(:automobiles) {|t| t.string :model }
     create_table(:devices) {|t| t.string :name; t.integer :age}
   end
 end

--- a/spec/fake_app/locales/en.yml
+++ b/spec/fake_app/locales/en.yml
@@ -1,0 +1,6 @@
+en:
+  activerecord:
+    models:
+      automobile:
+        one: "car"
+        other: "cars"

--- a/spec/fake_app/rails_app.rb
+++ b/spec/fake_app/rails_app.rb
@@ -14,8 +14,12 @@ app.config.active_support.deprecation = :log
 app.config.eager_load = false
 # Rails.root
 app.config.root = File.dirname(__FILE__)
+app.config.i18n.default_locale = :en
 Rails.backtrace_cleaner.remove_silencers!
 app.initialize!
+
+I18n.load_path += Dir[Rails.root.join('locales', '*.yml')]
+I18n.reload!
 
 # routes
 app.routes.draw do
@@ -50,6 +54,15 @@ if defined? ActiveRecord
       render :inline => <<-ERB
   <%= @addresses.map(&:street).join("\n") %>
   <%= paginate @addresses %>
+  ERB
+    end
+  end
+  class AutomobilesController < ApplicationController
+    def index
+      @automobiles = Automobile.page params[:page]
+      render :inline => <<-ERB
+  <%= @automobiles.map(&:modle).join("\n") %>
+  <%= paginate @automobiles %>
   ERB
     end
   end

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -132,167 +132,244 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(Rails) do
   end
 
   describe '#page_entries_info' do
-    context 'on a model without namespace' do
-      before do
-        @users = User.page(1).per(25)
-      end
-
-      context 'having no entries' do
-        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-        it      { should == 'No users found' }
-
-        context 'setting the entry name option to "member"' do
-          subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'No members found' }
-        end
-      end
-
-      context 'having 1 entry' do
+    context 'on a model without explicit i18n' do
+      context 'on a model without namespace' do
         before do
-          User.create! :name => 'user1'
           @users = User.page(1).per(25)
         end
 
-        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-        it      { should == 'Displaying <b>1</b> user' }
+        context 'having no entries' do
+          subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+          it      { should == 'No users found' }
 
-        context 'setting the entry name option to "member"' do
-          subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying <b>1</b> member' }
-        end
-      end
-
-      context 'having more than 1 but less than a page of entries' do
-        before do
-          10.times {|i| User.create! :name => "user#{i}"}
-          @users = User.page(1).per(25)
+          context 'setting the entry name option to "member"' do
+            subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'No members found' }
+          end
         end
 
-        subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-        it      { should == 'Displaying <b>all 10</b> users' }
-
-        context 'setting the entry name option to "member"' do
-          subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying <b>all 10</b> members' }
-        end
-      end
-
-      context 'having more than one page of entries' do
-        before do
-          50.times {|i| User.create! :name => "user#{i}"}
-        end
-
-        describe 'the first page' do
+        context 'having 1 entry' do
           before do
+            User.create! :name => 'user1'
             @users = User.page(1).per(25)
           end
 
           subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+          it      { should == 'Displaying <b>1</b> user' }
 
           context 'setting the entry name option to "member"' do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-            it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            it      { should == 'Displaying <b>1</b> member' }
           end
         end
 
-        describe 'the next page' do
+        context 'having more than 1 but less than a page of entries' do
           before do
-            @users = User.page(2).per(25)
+            10.times {|i| User.create! :name => "user#{i}"}
+            @users = User.page(1).per(25)
           end
 
           subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying users <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+          it      { should == 'Displaying <b>all 10</b> users' }
 
           context 'setting the entry name option to "member"' do
             subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
-            it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            it      { should == 'Displaying <b>all 10</b> members' }
           end
         end
 
-        describe 'the last page' do
+        context 'having more than one page of entries' do
           before do
-            User.max_pages_per 4
-            @users = User.page(4).per(10)
+            50.times {|i| User.create! :name => "user#{i}"}
           end
 
-          after { User.max_pages_per nil }
+          describe 'the first page' do
+            before do
+              @users = User.page(1).per(25)
+            end
 
-          subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
-          it      { should == 'Displaying users <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total' }
+            subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying members <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+          end
+
+          describe 'the next page' do
+            before do
+              @users = User.page(2).per(25)
+            end
+
+            subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying users <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "member"' do
+              subject { helper.page_entries_info @users, :entry_name => 'member', :params => {:controller => 'users', :action => 'index'} }
+              it      { should == 'Displaying members <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+          end
+
+          describe 'the last page' do
+            before do
+              User.max_pages_per 4
+              @users = User.page(4).per(10)
+            end
+
+            after { User.max_pages_per nil }
+
+            subject { helper.page_entries_info @users, :params => {:controller => 'users', :action => 'index'} }
+            it      { should == 'Displaying users <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total' }
+          end
+        end
+      end
+      context 'on a model with namespace' do
+        before do
+          @addresses = User::Address.page(1).per(25)
+        end
+
+        context 'having no entries' do
+          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'No addresses found' }
+        end
+
+        context 'having 1 entry' do
+          before do
+            User::Address.create!
+            @addresses = User::Address.page(1).per(25)
+          end
+
+          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying <b>1</b> address' }
+
+          context 'setting the entry name option to "place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>1</b> place' }
+          end
+        end
+
+        context 'having more than 1 but less than a page of entries' do
+          before do
+            10.times {|i| User::Address.create!}
+            @addresses = User::Address.page(1).per(25)
+          end
+
+          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+          it      { should == 'Displaying <b>all 10</b> addresses' }
+
+          context 'setting the entry name option to "place"' do
+            subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying <b>all 10</b> places' }
+          end
+        end
+
+        context 'having more than one page of entries' do
+          before do
+            50.times {|i| User::Address.create!}
+          end
+
+          describe 'the first page' do
+            before do
+              @addresses = User::Address.page(1).per(25)
+            end
+
+            subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying addresses <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+            end
+          end
+
+          describe 'the next page' do
+            before do
+              @addresses = User::Address.page(2).per(25)
+            end
+
+            subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
+            it      { should == 'Displaying addresses <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+
+            context 'setting the entry name option to "place"' do
+              subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
+              it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+            end
+          end
         end
       end
     end
-    context 'on a model with namespace' do
+
+    context 'on a model with explicit translation', focus: true do
       before do
-        @addresses = User::Address.page(1).per(25)
+        @cars = Automobile.page(1).per(25)
       end
 
       context 'having no entries' do
-        subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-        it      { should == 'No addresses found' }
+        subject { helper.page_entries_info @cars, :params => {:controller => 'automobiles', :action => 'index'} }
+        it      { should == 'No cars found' }
       end
 
       context 'having 1 entry' do
         before do
-          User::Address.create!
-          @addresses = User::Address.page(1).per(25)
+          Automobile.create!
+          @cars = Automobile.page(1).per(25)
         end
 
-        subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-        it      { should == 'Displaying <b>1</b> address' }
+        subject { helper.page_entries_info @cars, :params => {:controller => 'automobiles', :action => 'index'} }
+        it      { should == 'Displaying <b>1</b> car' }
 
-        context 'setting the entry name option to "place"' do
-          subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying <b>1</b> place' }
+        context 'setting the entry name option to "vehicle"' do
+          subject { helper.page_entries_info @cars, :entry_name => 'vehicle', :params => {:controller => 'automobiles', :action => 'index'} }
+          it      { should == 'Displaying <b>1</b> vehicle' }
         end
       end
 
       context 'having more than 1 but less than a page of entries' do
         before do
-          10.times {|i| User::Address.create!}
-          @addresses = User::Address.page(1).per(25)
+          10.times {|i| Automobile.create!}
+          @cars = Automobile.page(1).per(25)
         end
 
-        subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-        it      { should == 'Displaying <b>all 10</b> addresses' }
+        subject { helper.page_entries_info @cars, :params => {:controller => 'automobiles', :action => 'index'} }
+        it      { should == 'Displaying <b>all 10</b> cars' }
 
-        context 'setting the entry name option to "place"' do
-          subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying <b>all 10</b> places' }
+        context 'setting the entry name option to "vehicle"' do
+          subject { helper.page_entries_info @cars, :entry_name => 'vehicle', :params => {:controller => 'automobiles', :action => 'index'} }
+          it      { should == 'Displaying <b>all 10</b> vehicles' }
         end
       end
 
       context 'having more than one page of entries' do
         before do
-          50.times {|i| User::Address.create!}
+          50.times {|i| Automobile.create!}
         end
 
         describe 'the first page' do
           before do
-            @addresses = User::Address.page(1).per(25)
+            @cars = Automobile.page(1).per(25)
           end
 
-          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying addresses <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+          subject { helper.page_entries_info @cars, :params => {:controller => 'automobiles', :action => 'index'} }
+          it      { should == 'Displaying cars <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
 
-          context 'setting the entry name option to "place"' do
-            subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-            it      { should == 'Displaying places <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
+          context 'setting the entry name option to "vehicle"' do
+            subject { helper.page_entries_info @cars, :entry_name => 'vehicle', :params => {:controller => 'automobiles', :action => 'index'} }
+            it      { should == 'Displaying vehicles <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total' }
           end
         end
 
         describe 'the next page' do
           before do
-            @addresses = User::Address.page(2).per(25)
+            @cars = Automobile.page(2).per(25)
           end
 
-          subject { helper.page_entries_info @addresses, :params => {:controller => 'addresses', :action => 'index'} }
-          it      { should == 'Displaying addresses <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+          subject { helper.page_entries_info @cars, :params => {:controller => 'automobiles', :action => 'index'} }
+          it      { should == 'Displaying cars <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
 
-          context 'setting the entry name option to "place"' do
-            subject { helper.page_entries_info @addresses, :entry_name => 'place', :params => {:controller => 'addresses', :action => 'index'} }
-            it      { should == 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
+          context 'setting the entry name option to "vehicle"' do
+            subject { helper.page_entries_info @cars, :entry_name => 'vehicle', :params => {:controller => 'automobiles', :action => 'index'} }
+            it      { should == 'Displaying vehicles <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total' }
           end
         end
       end


### PR DESCRIPTION
ActiveRecord supports I18n of model names with the key `activerecord.models.[model]`. Kaminari's `page_entries_info` should use this translation for the entry name.

This commit keeps functionality unchanged for untranslated apps, but apps with translations for models will change (for the better, presumably!).

Example:

With these Norwegian translations:

```
  helper.page_entries_info.one_page.display_entries.zero =
    'Ingen %{entry_name} funnet'

  activerecord.models.user = { one: 'bruker', other: 'brukere' }
```

With this commit, `page_entries_info` outputs 'Ingen brukere funnet'. Previously, the output would be 'Ingen users funnet'.
