### PR TITLE
Remove activerecord 4.0 gemfile from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ namespace :spec do
     active_record_50
     active_record_42
     active_record_41
-    active_record_40
   )
 
   mappers.each do |gemfile|


### PR DESCRIPTION
There is no gemfile for AR 4.0 anymore but it was still referenced in the Rakefile.
