### PR TITLE
Coerce num param to int and assign to @_padding

### DIFF
--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -25,8 +25,8 @@ module Kaminari
     end
 
     def padding(num)
-      @_padding = num
-      offset(offset_value + num.to_i)
+      @_padding = num.to_i
+      offset(offset_value + @_padding)
     end
 
     # Total number of pages

--- a/kaminari-core/test/models/active_record/scopes_test.rb
+++ b/kaminari-core/test/models/active_record/scopes_test.rb
@@ -190,6 +190,13 @@ if defined? ActiveRecord
             assert_equal 'user002', relation.first.name
           end
 
+          test 'page 1 per 5 padding "1" (as string)' do
+            relation = model_class.page(1).per(5).padding('1')
+
+            assert_equal 5, relation.count
+            assert_equal 'user002', relation.first.name
+          end
+
           test 'page 19 per 5 padding 5' do
             relation = model_class.page(19).per(5).padding(5)
 


### PR DESCRIPTION
This avoids code failing when calling `Model.padding(params[:padding] || 0)` since `params[:padding]` is a string.