### PR TITLE
add pluralization based on locale setup for any language

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -99,7 +99,7 @@ module Kaminari
       #   #-> Displaying items 6 - 10 of 26 in total
       def page_entries_info(collection, entry_name: nil)
         entry_name = if entry_name
-                       entry_name.pluralize(collection.size)
+                       entry_name.pluralize(collection.size, I18n.locale)
                      else
                        collection.entry_name(count: collection.size).downcase
                      end

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -270,49 +270,39 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
         end
 
         sub_test_case 'with any other locale' do
+          teardown do
+            I18n.backend.reload!
+          end
+
           sub_test_case ':de' do
             setup do
               I18n.locale = :de
+              I18n.backend.store_translations(:de,
+                helpers: {
+                  page_entries_info: {
+                    one_page: {
+                      display_entries: {
+                        one: "Displaying <b>1</b> %{entry_name}",
+                        other: "Displaying <b>all %{count}</b> %{entry_name}"
+                      }
+                    },
+                    more_pages: {
+                      display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+                    }
+                  }
+                }
+              )
             end
 
             test 'with default entry name' do
               users = User.page(1).per(50)
-              begin
-                I18n.backend.store_translations(:de,
-                  helpers: {
-                    page_entries_info: {
-                      one_page: {
-                        display_entries: {
-                          one: "Displaying <b>1</b> %{entry_name}",
-                          other: "Displaying <b>all %{count}</b> %{entry_name}"
-                        }
-                      }
-                    }
-                  }
-                )
-                assert_equal 'Displaying <b>all 50</b> Benutzer', view.page_entries_info(users,  entry_name: 'Benutzer')
-              ensure
-                I18n.backend.reload!
-              end
+              assert_equal 'Displaying <b>all 50</b> Benutzer', view.page_entries_info(users,  entry_name: 'Benutzer')
             end
 
             test 'the last page with default entry name' do
               User.max_pages 4
               users = User.page(4).per(10)
-              begin
-                I18n.backend.store_translations(:de,
-                  helpers: {
-                    page_entries_info: {
-                      more_pages: {
-                        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
-                      }
-                    }
-                  }
-                )
-                assert_equal 'Displaying Benutzer <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'Benutzer')
-              ensure
-                I18n.backend.reload!
-              end
+              assert_equal 'Displaying Benutzer <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'Benutzer')
             end
           end
         end
@@ -324,6 +314,21 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
               inflect.plural(/$/, 's')
               inflect.singular(/s$/, '')
             end
+            I18n.backend.store_translations(:fr,
+              helpers: {
+                page_entries_info: {
+                  one_page: {
+                    display_entries: {
+                      one: "Displaying <b>1</b> %{entry_name}",
+                      other: "Displaying <b>all %{count}</b> %{entry_name}"
+                    }
+                  },
+                  more_pages: {
+                    display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+                  }
+                }
+              }
+            )
           end
 
           sub_test_case 'having 1 entry' do
@@ -334,64 +339,19 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
 
             test 'with default entry name' do
               users = User.page(1).per(25)
-              begin
-                I18n.backend.store_translations(:fr,
-                  helpers: {
-                    page_entries_info: {
-                      one_page: {
-                        display_entries: {
-                          one: "Displaying <b>1</b> %{entry_name}",
-                          other: "Displaying <b>all %{count}</b> %{entry_name}"
-                        }
-                      }
-                    }
-                  }
-                  )
-                assert_equal 'Displaying <b>1</b> utilisateur', view.page_entries_info(users,  entry_name: 'utilisateur')
-              ensure
-                I18n.backend.reload!
-              end
+              assert_equal 'Displaying <b>1</b> utilisateur', view.page_entries_info(users,  entry_name: 'utilisateur')
             end
           end
 
           test 'having multiple entries with default entry name' do
             users = User.page(1).per(50)
-            begin
-              I18n.backend.store_translations(:fr,
-                helpers: {
-                  page_entries_info: {
-                    one_page: {
-                      display_entries: {
-                        one: "Displaying <b>1</b> %{entry_name}",
-                        other: "Displaying <b>all %{count}</b> %{entry_name}"
-                      }
-                    }
-                  }
-                }
-                )
-              assert_equal 'Displaying <b>all 50</b> utilisateurs', view.page_entries_info(users,  entry_name: 'utilisateur')
-            ensure
-              I18n.backend.reload!
-            end
+            assert_equal 'Displaying <b>all 50</b> utilisateurs', view.page_entries_info(users,  entry_name: 'utilisateur')
           end
 
           test 'the last page with default entry name' do
             User.max_pages 4
             users = User.page(4).per(10)
