### PR TITLE
add per_page to paginate_array

### DIFF
--- a/kaminari-core/lib/kaminari/models/array_extension.rb
+++ b/kaminari-core/lib/kaminari/models/array_extension.rb
@@ -58,6 +58,11 @@ module Kaminari
     def offset(num)
       self.class.new @_original_array, limit: @_limit_value, offset: num, total_count: @_total_count, padding: @_padding
     end
+
+    # return chunk of the original array item numbers
+    def per_page
+      limit_value
+    end
   end
 
   # Wrap an Array object to make it paginatable


### PR DESCRIPTION
add per_page method to paginate_array

before
```
irb(main):001:0> Kaminari.paginate_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).page(1).per_page
NoMethodError: undefined method `per_page' for [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]:Kaminari::PaginatableArray
```

after
```
irb(main):008:0> Kaminari.paginate_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).page(1).per_page
=> 25
irb(main):009:0> Kaminari.paginate_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).page(1).per(5).per_page
=> 5
```