### PR TITLE
Improve performance of total_count for grouped queries

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -29,14 +29,11 @@ module Kaminari
       c = except(:offset, :limit, :order)
       # Remove includes only if they are irrelevant
       c = c.except(:includes) unless references_eager_loaded_tables?
-      # .group returns an OrderedHash that responds to #count
-      c = c.count(column_name)
-      @total_count = if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-        c.count
-     elsif c.respond_to? :count
-       c.count(column_name)
-     else
-       c
+      # Handle grouping with a subquery
+      @total_count = if c.group_values.any?
+        c.model.from(c.except(:select).select("1")).count
+      else
+        c.count(column_name)
       end
     end
 

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -95,6 +95,10 @@ if defined? ActiveRecord
       test 'total_count is calculable with page 1 per "5" (the string)' do
         assert_equal 7, User.page(1).per('5').load.total_count
       end
+
+      test 'calculating total_count with GROUP BY ... HAVING clause' do
+        assert_equal 2, Authorship.group(:user_id).having("COUNT(book_id) >= 3").page(1).total_count
+      end
     end
   end
 end


### PR DESCRIPTION
Code for https://github.com/kaminari/kaminari/issues/978.

SQL query will return a single count instead of forcing AR to serialize a hash which entries will be counted.