-            begin
-              I18n.backend.store_translations(:fr,
-                helpers: {
-                  page_entries_info: {
-                    more_pages: {
-                      display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
-                    }
-                  }
-                }
-              )
-              assert_equal 'Displaying utilisateurs <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'utilisateur')
-            ensure
-              I18n.backend.reload!
-            end
+            assert_equal 'Displaying utilisateurs <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'utilisateur')
           end
         end
       end

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -5,6 +5,8 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
   class ActionViewExtensionTest < ActionView::TestCase
     setup do
       self.output_buffer = ::ActionView::OutputBuffer.new
+      I18n.available_locales = [:en, :de, :fr]
+      I18n.locale = :en
     end
     teardown do
       User.delete_all
@@ -264,6 +266,132 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
             assert_equal 'Displaying people <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total', view.page_entries_info(users)
           ensure
             I18n.backend.reload!
+          end
+        end
+
+        sub_test_case 'with any other locale' do
+          sub_test_case ':de' do
+            setup do
+              I18n.locale = :de
+            end
+
+            test 'with default entry name' do
+              users = User.page(1).per(50)
+              begin
+                I18n.backend.store_translations(:de,
+                  helpers: {
+                    page_entries_info: {
+                      one_page: {
+                        display_entries: {
+                          one: "Displaying <b>1</b> %{entry_name}",
+                          other: "Displaying <b>all %{count}</b> %{entry_name}"
+                        }
+                      }
+                    }
+                  }
+                )
+                assert_equal 'Displaying <b>all 50</b> Benutzer', view.page_entries_info(users,  entry_name: 'Benutzer')
+              ensure
+                I18n.backend.reload!
+              end
+            end
+
+            test 'the last page with default entry name' do
+              User.max_pages 4
+              users = User.page(4).per(10)
+              begin
+                I18n.backend.store_translations(:de,
+                  helpers: {
+                    page_entries_info: {
+                      more_pages: {
+                        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+                      }
+                    }
+                  }
+                )
+                assert_equal 'Displaying Benutzer <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'Benutzer')
+              ensure
+                I18n.backend.reload!
+              end
+            end
+          end
+        end
+
+        sub_test_case ':fr' do
+          setup do
+            I18n.locale = :fr
+            ActiveSupport::Inflector.inflections(:fr) do |inflect|
+              inflect.plural(/$/, 's')
+              inflect.singular(/s$/, '')
+            end
+          end
+
+          sub_test_case 'having 1 entry' do
+            setup do
+              User.delete_all
+              User.create! name: 'user1'
+            end
+
+            test 'with default entry name' do
+              users = User.page(1).per(25)
+              begin
+                I18n.backend.store_translations(:fr,
+                  helpers: {
+                    page_entries_info: {
+                      one_page: {
+                        display_entries: {
+                          one: "Displaying <b>1</b> %{entry_name}",
+                          other: "Displaying <b>all %{count}</b> %{entry_name}"
+                        }
+                      }
+                    }
+                  }
+                  )
+                assert_equal 'Displaying <b>1</b> utilisateur', view.page_entries_info(users,  entry_name: 'utilisateur')
+              ensure
+                I18n.backend.reload!
+              end
+            end
+          end
+
+          test 'having multiple entries with default entry name' do
+            users = User.page(1).per(50)
+            begin
+              I18n.backend.store_translations(:fr,
+                helpers: {
+                  page_entries_info: {
+                    one_page: {
+                      display_entries: {
+                        one: "Displaying <b>1</b> %{entry_name}",
+                        other: "Displaying <b>all %{count}</b> %{entry_name}"
+                      }
+                    }
+                  }
+                }
+                )
+              assert_equal 'Displaying <b>all 50</b> utilisateurs', view.page_entries_info(users,  entry_name: 'utilisateur')
+            ensure
+              I18n.backend.reload!
+            end
+          end
+
+          test 'the last page with default entry name' do
+            User.max_pages 4
+            users = User.page(4).per(10)
+            begin
+              I18n.backend.store_translations(:fr,
+                helpers: {
+                  page_entries_info: {
+                    more_pages: {
+                      display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+                    }
+                  }
+                }
+              )
+              assert_equal 'Displaying utilisateurs <b>31&nbsp;-&nbsp;40</b> of <b>50</b> in total', view.page_entries_info(users,  entry_name: 'utilisateur')
+            ensure
+              I18n.backend.reload!
+            end
           end
         end
       end


### PR DESCRIPTION
this solves the issue with using .pluralize for languages like :de etc, that dont always add `s` on the end of the pluralized words