### PR TITLE
Make helpers work without count

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,13 +418,6 @@ Just add `.without_count` to your paginated object:
 User.page(3).without_count
 ```
 
-In your view file, you can only use simple helpers like the following instead of the full-featured `paginate` helper:
-
-```erb
-<%= link_to_prev_page @users, 'Previous Page' %>
-<%= link_to_next_page @users, 'Next Page' %>
-```
-
 
 ## Paginating a Generic Array object
 

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -46,6 +46,10 @@ module Kaminari
     def without_count
       extend ::Kaminari::PaginatableWithoutCount
     end
+
+    def without_count?
+      false
+    end
   end
 
   # A module that makes AR::Relation paginatable without having to cast another SELECT COUNT query
@@ -87,8 +91,11 @@ module Kaminari
 
     # Force to raise an exception if #total_count is called explicitly.
     def total_count
-      raise "This scope is marked as a non-count paginable scope and can't be used in combination " \
-            "with `#paginate' or `#page_entries_info'. Use #link_to_next_page or #link_to_previous_page instead."
+      raise 'This scope is marked as a non-count paginable scope.'
+    end
+
+    def without_count?
+      true
     end
   end
 end

--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -21,3 +21,5 @@ en:
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
         display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+      without_count:
+        display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b>"

--- a/kaminari-core/lib/kaminari/helpers/paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/paginator.rb
@@ -21,11 +21,13 @@ module Kaminari
         else
           ActiveSupport::SafeBuffer.new
         end
+
+        @render_without_count = true
       end
 
       # render given block as a view template
       def render(&block)
-        instance_eval(&block) if @options[:total_pages] > 1
+        instance_eval(&block) if @options[:total_pages] > 1 || @options[:without_count]
 
         # This allows for showing fall-back HTML when there's only one page:
         #
@@ -49,6 +51,8 @@ module Kaminari
       alias each_page each_relevant_page
 
       def relevant_pages(options)
+        return [] if @options[:without_count]
+
         left_window_plus_one = [*1..options[:left] + 1]
         right_window_plus_one = [*options[:total_pages] - options[:right]..options[:total_pages]]
         inside_window_plus_each_sides = [*options[:current_page] - options[:window] - 1..options[:current_page] + options[:window] + 1]

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -25,9 +25,12 @@ module Kaminari
         @params = @params.with_indifferent_access
         @params.except!(*PARAM_KEY_BLACKLIST)
         @params.merge! params
+        @render_without_count = false
       end
 
       def to_s(locals = {}) #:nodoc:
+        return '' if @options[:without_count] && !@render_without_count
+
         formats = (@template.respond_to?(:formats) ? @template.formats : Array(@template.params[:format])) + [:html]
         @template.render partial: partial_path, locals: @options.merge(locals), formats: formats
       end
@@ -128,6 +131,8 @@ module Kaminari
         end
 
         super(template, params: params, param_name: param_name, theme: theme, views_prefix: views_prefix, **options)
+
+        @render_without_count = true
       end
 
       def page #:nodoc:
@@ -149,6 +154,8 @@ module Kaminari
         end
 
         super(template, params: params, param_name: param_name, theme: theme, views_prefix: views_prefix, **options)
+
+        @render_without_count = true
       end
 
       def page #:nodoc:

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -82,6 +82,16 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
         assert_not_match(/Last/, html)
         assert_not_match(/Next/, html)
       end
+
+      test 'scope without count' do
+        users = User.page(7).without_count
+
+        html = view.paginate users, params: {controller: 'users', action: 'index'}
+        assert_match(/<a [^>]*>&lsaquo; Prev<\/a>/, html)
+        assert_match(/<a [^>]*>Next &rsaquo;<\/a>/, html)
+        assert_not_match(/First/, html)
+        assert_not_match(/Last/, html)
+      end
     end
 
     sub_test_case '#link_to_previous_page' do
