### PR TITLE
Note page(0) and page(1) return the same results

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,8 @@ Then bundle:
   To fetch the 7th page of users (default +per_page+ is 25)
     User.page(7)
 
+  Note: pagination starts at page 1, not at page 0. (page(0) will return the same results as page(1).)
+
 * the +per+ scope
 
   To show a lot more users per each page (change the +per_page+ value)


### PR DESCRIPTION
I didn't realize that pagination starts at 1 rather than 0, which led to some time debugging this afternoon. If you're amenable to a small change to the readme, noting that point might be useful for others.

Thanks for the great gem!
