### PR TITLE
Fixed a bug where two variations of COUNT request is fired

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -100,16 +100,18 @@ module Kaminari
       #   <%= page_entries_info @posts, entry_name: 'item' %>
       #   #-> Displaying items 6 - 10 of 26 in total
       def page_entries_info(collection, entry_name: nil)
+        number_of_entries = collection.total_count
+
         entry_name = if entry_name
-                       entry_name.pluralize(collection.size, I18n.locale)
+                       entry_name.pluralize(number_of_entries, I18n.locale)
                      else
-                       collection.entry_name(count: collection.size).downcase
+                       collection.entry_name(count: number_of_entries).downcase
                      end
 
         if collection.total_pages < 2
-          t('helpers.page_entries_info.one_page.display_entries', entry_name: entry_name, count: collection.total_count)
+          t('helpers.page_entries_info.one_page.display_entries', entry_name: entry_name, count: number_of_entries)
         else
-          t('helpers.page_entries_info.more_pages.display_entries', entry_name: entry_name, first: collection.offset_value + 1, last: [collection.offset_value + collection.limit_value, collection.total_count].min, total: collection.total_count)
+          t('helpers.page_entries_info.more_pages.display_entries', entry_name: entry_name, first: collection.offset_value + 1, last: [collection.offset_value + collection.limit_value, number_of_entries].min, total: number_of_entries)
         end.html_safe
       end
 


### PR DESCRIPTION
With patch: 

```
 Rendering search/index.html.erb within layouts/application
   (28.0ms)  SELECT COUNT(*) FROM "items" WHERE "items"."public" = $1 AND (subject ILIKE '%something%' OR body ILIKE '%something%')  [["public", "t"]]
  Item Exists (2.7ms)  SELECT  1 AS one FROM "items" WHERE "items"."public" = $1 AND (subject ILIKE '%something%' OR body ILIKE '%something%') LIMIT $2 OFFSET $3  [["public", "t"], ["LIMIT", 1], ["OFFSET", 0]]
```

Without patch:

```
  Rendering search/index.html.erb within layouts/application
   (28.8ms)  SELECT COUNT(*) FROM (SELECT  1 FROM "items" WHERE "items"."public" = $1 AND (subject ILIKE '%something%' OR body ILIKE '%something%') ORDER BY "items"."time" DESC LIMIT $2 OFFSET $3) subquery_for_count  [["public", "t"], ["LIMIT", 10], ["OFFSET", 0]]
   (25.8ms)  SELECT COUNT(*) FROM "items" WHERE "items"."public" = $1 AND (subject ILIKE '%something%' OR body ILIKE '%something%')  [["public", "t"]]
  Item Exists (2.5ms)  SELECT  1 AS one FROM "items" WHERE "items"."public" = $1 AND (subject ILIKE '%something%' OR body ILIKE '%something%') LIMIT $2 OFFSET $3  [["public", "t"], ["LIMIT", 1], ["OFFSET", 0]]
```

For huge array of selected items firing COUNT request twice (in different forms — thus, preventing AR caching) effectively doubles page rendering time.

This happens when view template includes both `page_entries_info` and `paginate`:

```
<%= page_entries_info @items %>
<%= paginate @items %>
```