@@ -468,6 +478,109 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
               addresses = User::Address.page(2).per(25)
               assert_equal 'Displaying places <b>26&nbsp;-&nbsp;50</b> of <b>50</b> in total', view.page_entries_info(addresses, entry_name: 'place')
             end
+          end
+        end
+      end
+
+      sub_test_case 'on a scope without count' do
+        sub_test_case 'having no entries' do
+          test 'with default entry name' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'No users found', view.page_entries_info(users)
+          end
+
+          test 'setting the entry name option to "member"' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'No members found', view.page_entries_info(users, entry_name: 'member')
+          end
+        end
+
+        sub_test_case 'having 1 entry' do
+          setup do
+            User.create! name: 'user1'
+          end
+
+          test 'with default entry name' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'Displaying <b>1</b> user', view.page_entries_info(users)
+          end
+
+          test 'setting the entry name option to "member"' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'Displaying <b>1</b> member', view.page_entries_info(users, entry_name: 'member')
+          end
+        end
+
+        sub_test_case 'having more than 1 but less than a page of entries' do
+          setup do
+            10.times {|i| User.create! name: "user#{i}"}
+          end
+
+          test 'with default entry name' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'Displaying <b>all 10</b> users', view.page_entries_info(users)
+          end
+
+          test 'setting the entry name option to "member"' do
+            users = User.page(1).per(25).without_count
+            assert_equal 'Displaying <b>all 10</b> members', view.page_entries_info(users, entry_name: 'member')
+          end
+        end
+
+        sub_test_case 'having more than one page of entries' do
+          setup do
+            50.times {|i| User.create! name: "user#{i}"}
+          end
+
+          sub_test_case 'the first page' do
+            test 'with default entry name' do
+              users = User.page(1).per(25).without_count
+              assert_equal 'Displaying users <b>1&nbsp;-&nbsp;25</b>', view.page_entries_info(users)
+            end
+
+            test 'setting the entry name option to "member"' do
+              users = User.page(1).per(25).without_count
+              assert_equal 'Displaying members <b>1&nbsp;-&nbsp;25</b>', view.page_entries_info(users, entry_name: 'member')
+            end
+          end
+
+          sub_test_case 'the next page' do
+            test 'with default entry name' do
+              users = User.page(2).per(25).without_count
+              assert_equal 'Displaying users <b>26&nbsp;-&nbsp;50</b>', view.page_entries_info(users)
+            end
+
+            test 'setting the entry name option to "member"' do
+              users = User.page(2).per(25).without_count
+              assert_equal 'Displaying members <b>26&nbsp;-&nbsp;50</b>', view.page_entries_info(users, entry_name: 'member')
+            end
+          end
+
+          sub_test_case 'the last page' do
+            test 'with default entry name' do
+              begin
+                User.max_pages 4
+                users = User.page(4).per(10).without_count
+
+                assert_equal 'Displaying users <b>31&nbsp;-&nbsp;40</b>', view.page_entries_info(users)
+              ensure
+                User.max_pages nil
+              end
+            end
+          end
+
+          test 'it accepts a decorated object' do
+            page_info_presenter = Class.new(SimpleDelegator) do
+              include ActionView::Helpers::NumberHelper
+
+              def total_count
+                number_with_delimiter(1_000)
+              end
+            end
+
+            users = page_info_presenter.new(User.page(1).per(25).without_count)
+
+            assert_equal 'Displaying users <b>1&nbsp;-&nbsp;25</b>', view.page_entries_info(users)
           end
         end
       end


### PR DESCRIPTION
I've been working with somewhat larger data sets lately where `SELECT COUNT` queries would often lead to timeouts. I would like to use the `without_count` method to solve this issue, however I see no reason why I'd need to change the templates for this, I think the gem could handle this use case automatically by only rendering the prev/next link tags.

This PR enables the use of `paginate` and `page_entries_info` with non-count scopes by automatically degrading their features, disabling functionality that can't be used without knowing the result set size.