### PR TITLE
add current and goto translations

### DIFF
--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -8,6 +8,9 @@ en:
       previous: "&lsaquo; Prev"
       next: "Next &rsaquo;"
       truncate: "&hellip;"
+      page:
+        current: "Current"
+        goto: "Go To"
   helpers:
     page_entries_info:
       entry:


### PR DESCRIPTION
Why:

- The `_page.html.erb` file from kaminari_themes uses `<%= t('views.pagination.page.current') %>` and `<%= t('views.pagination.page.goto') %>`, but these translations don't exist in the locale file.

This change addresses the need by:

- Add the two missing translations to the locale file

Reference Links:

- https://github.com/amatsuda/kaminari/blob/master/kaminari-core/config/locales/kaminari.yml
- https://github.com/amatsuda/kaminari_themes/blob/master/semantic_ui/app/views/kaminari/_page.html.erb