### PR TITLE
Absolute URL for pagination links

### DIFF
--- a/lib/kaminari/helpers/tags.rb
+++ b/lib/kaminari/helpers/tags.rb
@@ -31,7 +31,7 @@ module Kaminari
       end
 
       def page_url_for(page)
-        @template.url_for params_for(page).merge(:only_path => true)
+        @template.url_for params_for(page).merge(:only_path => false)
       end
 
       private

--- a/spec/helpers/action_view_extension_spec.rb
+++ b/spec/helpers/action_view_extension_spec.rb
@@ -34,7 +34,7 @@ describe 'Kaminari::ActionViewExtension', :if => defined?(::Rails::Railtie) && d
 
     context "total_pages: 3" do
       subject { helper.paginate @users, :total_pages => 3, :params => {:controller => 'users', :action => 'index'} }
-      it { should match(/<a href="\/users\?page=3">Last/) }
+      it { should match(/<a href="http:\/\/test.host\/users\?page=3">Last/) }
     end
 
     context "page: 20 (out of range)" do

--- a/spec/helpers/tags_spec.rb
+++ b/spec/helpers/tags_spec.rb
@@ -11,12 +11,12 @@ describe 'Kaminari::Helpers' do
 
       context "for first page" do
         subject { Tag.new(helper).page_url_for(1) }
-        it { should == "/users" }
+        it { should == "http://test.host/users" }
 
         context 'config.params_on_first_page == false' do
           before { Kaminari.config.params_on_first_page = true }
           after  { Kaminari.config.params_on_first_page = false }
-          it { should == "/users?page=1" }
+          it { should == "http://test.host/users?page=1" }
         end
       end
 
@@ -29,7 +29,7 @@ describe 'Kaminari::Helpers' do
 
         context "for first page" do
           subject { Tag.new(helper).page_url_for(1) }
-          it { should == "/addresses" }
+          it { should == "http://test.host/addresses" }
 
           context 'config.params_on_first_page == false' do
             before { Kaminari.config.params_on_first_page = true }
@@ -40,7 +40,7 @@ describe 'Kaminari::Helpers' do
 
         context "for other page" do
           subject { Tag.new(helper).page_url_for(5) }
-          it { should == "/addresses/page/5" }
+          it { should == "http://test.host/addresses/page/5" }
         end
       end
 


### PR DESCRIPTION
Following the discussion #496, I don't know the background of why the option `:only_path => true` has been added for `rel_next_prev_link_tags`, but I think those link should be full URL.

According to [Official Google Blog](https://webmasters.googleblog.com/2011/09/pagination-with-relnext-and-relprev.html), 

> On the second page, http://www.example.com/article?story=abc&page=2:
> 
> ```
> <link rel="prev" href="http://www.example.com/article?story=abc&page=1" />
> <link rel="next" href="http://www.example.com/article?story=abc&page=3" />
> ```

It also says:

> rel=”next” and rel=”prev” values can be either relative or absolute URLs (as allowed by the <link> tag).

According to [Another official document](https://support.google.com/webmasters/answer/1663744?hl=en):

> In the <head> section of the first page (http://www.example.com/article-part1.html), add a link tag pointing to the next page in the sequence, like this:
> 
> ```
> <link rel="next" href="http://www.example.com/article-part2.html">
> ```

All link tags are specified by full URL. I would say in terms of SEO, full URL is more crawler-friendly.

This pull request make pagination link URLs absolute.

Or, any positive reason why `:only_path => true` was added?
## Reference
- [Official Google Webmaster Central Blog: Pagination with rel=“next” and rel=“prev”](https://webmasters.googleblog.com/2011/09/pagination-with-relnext-and-relprev.html)
- [Indicate paginated content - Search Console Help](https://support.google.com/webmasters/answer/1663744?hl=en)
