### PR TITLE
Fix #570: make per(nil) respect max_per_page

### DIFF
--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,11 +3,11 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if num == 0 || num == '0'
+      n = Integer(num || -1) rescue -1
+      if n == 0
         limit(0)
       else
-        n = num.to_i
-        n = default_per_page if n <= 0
+        n = default_per_page if n < 0
         n = max_per_page if max_per_page && n > max_per_page
         limit(n).offset(offset_value / limit_value * n)
       end

--- a/lib/kaminari/models/page_scope_methods.rb
+++ b/lib/kaminari/models/page_scope_methods.rb
@@ -3,13 +3,12 @@ module Kaminari
     # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
     #   Model.page(3).per(10)
     def per(num)
-      if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
-        self
-      elsif n.zero?
-        limit(n)
-      elsif max_per_page && max_per_page < n
-        limit(max_per_page).offset(offset_value / limit_value * max_per_page)
+      if num == 0 || num == '0'
+        limit(0)
       else
+        n = num.to_i
+        n = default_per_page if n <= 0
+        n = max_per_page if max_per_page && n > max_per_page
         limit(n).offset(offset_value / limit_value * n)
       end
     end

--- a/spec/models/active_record/scopes_spec.rb
+++ b/spec/models/active_record/scopes_spec.rb
@@ -80,11 +80,23 @@ if defined? ActiveRecord
             subject { model_class.page(1).per(5) }
             it { should have(5).users }
             its('first.name') { should == 'user001' }
+
+            context 'with max_per_page < 5' do
+              before { model_class.max_paginates_per 4 }
+              it { should have(4).users }
+              after { model_class.max_paginates_per nil }
+            end
           end
 
           context "page 1 per nil (using default)" do
             subject { model_class.page(1).per(nil) }
             it { should have(model_class.default_per_page).users }
+
+            context 'with max_per_page < default_per_page' do
+              before { model_class.max_paginates_per (model_class.default_per_page - 1) }
+              it { should have(model_class.max_per_page).users }
+              after { model_class.max_paginates_per nil }
+            end
           end
 
           context "page 1 per 0" do


### PR DESCRIPTION
This makes `per` always respect `max_per_page`, fixing #570.  The issue actually applies to any invalid argument, e.g. `per("bad")`. Now, when an invalid argument is given, `per` uses `default_per_page` in its place.
