### PR TITLE
Use latest Rubies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.5.0
-  - 2.4.2
-  - 2.3.5
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
   - ruby-head
   - jruby-9.1.13.0
   # - rbx-3
@@ -24,27 +24,27 @@ sudo: false
 
 before_install:
   - gem update --system
-  - gem pristine bundler
+  - gem install bundler
 script: 'bundle exec rake test'
 
 cache: bundler
 
 matrix:
   exclude:
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       gemfile: gemfiles/active_record_42.gemfile
-    - rvm: 2.5.0
+    - rvm: 2.5.1
       gemfile: gemfiles/active_record_41.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       gemfile: gemfiles/active_record_42.gemfile
-    - rvm: 2.4.2
+    - rvm: 2.4.4
       gemfile: gemfiles/active_record_41.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/active_record_42.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/active_record_41.gemfile
   include:
-    - rvm: 2.2.8
+    - rvm: 2.2.10
       gemfile: gemfiles/active_record_51.gemfile
       env: DB=sqlite3
     - rvm: 2.1.10

--- a/gemfiles/active_record_42.gemfile
+++ b/gemfiles/active_record_42.gemfile
@@ -11,7 +11,7 @@ platforms :ruby do
     gem 'nokogiri', '~> 1.6.8'
   end
   gem 'pg', '< 1.0.0', require: false
-  gem 'mysql2', require: false
+  gem 'mysql2', '< 0.4', require: false
 end
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', require: false


### PR DESCRIPTION
These Rubies has been released and available on Travis CI.
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/