### PR TITLE
Remove magic comment

### DIFF
--- a/kaminari-actionview/kaminari-actionview.gemspec
+++ b/kaminari-actionview/kaminari-actionview.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/kaminari-activerecord/kaminari-activerecord.gemspec
+++ b/kaminari-activerecord/kaminari-activerecord.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/kaminari-core/kaminari-core.gemspec
+++ b/kaminari-core/kaminari-core.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/kaminari.gemspec
+++ b/kaminari.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "kaminari/version"


### PR DESCRIPTION
Since the support version is Ruby 2.0 or later, magic comment is unnecessary.

`The UTF-8 default encoding, which make many magic comments omissible`
https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/