### PR TITLE
Add ability to inspect current value of per_page

### DIFF
--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -19,7 +19,7 @@ module Kaminari
 
     def max_paginates_per(new_max_per_page)
       @_max_per_page = new_max_per_page
-      per ((defined?(@_per) && @_per) || default_per_page), max_per_page: new_max_per_page
+      per current_per_page, max_per_page: new_max_per_page
     end
 
     def padding(num)
@@ -50,6 +50,11 @@ module Kaminari
       (offset_without_padding / limit_value) + 1
     rescue ZeroDivisionError
       raise ZeroPerPageOperation, "Current page was incalculable. Perhaps you called .per(0)?"
+    end
+
+    # Current per-page number
+    def current_per_page
+      (defined?(@_per) && @_per) || default_per_page
     end
 
     # Next page number in the collection

--- a/kaminari-core/test/models/active_record/scopes_test.rb
+++ b/kaminari-core/test/models/active_record/scopes_test.rb
@@ -293,6 +293,20 @@ if defined? ActiveRecord
           end
         end
 
+        sub_test_case '#current_per_page' do
+          test 'per 0' do
+            assert_equal 0, model_class.page.per(0).current_per_page
+          end
+
+          test 'no per specified' do
+            assert_equal model_class.default_per_page, model_class.page.current_per_page
+          end
+
+          test 'per specified as 42' do
+            assert_equal 42, model_class.page.per(42).current_per_page
+          end
+        end
+
         sub_test_case '#next_page' do
           test 'page 1' do
             assert_equal 2, model_class.page.next_page


### PR DESCRIPTION
Found a use case where it is helpful to know what the current per-page value is set to, and I'm contributing it back.