### PR TITLE
Try to fix @output_buffer error caused by capture

### DIFF
--- a/kaminari-core/test/fake_app/views/kaminari/output_buffer/_first_page.html.erb
+++ b/kaminari-core/test/fake_app/views/kaminari/output_buffer/_first_page.html.erb
@@ -1,0 +1,1 @@
+<b><%= current_page %></b>

--- a/kaminari-core/test/fake_app/views/kaminari/output_buffer/_page.html.erb
+++ b/kaminari-core/test/fake_app/views/kaminari/output_buffer/_page.html.erb
@@ -1,0 +1,1 @@
+<li><%= link_to page, url %></li>

--- a/kaminari-core/test/fake_app/views/kaminari/output_buffer/_paginator.html.erb
+++ b/kaminari-core/test/fake_app/views/kaminari/output_buffer/_paginator.html.erb
@@ -1,0 +1,13 @@
+<%= paginator.render do %>
+  <%= form_tag '#' do %>
+    <%= number_field_tag :per_page %>
+    <%= first_page_tag %>
+    <% each_page do |page| %>
+      <%= page_tag(page) %>
+      <p>hello</p>
+    <% end %>
+  <% end %>
+  <% each_page do |page| %>
+    <%= page_tag(page) %>
+  <% end %>
+<% end %>

--- a/kaminari-core/test/helpers/helpers_test.rb
+++ b/kaminari-core/test/helpers/helpers_test.rb
@@ -13,12 +13,8 @@ class PaginatorHelperTest < ActiveSupport::TestCase
       link_to { "<a href='#'>link</a>" }
       output_buffer { defined?(ActionView) ? ::ActionView::OutputBuffer.new : ::ActiveSupport::SafeBuffer.new }
     end
+    r.params
     r
-  end
-
-  test 'view helper methods delegated to template' do
-    paginator = Paginator.new(template, params: {})
-    assert_equal "<a href='#'>link</a>", paginator.link_to('link', '#')
   end
 
   sub_test_case '#params' do


### PR DESCRIPTION
When I use form_tag inside paginator.render block (the template may like below, also in test case), the output is incorrect.

```ruby
# kaminari-core/test/fake_app/views/kaminari/output_buffer/_paginator.html.erb
<%= paginator.render do %>
  <%= form_tag '#' do %>
    <%= number_field_tag :per_page %>
    <%= first_page_tag %>
    <% each_page do |page| %>
      <%= page_tag(page) %>
      <p>hello</p>
    <% end %>
  <% end %>
  <% each_page do |page| %>
    <%= page_tag(page) %>
  <% end %>
<% end %>
```
The test case in this PR reproduces this scenario.

The reason is that methods like form_tag which call `capture` in Rails(https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/capture_helper.rb#L37-L43 and https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/capture_helper.rb#L195-L207).


But I think that my PR is not a perfect solution.