### PR TITLE
update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
 
 * Renamed the model class method for configuring `max_pages` from `max_pages_per` to `max_pages`
 
+* Raise ZeroPerPageOperation when The number of pages was incalculable of `total_pages`, `current_page` methods
+
 ### Enhancements:
 
 * Exposed `path_to_prev_page`, `path_to_next_page` helpers as public API #683 [@neilang]


### PR DESCRIPTION
i'm updated version 0.17-stable to v1.1.1 

At that time I noticed that raise a ZeroPerPageOperation occurred in `total_pages`, `current_page` methods, but since it is not described in CHANGELOG, I will add it.

It seems that the update was from v1.0.0.beta.

https://github.com/kaminari/kaminari/commit/af769b6a3a589c83887fee94d1c5a1657d3d664c