### PR TITLE
Mandatory ordering flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ end
 
 ### Mandatory ordering
 
-When `mandatory_ordering` option is set to truthy value, calling `page` methon on un-ordered collection will raise `Kaminari::CollectionNotOrderedError` error.
+When `mandatory_ordering` option is set to truthy value, calling `page` method on un-ordered collection will raise `Kaminari::CollectionNotOrderedError` error.
 If no order is set, databases can choose to return records in arbitrary sequence, preventing you from reliably iterating through them.
 
 ## Controllers

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can configure the following default values by overriding these values using 
     page_method_name      # :page by default
     param_name            # :page by default
     params_on_first_page  # false by default
+    mandatory_ordering    # false by default
 
 There's a handy generator that generates the default configuration file into config/initializers directory.
 Run the following generator command, then edit the generated file.
@@ -170,6 +171,10 @@ class User < ActiveRecord::Base
 end
 ```
 
+### Mandatory ordering
+
+When `mandatory_ordering` option is set to truthy value, calling `page` methon on un-ordered collection will raise `Kaminari::CollectionNotOrderedError` error.
+If no order is set, databases can choose to return records in arbitrary sequence, preventing you from reliably iterating through them.
 
 ## Controllers
 

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -10,15 +10,19 @@ module Kaminari
     included do
       include Kaminari::ConfigurationMethods
 
+      mandatory_ordering_check = <<-RUBY
+        if all.values.fetch(:order, []).none?
+          raise Kaminari::CollectionNotOrderedError
+        end
+      RUBY
+
       # Fetch the values at the specified page number
       #   Model.page(5)
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
         def self.#{Kaminari.config.page_method_name}(num = nil)
           per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
 
-          if Kaminari.config.mandatory_ordering && all.values.fetch(:order, []).none?
-            raise Kaminari::CollectionNotOrderedError
-          end
+          #{Kaminari.config.mandatory_ordering ? mandatory_ordering_check : ''}
 
           limit(per_page).offset(per_page * ((num = num.to_i - 1) < 0 ? 0 : num)).extending do
             include Kaminari::ActiveRecordRelationMethods

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -2,6 +2,8 @@
 require 'kaminari/activerecord/active_record_relation_methods'
 
 module Kaminari
+  class CollectionNotOrderedError < RuntimeError; end
+
   module ActiveRecordModelExtension
     extend ActiveSupport::Concern
 
@@ -13,6 +15,11 @@ module Kaminari
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
         def self.#{Kaminari.config.page_method_name}(num = nil)
           per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
+
+          if Kaminari.config.mandatory_ordering && all.values.fetch(:order, []).none?
+            raise Kaminari::CollectionNotOrderedError
+          end
+
           limit(per_page).offset(per_page * ((num = num.to_i - 1) < 0 ? 0 : num)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods

--- a/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
+++ b/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
@@ -9,4 +9,5 @@ Kaminari.configure do |config|
   # config.page_method_name = :page
   # config.param_name = :page
   # config.params_on_first_page = false
+  # config.mandatory_ordering = false
 end

--- a/kaminari-core/lib/kaminari/config.rb
+++ b/kaminari-core/lib/kaminari/config.rb
@@ -19,6 +19,7 @@ module Kaminari
     self.param_name = :page
     self.max_pages = nil
     self.params_on_first_page = false
+    self.mandatory_ordering = false
 
     # If param_name was given as a callable object, call it when returning
     def param_name

--- a/kaminari-core/test/models/active_record/mandatory_ordering_test.rb
+++ b/kaminari-core/test/models/active_record/mandatory_ordering_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+if defined? ActiveRecord
+  class ActiveRecordMandatoryOrderingTest < ActiveSupport::TestCase
+    def with_mandatory_ordering_flag(mandatory_ordering_flag)
+      Kaminari.configure { |config| config.mandatory_ordering = mandatory_ordering_flag }
+
+      yield
+    ensure
+      Kaminari.configure {|config| config.mandatory_ordering = false }
+    end
+
+    test 'Raises error when mandatory ordering is enabled and paged relation is not ordered' do
+      with_mandatory_ordering_flag(true) do
+        assert_raise Kaminari::CollectionNotOrderedError do
+          User.page(1)
+        end
+      end
+    end
+
+    test 'Does not raise error when mandatory ordering is enabled and paged relation is ordered' do
+      with_mandatory_ordering_flag(true) do
+        assert_nothing_raised do
+          User.order(:id).page(1)
+        end
+      end
+    end
+
+    test 'Does not raise error when mandatory ordering is disabled and paged relation is not ordered' do
+      with_mandatory_ordering_flag(false) do
+        assert_nothing_raised do
+          User.page(1)
+        end
+      end
+    end
+
+    test 'Should recognize order set in default scope' do
+      with_mandatory_ordering_flag(true) do
+        klass = Class.new(ActiveRecord::Base) do
+          self.table_name = 'users'
+          default_scope { order(:id) }
+        end
+
+        assert_nothing_raised do
+          klass.page(1)
+        end
+      end
+    end
+  end
+end
+
+

--- a/kaminari-core/test/models/active_record/mandatory_ordering_test.rb
+++ b/kaminari-core/test/models/active_record/mandatory_ordering_test.rb
@@ -6,44 +6,47 @@ if defined? ActiveRecord
     def with_mandatory_ordering_flag(mandatory_ordering_flag)
       Kaminari.configure { |config| config.mandatory_ordering = mandatory_ordering_flag }
 
-      yield
+      model = Class.new(ActiveRecord::Base) do
+        self.table_name = 'users'
+      end
+
+      yield model
     ensure
       Kaminari.configure {|config| config.mandatory_ordering = false }
     end
 
     test 'Raises error when mandatory ordering is enabled and paged relation is not ordered' do
-      with_mandatory_ordering_flag(true) do
+      with_mandatory_ordering_flag(true) do |model|
         assert_raise Kaminari::CollectionNotOrderedError do
-          User.page(1)
+          model.page(1)
         end
       end
     end
 
     test 'Does not raise error when mandatory ordering is enabled and paged relation is ordered' do
-      with_mandatory_ordering_flag(true) do
+      with_mandatory_ordering_flag(true) do |model|
         assert_nothing_raised do
-          User.order(:id).page(1)
+          model.order(:id).page(1)
         end
       end
     end
 
     test 'Does not raise error when mandatory ordering is disabled and paged relation is not ordered' do
-      with_mandatory_ordering_flag(false) do
+      with_mandatory_ordering_flag(false) do |model|
         assert_nothing_raised do
-          User.page(1)
+          model.page(1)
         end
       end
     end
 
     test 'Should recognize order set in default scope' do
-      with_mandatory_ordering_flag(true) do
-        klass = Class.new(ActiveRecord::Base) do
-          self.table_name = 'users'
-          default_scope { order(:id) }
+      with_mandatory_ordering_flag(true) do |model|
+        model.define_singleton_method(:default_scope) do
+          order(:id)
         end
 
         assert_nothing_raised do
-          klass.page(1)
+          model.page(1)
         end
       end
     end


### PR DESCRIPTION
Every now and then I run into hard-to-debug problems caused by forgetting to order an ActiveRecord relation before paging over it.

This would allow me to catch this category of problem much easier.