### PR TITLE
Add without count paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,13 @@ In your view file, you can only use simple helpers like the following instead of
 <%= link_to_next_page @users, 'Next Page' %>
 ```
 
+Or use a `without_count` and `paginate` methods:
+
+```erb
+<%= @users = User.page(3).without_count %>
+<%= paginate @users %>
+```
+
 
 ## Paginating a Generic Array object
 

--- a/kaminari-core/app/views/kaminari/_without_count_paginator.html.erb
+++ b/kaminari-core/app/views/kaminari/_without_count_paginator.html.erb
@@ -1,0 +1,24 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/kaminari-core/app/views/kaminari/_without_count_paginator.html.haml
+++ b/kaminari-core/app/views/kaminari/_without_count_paginator.html.haml
@@ -1,0 +1,17 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %nav.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?

--- a/kaminari-core/app/views/kaminari/_without_count_paginator.html.slim
+++ b/kaminari-core/app/views/kaminari/_without_count_paginator.html.slim
@@ -1,0 +1,18 @@
+/ The container tag
+  - available local variables
+    current_page : a page object for the currently displayed page
+    total_pages  : total number of pages
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+    paginator    : the paginator that renders the pagination tags inside
+
+== paginator.render do
+  nav.pagination
+    == first_page_tag unless current_page.first?
+    == prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag unless current_page.last?

--- a/kaminari-core/lib/kaminari/core.rb
+++ b/kaminari-core/lib/kaminari/core.rb
@@ -13,6 +13,7 @@ end
 require 'kaminari/config'
 require 'kaminari/exceptions'
 require 'kaminari/helpers/paginator'
+require 'kaminari/helpers/without_count_paginator'
 require 'kaminari/models/page_scope_methods'
 require 'kaminari/models/configuration_methods'
 require 'kaminari/models/array_extension'

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -18,8 +18,15 @@ module Kaminari
       # * <tt>:paginator_class</tt> - Specify a custom Paginator (Kaminari::Helpers::Paginator by default)
       # * <tt>:template</tt> - Specify a custom template renderer for rendering the Paginator (receiver by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
-      def paginate(scope, paginator_class: Kaminari::Helpers::Paginator, template: nil, **options)
-        options[:total_pages] ||= scope.total_pages
+      def paginate(scope, paginator_class: nil, template: nil, **options)
+        if scope.singleton_class.include?(::Kaminari::PaginatableWithoutCount)
+          paginator_class ||= Kaminari::Helpers::WithoutCountPaginator
+          options[:total_pages] ||= scope.any? ? 999_999_999 : scope.current_page
+        else
+          paginator_class ||= Kaminari::Helpers::Paginator
+          options[:total_pages] ||= scope.total_pages
+        end
+
         options.reverse_merge! current_page: scope.current_page, per_page: scope.limit_value, remote: false
 
         paginator = paginator_class.new (template || self), options

--- a/kaminari-core/lib/kaminari/helpers/without_count_paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/without_count_paginator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'kaminari/helpers/paginator'
+
+module Kaminari
+  module Helpers
+    class WithoutCountPaginator < Paginator
+      private :relevant_pages
+
+      def relevant_pages(options)
+        super.select { |page| page <= options[:current_page].to_i }
+      end
+    end
+  end
+end

--- a/kaminari-core/test/fake_app/rails_app.rb
+++ b/kaminari-core/test/fake_app/rails_app.rb
@@ -20,6 +20,7 @@ Rails.application.initialize!
 Rails.application.routes.draw do
   resources :users do
     get 'index_text(.:format)', action: :index_text, on: :collection
+    get 'index_without_count', action: :index_without_count, on: :collection
   end
   resources :addresses do
     get 'page/:page', action: :index, on: :collection
@@ -45,6 +46,14 @@ ERB
 
   def index_text
     @users = User.page params[:page]
+  end
+
+  def index_without_count
+    @users = User.page(params[:page]).per(5).without_count
+    render inline: <<-ERB
+<%= @users.map(&:name).join("\n") %>
+<%= paginate @users %>
+ERB
   end
 end
 

--- a/kaminari-core/test/requests/navigation_test.rb
+++ b/kaminari-core/test/requests/navigation_test.rb
@@ -14,65 +14,101 @@ class NavigationTest < Test::Unit::TestCase
     User.delete_all
   end
 
-  test 'navigating by pagination links' do
+  def go_to_next_page
+    within('span.next') { click_link 'Next ›' }
+  end
+
+  def go_to_prev_page
+    within('span.prev') { click_link '‹ Prev' }
+  end
+
+  def go_to_first_page
+    within('span.first') { click_link '« First' }
+  end
+
+  def go_to_last_page
+    within('span.last') { click_link 'Last »' }
+  end
+
+  def assert_current_page(page_num)
+    within 'span.page.current' do
+      assert page.has_content? page_num
+    end
+  end
+
+  def within_navigation(&block)
+    within 'nav.pagination', &block
+  end
+
+  test 'navigating by pagination links (with Paginator)' do
     visit '/users'
 
     assert page.has_no_content? 'previous page'
     assert page.has_content? 'next page'
 
-    within 'nav.pagination' do
-      within 'span.page.current' do
-        assert page.has_content? '1'
-      end
-      within 'span.next' do
-        click_link 'Next ›'
-      end
+    within_navigation do
+      assert_current_page(1)
+      go_to_next_page
     end
 
     assert page.has_content? 'previous page'
     assert page.has_content? 'next page'
 
-    within 'nav.pagination' do
-      within 'span.page.current' do
-        assert page.has_content? '2'
-      end
-      within 'span.last' do
-        click_link 'Last »'
-      end
+    within_navigation do
+      assert_current_page(2)
+      go_to_last_page
     end
 
     assert page.has_content? 'previous page'
     assert page.has_no_content? 'next page'
 
-    within 'nav.pagination' do
-      within 'span.page.current' do
-        assert page.has_content? '4'
-      end
-      within 'span.prev' do
-        click_link '‹ Prev'
-      end
+    within_navigation do
+      assert_current_page(4)
+      go_to_prev_page
     end
 
     assert page.has_content? 'previous page'
     assert page.has_content? 'next page'
 
-    within 'nav.pagination' do
-      within 'span.page.current' do
-        assert page.has_content? '3'
-      end
-      within 'span.first' do
-        click_link '« First'
-      end
+    within_navigation do
+      assert_current_page(3)
+      go_to_first_page
     end
 
-    within 'nav.pagination' do
-      within 'span.page.current' do
-        assert page.has_content? '1'
-      end
+    within_navigation do
+      assert_current_page(1)
     end
 
     within 'div.info' do
       assert page.has_text? 'Displaying users 1'
+    end
+  end
+
+  test 'navigating by pagination links (with WithoutCountPaginator)' do
+    visit '/users/index_without_count'
+
+    within_navigation do
+      assert_current_page(1)
+      go_to_next_page
+    end
+
+    within_navigation do
+      assert_current_page(2)
+      go_to_next_page
+    end
+
+    within_navigation do
+      assert_current_page(3)
+      go_to_prev_page
+    end
+
+    within_navigation do
+      assert_current_page(2)
+      go_to_first_page
+    end
+
+    within_navigation do
+      assert_current_page(1)
     end
   end
 end


### PR DESCRIPTION
### Overview

Added WithoutCountPaginator. It simplifies using of `.without_count` and pagination templates. I am going to use it for optimizing rails admin (https://github.com/sferik/rails_admin/issues/2699)