### PR TITLE
Pluralize entry name in page_entries_info using current locale

### DIFF
--- a/lib/kaminari/helpers/action_view_extension.rb
+++ b/lib/kaminari/helpers/action_view_extension.rb
@@ -91,7 +91,7 @@ module Kaminari
     #   #-> Displaying items 6 - 10 of 26 in total
     def page_entries_info(collection, options = {})
       entry_name = options[:entry_name] || collection.entry_name
-      entry_name = entry_name.pluralize unless collection.total_count == 1
+      entry_name = entry_name.pluralize(collection.total_count, I18n.locale)
 
       if collection.total_pages < 2
         t('helpers.page_entries_info.one_page.display_entries', :entry_name => entry_name, :count => collection.total_count)


### PR DESCRIPTION
Pluralize according to locale when using the `page_entries_info` helper. `String#pluralize` from AS accepts optional parameters for count and locale since Rails 4.

Similar to #775 #694, but uses the method arguments available from Rails `>= 4`
