### PR TITLE
Fix total_count on loaded relation

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -21,8 +21,7 @@ module Kaminari
         # Total count has to be 0 if loaded records are 0
         return @total_count = 0 if (current_page == 1) && @records.empty?
         # Total count is calculable at the last page
-        per_page = (defined?(@_per) && @_per) || default_per_page
-        return @total_count = (current_page - 1) * per_page + @records.length if @records.any? && (@records.length < per_page)
+        return @total_count = (current_page - 1) * limit_value + @records.length if @records.any? && (@records.length < limit_value)
       end
 
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -30,7 +30,7 @@ if defined? ActiveRecord
         assert_equal 7, User.page(2).per(2).total_count
       end
 
-      test 'total_count on loded Relation' do
+      test 'total_count on loaded Relation' do
         assert_equal 0, User.where('1 = 0').page(1).load.total_count
         assert_equal 0, User.where('1 = 0').page(1).per(10).load.total_count
         assert_equal 7, User.page(1).load.total_count
@@ -38,6 +38,12 @@ if defined? ActiveRecord
         assert_equal 7, User.page(2).load.total_count
         assert_equal 7, User.page(2).per(10).load.total_count
         assert_equal 7, User.page(2).per(2).load.total_count
+
+        old_max_per_page = User.max_per_page
+        User.max_paginates_per(5)
+        assert_equal 7, User.page(1).per(100).load.total_count
+        assert_equal 7, User.page(2).per(100).load.total_count
+        User.max_paginates_per(old_max_per_page)
       end
 
       test 'it should reset total_count memoization when the scope is cloned' do


### PR DESCRIPTION
Fix total_count on loaded relation

before:
~~~ruby
[1] pry(main)> User.count
=> 107
[2] pry(main)> User.max_per_page
=> 25
[3] pry(main)> User.page(1).per(100).load.total_count
=> 25
[4] pry(main)> User.page(2).per(100).load.total_count
=> 125
~~~

after:
~~~ruby
[1] pry(main)> User.count
=> 107
[2] pry(main)> User.max_per_page
=> 25
[3] pry(main)> User.page(1).per(100).load.total_count
=> 107
[4] pry(main)> User.page(2).per(100).load.total_count
=> 107
~~~