### PR TITLE
Fix URL generation when explicitly passing params to link helpers

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -27,6 +27,7 @@ module Kaminari
         # params in Rails 5 may not be a Hash either,
         # so it must be converted to a Hash to be merged into @params
         unless params.empty?
+          ActiveSupport::Deprecation.warn 'Explicitly passing params to helpers could be removed in the future.'
           params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
           params = params.with_indifferent_access
           @params.merge! params

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -24,7 +24,7 @@ module Kaminari
         @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
         @params = @params.with_indifferent_access
         @params.except!(*PARAM_KEY_BLACKLIST)
-        @params.merge! params
+        @params.reverse_merge! params
       end
 
       def to_s(locals = {}) #:nodoc:

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -24,7 +24,13 @@ module Kaminari
         @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
         @params = @params.with_indifferent_access
         @params.except!(*PARAM_KEY_BLACKLIST)
-        @params.reverse_merge! params
+        # params in Rails 5 may not be a Hash either,
+        # so it must be converted to a Hash to be merged into @params
+        unless params.empty?
+          params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
+          params = params.with_indifferent_access
+          @params.merge! params
+        end
       end
 
       def to_s(locals = {}) #:nodoc:

--- a/kaminari-core/test/helpers/tags_test.rb
+++ b/kaminari-core/test/helpers/tags_test.rb
@@ -67,6 +67,20 @@ if defined?(::Rails::Railtie) && defined?(ActionView)
         end
       end
 
+      sub_test_case "when passing nested params" do
+        setup do
+          self.params[:filter] = ActionController::Parameters.new({status: 'active'})
+        end
+
+        test 'for first page' do
+          assert_match(/users\?filter%5Bstatus%5D=active/, Kaminari::Helpers::Tag.new(self, params: self.params).page_url_for(1))
+        end
+
+        test 'for other page' do
+          assert_match(/users\?filter%5Bstatus%5D=active&page=2/, Kaminari::Helpers::Tag.new(self, params: self.params).page_url_for(2))
+        end
+      end
+
       sub_test_case "with param_name = 'foo.page' option" do
         setup do
           self.params['foo.page'] = 2


### PR DESCRIPTION
This resolves #873 

As I described in [this comment](https://github.com/kaminari/kaminari/issues/873#issuecomment-285118485), `params` may have nested `ActionController::Parameters` .

Although Kaminari converts `ActionController::Parameters` to `Hash` in initializer of `Kaminari::Helpers::Tag` in order to pass it to `url_for` helper for URL generation, `ActionController::Parameters` in explicitly passed `params` remain as it was because `merge!` won't replace other hash's values if keys are already exist.

So, I have simply changed `merge!` to `reverse_merge!` to have an expected result. How does this sound to you?

In addition to that, on the edge Rails `url_for` helper seems to have been improved to take `ActionController::Parameters` as an argument. I am not sure if Kaminiari requires additional changes for Rails' changes.