### PR TITLE
Add `require kaminari/core` to kaminari-activerecord

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord.rb
@@ -3,6 +3,7 @@ require "kaminari/activerecord/version"
 require 'active_support/lazy_load_hooks'
 
 ActiveSupport.on_load :active_record do
+  require 'kaminari/core'
   require 'kaminari/activerecord/active_record_extension'
   ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
 end


### PR DESCRIPTION
I tried to use kaminari-activerecord in my Sinatra app, and noticed that two `require`'s are actually needed:

Gemfile:

    gem 'kaminari-activerecord'

app.rb:

    require 'kaminari/core'  # error is raised without this
    require 'kaminari/activerecord'

This PR allows you to load this gem just by:

    require 'kaminari/activerecord'