### PR TITLE
fix bug last_page? wrong when current_page is 1 and total_pages is 0 (version 1.0.1)

### DIFF
--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -69,7 +69,7 @@ module Kaminari
 
     # Last page of the collection?
     def last_page?
-      current_page == total_pages
+      current_page >= total_pages
     end
 
     # Out of range of the collection?

--- a/kaminari-core/test/models/active_record/scopes_test.rb
+++ b/kaminari-core/test/models/active_record/scopes_test.rb
@@ -337,7 +337,7 @@ if defined? ActiveRecord
           end
 
           test 'out of range' do
-            assert_false model_class.page(11).per(10).last_page?
+            assert_true model_class.page(11).per(10).last_page?
           end
         end
 


### PR DESCRIPTION
I found a bug when when `current_page is 1` and `total_pages is 0` (There last page is also last page in this case)
When I tried to query like this: User.where(id: 'not_exist').page(1).per(10)
Then last_page? is `false` But it's should be `true`.
Please review and comfirm if I am correct. thanks