### PR TITLE
Extract path helpers out of the HelperMethods

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -2,7 +2,66 @@
 
 module Kaminari
   module Helpers
+
+    # The Kaminari::Helpers::UrlHelper module provides useful methods for
+    # generating a path or url to a particlar page. A class must implement the
+    # following methods:
+    #
+    #   * <tt>url_for</tt>: A method that generates an actual path
+    #   * <tt>params</tt>: A method that returns query string parameters
+    #
+    # A normal Rails controller implements both of the methods, which makes it
+    # trivial to use this module:
+    #
+    # ==== Examples
+    #
+    #   class UsersController < ApplicationController
+    #     include Kaminari::Helpers::UrlHelper
+    #
+    #     def index
+    #      @users = User.page(1)
+    #
+    #      path_to_next_page(@items)
+    #      # => /items?page=2
+    #     end
+    #   end
+    #
+    module UrlHelper
+
+      # A helper that calculates the path to the next page.
+      #
+      # ==== Examples
+      # Basic usage:
+      #
+      #   <%= path_to_next_page @items %>
+      #   #-> /items?page=2
+      #
+      # It will return `nil` if there is no next page.
+      def next_page_path(scope, options = {})
+        Kaminari::Helpers::NextPage.new(self, options.reverse_merge(current_page: scope.current_page)).url if scope.next_page
+      end
+      alias path_to_next_page next_page_path
+
+      # A helper that calculates the path to the previous page.
+      #
+      # ==== Examples
+      # Basic usage:
+      #
+      #   <%= path_to_prev_page @items %>
+      #   #-> /items
+      #
+      # It will return `nil` if there is no previous page.
+      def prev_page_path(scope, options = {})
+        Kaminari::Helpers::PrevPage.new(self, options.reverse_merge(current_page: scope.current_page)).url if scope.prev_page
+      end
+      alias previous_page_path     prev_page_path
+      alias path_to_previous_page  prev_page_path
+      alias path_to_prev_page      prev_page_path
+    end
+
     module HelperMethods
+      include UrlHelper
+
       # A helper that renders the pagination links.
       #
       #   <%= paginate @articles %>
@@ -143,32 +202,6 @@ module Kaminari
         output << %Q|<link rel="next" href="#{next_page}"></link>| if next_page
         output << %Q|<link rel="prev" href="#{prev_page}"></link>| if prev_page
         output.html_safe
-      end
-
-      # A helper that calculates the path to the next page.
-      #
-      # ==== Examples
-      # Basic usage:
-      #
-      #   <%= path_to_next_page @items %>
-      #   #-> /items?page=2
-      #
-      # It will return `nil` if there is no next page.
-      def path_to_next_page(scope, options = {})
-        Kaminari::Helpers::NextPage.new(self, options.reverse_merge(current_page: scope.current_page)).url if scope.next_page
-      end
-
-      # A helper that calculates the path to the previous page.
-      #
-      # ==== Examples
-      # Basic usage:
-      #
-      #   <%= path_to_prev_page @items %>
-      #   #-> /items
-      #
-      # It will return `nil` if there is no previous page.
-      def path_to_prev_page(scope, options = {})
-        Kaminari::Helpers::PrevPage.new(self, options.reverse_merge(current_page: scope.current_page)).url if scope.prev_page
       end
     end
   end


### PR DESCRIPTION
This PR extracts the `#path_to_next_page` and `#path_to_prev_page` methods out of the `HelperMethods` module to their own module. The use case here is that this will allow for including the `Kaminari::Helpers::UrlHelper` in a controller and using these methods in an action:

```ruby
class UsersController < ApplicationController
  include Kaminari::Helpers::UrlHelper

  def index
    @users = User.page(1)

    path_to_next_page(@items) # => /items?page=2
  end
end
```

Which may not look like a useful feature as it currently stands, but this will also help organize new methods for https://github.com/kaminari/kaminari/issues/861 and https://github.com/kaminari/kaminari/issues/437, then we will be able to generate link headers like the following:

```ruby
class UsersController < ApplicationController
  include Kaminari::Helpers::UrlHelper

  def index
    @users = User.page(1)

    response.headers['Link'] = [
      "<#{next_page_url(@users)}>; rel='next'",
      "<#{prev_page_url(@users)}>; rel='prev'",
    ].join(",\n  ")
    # => Link: <https://example.org/items?page=2>; rel="next",
    #      <https://example.org/items?page=2>; rel="prev"
  end
end
```

Then it could be wrapped into another helper method:

```ruby
class UsersController < ApplicationController
  include Kaminari::Helpers::UrlHelper

  def index
    @users = User.page(1)

    # Not 100% sold to the name `next_prev_link_headers', open to suggestions
    response.headers['Link'] = next_prev_link_headers(@users)
    # => Link: <https://example.org/items?page=2>; rel="next",
    #      <https://example.org/items?page=2>; rel="prev"
  end
end
```

A class that includes `Kaminari::Helpers::UrlHelper` must implement the `#url_for` and `#params` methods, which are both implemented by a normal Rails controller. What this means is that it is very easy to use in Rails but also provides flexibility for other frameworks like Sinatra and Grape to use this module.
