### PR TITLE
Custom routes option

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -19,6 +19,7 @@ module Kaminari
       def initialize(template, params: {}, param_name: nil, theme: nil, views_prefix: nil, **options) #:nodoc:
         @template, @theme, @views_prefix, @options = template, theme, views_prefix, options
         @param_name = param_name || Kaminari.config.param_name
+        @route  = @options.delete(:route)
         @params = template.params
         # @params in Rails 5 no longer inherits from Hash
         @params = @params.to_unsafe_h if @params.respond_to?(:to_unsafe_h)
@@ -34,8 +35,12 @@ module Kaminari
 
       def page_url_for(page)
         params = params_for(page)
-        params[:only_path] = true
-        @template.url_for params
+        if @route
+          @template.send(@route, params)
+        else
+          params[:only_path] = true
+          @template.url_for params
+        end
       end
 
       private

--- a/kaminari-core/test/fake_app/rails_app.rb
+++ b/kaminari-core/test/fake_app/rails_app.rb
@@ -62,3 +62,14 @@ end
 
 # helpers
 Object.const_set(:ApplicationHelper, Module.new)
+
+module CustomRoutesHelper
+  def posts_path(params={})
+    page = params.delete(:page)
+    if page
+      "/posts/page/#{page}"
+    else
+      "/posts"
+    end
+  end
+end

--- a/kaminari-core/test/helpers/helpers_test.rb
+++ b/kaminari-core/test/helpers/helpers_test.rb
@@ -43,4 +43,9 @@ class PaginatorHelperTest < ActiveSupport::TestCase
     paginator = Paginator.new(template, param_name: :pagina)
     assert_equal :pagina, paginator.page_tag(template).instance_variable_get('@param_name')
   end
+
+  test '#route' do
+    paginator = Paginator.new(template, route: :users_path)
+    assert_equal :users_path, paginator.page_tag(template).instance_variable_get('@route')
+  end
 end

--- a/kaminari-core/test/helpers/tags_test.rb
+++ b/kaminari-core/test/helpers/tags_test.rb
@@ -51,6 +51,35 @@ if defined?(::Rails::Railtie) && defined?(ActionView)
         end
       end
 
+      sub_test_case "with a custom route setting" do
+        include CustomRoutesHelper
+
+        setup do
+          self.params[:controller] = nil
+          self.params[:action] = nil
+          self.params[:page] = 3
+        end
+
+        sub_test_case 'for first page' do
+          test 'by default' do
+            assert_equal('/posts', Kaminari::Helpers::Tag.new(self, route: :posts_path).page_url_for(1))
+          end
+
+          test 'config.params_on_first_page == false' do
+            begin
+              Kaminari.config.params_on_first_page = true
+              assert_equal('/posts/page/1', Kaminari::Helpers::Tag.new(self, route: :posts_path).page_url_for(1))
+            ensure
+              Kaminari.config.params_on_first_page = false
+            end
+          end
+        end
+
+        test 'for other page' do
+          assert_equal('/posts/page/5', Kaminari::Helpers::Tag.new(self, route: :posts_path).page_url_for(5))
+        end
+      end
+
       sub_test_case "with param_name = 'user[page]' option" do
         setup do
           self.params[:user] = {page: '3', scope: 'active'}


### PR DESCRIPTION
Hey kaminari team,

I'm building a project which requires dynamic routes that go through a wildcard domain and are handled by a custom Rack application that acts as the router. E.g.:

```
match '(*path)', to: WebsiteRouter.new, via: :all
```

Because of this it's not possible to use `url_for` and I've built my own `_path` methods. Or at least I haven't found a way to get it to work with `url_for`.

Now because I can't use `url_for`, kaminari pagination doesn't work for those custom routes. Inspired by https://github.com/kaminari/kaminari/pull/115 I've added an option that would add support for other methods than `url_for`:

```
<%= paginate @posts, route: :custom_posts_path %>
```

How those methods build the path is up to the application itself. 

The vulnerability issue discussed in #115 isn't affected anymore because the `route` option is no longer passed along with the `params` option.

Maybe this use case is to special for my own use case to implement as a feature. In this case I'll just go with monkey patching. Let me know what you think. 