### PR TITLE
Remove the redundant argument of warn

### DIFF
--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -49,7 +49,7 @@ module Kaminari
       end
 
       def max_pages_per(val)
-        ActiveSupport::Deprecation.warn 'max_pages_per is deprecated. Use max_pages instead.', caller_locations(2)
+        ActiveSupport::Deprecation.warn 'max_pages_per is deprecated. Use max_pages instead.'
         max_pages val
       end
     end


### PR DESCRIPTION
When I use `max_pages_per` in Rails4, `warn` raise an error.

In Rails4, `callstack` is `caller` , and it is given by default. https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/deprecation/reporting.rb#L17
In Rails5, `caller_locations(2)` is given by default, too. https://github.com/rails/rails/blob/5-0-stable/activesupport/lib/active_support/deprecation/reporting.rb#L19