### PR TITLE
explicitly remove select condition from AREL when counting

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -26,7 +26,7 @@ module Kaminari
       end
 
       # #count overrides the #select which could include generated columns referenced in #order, so skip #order here, where it's irrelevant to the result anyway
-      c = except(:offset, :limit, :order)
+      c = except(:select, :offset, :limit, :order)
       # Remove includes only if they are irrelevant
       c = c.except(:includes) unless references_eager_loaded_tables?
       # .group returns an OrderedHash that responds to #count


### PR DESCRIPTION
For some reason in my app ActiveRecord is not removing the select when executing a count. I know this because PostgreSQL is giving an explicit error message showing that ActiveRecord is trying to do both the count and the custom select.

Explicitly telling ActiveRecord to remove the select fixes my problem.

I have attached a stack trace of the failure in my app. After many hours of trying, I cannot create a test case that elicits this problem in the Kaminari test suite. The differences between my very large app and the Kaminari test app are too great and the specific failing example involves some extremely complex AREL.

Anyhow, would you be willing to add this explicit removal of the select clause when counting? It is always good to remove the select when counting, and apparently we cannot trust ActiveRecord to remove it automatically in every case, even if I can't work out the exact permutation to elicit the bug in ActiveRecord.

Thank you for your consideration!
Eric
[kaminari_stack_trace.txt](https://github.com/kaminari/kaminari/files/2612757/kaminari_stack_trace.txt)
