### PR TITLE
replace string eval with define_method

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/paginator.rb
@@ -68,11 +68,9 @@ module Kaminari
       end
 
       %w[first_page prev_page next_page last_page gap].each do |tag|
-        eval <<-DEF
-          def #{tag}_tag
-            @last = #{tag.classify}.new @template, @options
-          end
-        DEF
+        define_method "#{tag}_tag" do
+          @last = tag.classify.constantize.new @template, @options
+        end
       end
 
       def to_s #:nodoc:


### PR DESCRIPTION
I think that is cleaner define dynamic methods using **define_method** instead of passing a string block to **eval**