### PR TITLE
Cursor pagination

### DIFF
--- a/gemfiles/active_record_50.gemfile
+++ b/gemfiles/active_record_50.gemfile
@@ -5,10 +5,11 @@ gem 'activerecord', '~> 5.0.0', require: 'active_record'
 gem 'actionview', '~> 5.0.0', require: 'action_view'
 
 platforms :ruby do
-  gem 'sqlite3', require: false
+  gem 'sqlite3', '~> 1.3.8', require: false
   gem 'pg', '< 1.0.0', require: false
   gem 'mysql2', require: false
 end
+
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', require: false
   gem 'activerecord-jdbcpostgresql-adapter', require: false

--- a/gemfiles/active_record_51.gemfile
+++ b/gemfiles/active_record_51.gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', '~> 5.1.0', require: 'active_record'
 gem 'actionview', '~> 5.1.0', require: 'action_view'
 
 platforms :ruby do
-  gem 'sqlite3', require: false
+  gem 'sqlite3', '~> 1.3.6', require: false
   gem 'pg', require: false
   gem 'mysql2', require: false
 end

--- a/gemfiles/active_record_52.gemfile
+++ b/gemfiles/active_record_52.gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', '~> 5.2.0', require: 'active_record'
 gem 'actionview', '~> 5.2.0', require: 'action_view'
 
 platforms :ruby do
-  gem 'sqlite3', require: false
+  gem 'sqlite3', '~> 1.3.8', require: false
   gem 'pg', require: false
   gem 'mysql2', require: false
 end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -20,6 +20,43 @@ module Kaminari
           end
         end
       RUBY
+
+      # cursor paginate with before
+      #   Model.before(5)
+      eval <<-RUBY, nil, __FILE__, __LINE__ + 1
+        def self.#{Kaminari.config.before_method_name}(position)
+          @_cursor_paginate_direction = 'before'
+          cursor_limit = cursor_max_limit && (default_cursor_limit > cursor_max_limit) ? cursor_max_limit : default_cursor_limit
+          limit(cursor_limit).where(arel_table[primary_key].lt(position)).reorder(primary_key => :desc).extending do
+            def cursor_paginate_direction
+              'before'
+            end
+
+            include Kaminari::ActiveRecordRelationMethods
+            include Kaminari::CursorPageScopeMethods
+          end
+        end
+      RUBY
+
+      # cursor paginate with after
+      #   Model.after(5)
+      eval <<-RUBY, nil, __FILE__, __LINE__ + 1
+        def self.#{Kaminari.config.after_method_name}(position)
+          @_cursor_paginate_direction = 'after'
+          cursor_limit = cursor_max_limit && (default_cursor_limit > cursor_max_limit) ? cursor_max_limit : default_cursor_limit
+          limit(cursor_limit).where(arel_table[primary_key].gt(position)).reorder(primary_key => :asc).extending do
+
+            def cursor_paginate_direction
+              'after'
+            end
+
+            include Kaminari::ActiveRecordRelationMethods
+            include Kaminari::CursorPageScopeMethods
+          end
+        end
+      RUBY
+
+
     end
   end
 end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -37,6 +37,10 @@ module Kaminari
       end
     end
 
+    def has_more? # cursor_paginates
+      last.present? && send(cursor_paginate_direction, last[primary_key]).exists?
+    end
+
     # Turn this Relation to a "without count mode" Relation.
     # Note that the "without count mode" is supposed to be performant but has a feature limitation.
     #   Pro: paginates without casting an extra SELECT COUNT query

--- a/kaminari-core/lib/kaminari/config.rb
+++ b/kaminari-core/lib/kaminari/config.rb
@@ -17,6 +17,7 @@ module Kaminari
 
   class Config
     attr_accessor :default_per_page, :max_per_page, :window, :outer_window, :left, :right, :page_method_name, :max_pages, :params_on_first_page
+    attr_accessor :default_cursor_limit, :cursor_max_limit, :before_method_name, :after_method_name
     attr_writer :param_name
 
     def initialize
@@ -30,6 +31,10 @@ module Kaminari
       @param_name = :page
       @max_pages = nil
       @params_on_first_page = false
+      @default_cursor_limit = @default_per_page
+      @cursor_max_limit = @max_per_page
+      @before_method_name = 'before'
+      @after_method_name = 'after'
     end
 
     # If param_name was given as a callable object, call it when returning

--- a/kaminari-core/lib/kaminari/config.rb
+++ b/kaminari-core/lib/kaminari/config.rb
@@ -17,7 +17,7 @@ module Kaminari
 
   class Config
     attr_accessor :default_per_page, :max_per_page, :window, :outer_window, :left, :right, :page_method_name, :max_pages, :params_on_first_page
-    attr_accessor :default_cursor_limit, :cursor_max_limit, :before_method_name, :after_method_name
+    attr_accessor :default_cursor_limit, :cursor_max_limit, :before_method_name, :after_method_name, :cursor_back_end
     attr_writer :param_name
 
     def initialize
@@ -35,6 +35,7 @@ module Kaminari
       @cursor_max_limit = @max_per_page
       @before_method_name = 'before'
       @after_method_name = 'after'
+      @cursor_back_end = 'sequence'
     end
 
     # If param_name was given as a callable object, call it when returning

--- a/kaminari-core/lib/kaminari/core.rb
+++ b/kaminari-core/lib/kaminari/core.rb
@@ -15,6 +15,7 @@ require 'kaminari/config'
 require 'kaminari/exceptions'
 require 'kaminari/helpers/paginator'
 require 'kaminari/models/page_scope_methods'
+require 'kaminari/models/cursor_page_scope_methods'
 require 'kaminari/models/configuration_methods'
 require 'kaminari/models/array_extension'
 

--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -7,6 +7,27 @@ module Kaminari
     extend ActiveSupport::Concern
     module ClassMethods #:nodoc:
 
+      # Overrides the default +cursor_backend + value per model can be ['sequence', 'uuid']
+      #   class Article < ActiveRecord::Base
+      #     cursor_paginates_back_end 'uuid'
+      #   end
+      def cursor_paginates_back_end(val)
+        @_cursor_backend = val
+      end
+
+      def cursor_backend
+        (defined?(@_cursor_backend) && @_cursor_backend) || Kaminari.config.cursor_back_end
+      end
+
+      def uuid_cursor?
+        cursor_backend == 'uuid'
+      end
+
+      def sequence_cursor?
+        cursor_backend == 'sequence'
+      end
+
+
       # Overrides the default +cursor_limit+ value per model
       #   class Article < ActiveRecord::Base
       #     cursor_paginates_limit 10

--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -6,6 +6,35 @@ module Kaminari
   module ConfigurationMethods #:nodoc:
     extend ActiveSupport::Concern
     module ClassMethods #:nodoc:
+
+      # Overrides the default +cursor_limit+ value per model
+      #   class Article < ActiveRecord::Base
+      #     cursor_paginates_limit 10
+      #   end
+      def cursor_paginates_limit(val)
+        @_default_cursor_limit = val
+      end
+
+      # This model's default +cursor_limit+ value
+      # returns +default_cursor_limit+ value unless explicitly overridden via <tt>cursor_paginates_limit</tt>
+      def default_cursor_limit
+        (defined?(@_default_cursor_limit) && @_default_cursor_limit) || Kaminari.config.default_cursor_limit
+      end
+
+      # Overrides the max +per_page+ value per model
+      #   class Article < ActiveRecord::Base
+      #     max_paginates_per 100
+      #   end
+      def max_cursor_limit(val)
+        @_cursor_max_limit = val
+      end
+
+      # This model's max +cursor_max_limit+ value
+      # returns +cursor_max_limit+ value unless explicitly overridden via <tt>max_cursor_limit</tt>
+      def cursor_max_limit
+        (defined?(@_cursor_max_limit) && @_cursor_max_limit) || Kaminari.config.cursor_max_limit
+      end
+
       # Overrides the default +per_page+ value per model
       #   class Article < ActiveRecord::Base
       #     paginates_per 10

--- a/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Kaminari
+  module CursorPageScopeMethods
+    # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
+    #   Model.before(3).cursor_limit(10)
+    #   Model.after(3).cursor_limit(10)
+    def cursor_limit(num, cursor_max_limit=nil)
+      cursor_max_limit ||= ( (defined?(@_cursor_max_limit) && @_cursor_max_limit) || self.cursor_max_limit)
+      @_cursor_limit = (num || default_cursor_limit).to_i
+      if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
+        self
+      elsif n.zero?
+        limit(n)
+      elsif cursor_max_limit && (cursor_max_limit < n)
+        limit(cursor_max_limit)
+      else
+        limit(n)
+      end
+    end
+
+  end
+end

--- a/kaminari-core/test/fake_app/active_record/models.rb
+++ b/kaminari-core/test/fake_app/active_record/models.rb
@@ -48,7 +48,18 @@ end
 class Product < ActiveRecord::Base
   self.abstract_class = true
 end
+
 class Device < Product
+end
+
+class Post < ActiveRecord::Base
+  cursor_paginates_back_end 'uuid'
+
+  before_create :set_uuid # for test with uuid
+
+  def set_uuid
+    self.id = SecureRandom.uuid
+  end
 end
 
 # migrations
@@ -66,6 +77,13 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id }
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }
     create_table(:devices) {|t| t.string :name; t.integer :age}
+
+    create_table(:posts, id: false) do |t|
+      t.string :id, limit: 36, primary_key: true, null: false
+      t.string :name
+      t.integer :age
+      t.timestamps
+    end
   end
 end
 CreateAllTables.up

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -4,6 +4,39 @@ require 'test_helper'
 
 if defined? ActiveRecord
   class ActiveRecordRelationMethodsTest < ActiveSupport::TestCase
+    sub_test_case '#has_more?' do
+      setup do
+        1.upto(100) {|i| User.create! name: "user#{'%03d' % i}", age: (i / 10)}
+      end
+
+      teardown do
+        User.delete_all
+      end
+
+      test 'has_more true with before' do
+        record = User.find_by name: 'user030'
+        assert_equal true, User.before(record.id).has_more?
+
+      end
+
+      test 'has_more true with after' do
+        record = User.find_by name: 'user030'
+        assert_equal true, User.after(record.id).has_more?
+      end
+
+      test 'has_more false with before' do
+        record = User.find_by name: 'user005'
+        assert_equal false, User.before(record.id).has_more?
+      end
+
+      test 'has_more false with after' do
+        record = User.find_by name: 'user095'
+        assert_equal false, User.after(record.id).has_more?
+      end
+
+
+    end
+
     sub_test_case '#total_count' do
       setup do
         @author = User.create! name: 'author'
@@ -15,6 +48,7 @@ if defined? ActiveRecord
         @readers = 4.times.map { User.create! name: 'reader' }
         @books.each {|book| book.readers << @readers }
       end
+
       teardown do
         Book.delete_all
         User.delete_all

--- a/kaminari-core/test/models/active_record/cursor_test.rb
+++ b/kaminari-core/test/models/active_record/cursor_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if defined? ActiveRecord
+  class ActiveRecordExtensionTest < ActiveSupport::TestCase
+    def assert_first_page(relation)
+      assert_equal 25, relation.count
+      assert_equal 'user001', relation.first.name
+    end
+
+    def assert_blank_page(relation)
+      assert_equal 0, relation.count
+    end
+
+    class << self
+      def startup
+        [User, GemDefinedModel, Device].each do |m|
+          1.upto(100) {|i| m.create! name: "user#{'%03d' % i}", age: (i / 10)}
+        end
+        super
+      end
+
+      def shutdown
+        [User, GemDefinedModel, Device].each(&:delete_all)
+        super
+      end
+    end
+
+    [User, Admin, GemDefinedModel, Device].each do |model_class|
+      sub_test_case "for #{model_class}" do
+        sub_test_case '#before' do
+          test 'cursor_page with before' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.before(record.id)
+            assert_equal 25, relation.count
+            assert_equal 'user029', relation.first.name
+            assert_equal 'user005', relation.last.name
+          end
+
+          test 'cursor_page with before out of range' do
+            relation = model_class.before(0)
+            assert_blank_page(relation)
+          end
+        end
+
+        sub_test_case '#after' do
+          test 'cursor_page with after' do
+            record = model_class.find_by(name: 'user025')
+            relation = model_class.after(record.id)
+            assert_equal 25, relation.count
+            assert_equal 'user026', relation.first.name
+            assert_equal 'user050', relation.last.name
+          end
+
+          test 'cursor_page with after out of range' do
+            relation = model_class.after(10000)
+            assert_blank_page(relation)
+          end
+        end
+
+        sub_test_case '#cursor_limit' do
+          test 'before with cursor_limit 5' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.before(record.id).cursor_limit(5)
+            assert_equal 5, relation.count
+            assert_equal 'user029', relation.first.name
+            assert_equal 'user025', relation.last.name
+          end
+
+          test 'after with cursor_limit 5' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.after(record.id).cursor_limit(5)
+            assert_equal 5, relation.count
+            assert_equal 'user031', relation.first.name
+            assert_equal 'user035', relation.last.name
+          end
+
+          test 'cursor_limit < 5' do
+            begin
+              model_class.max_cursor_limit 4
+              record = model_class.find_by(name: 'user030')
+              relation = model_class.after(record.id).cursor_limit(5)
+
+              assert_equal 4, relation.count
+            ensure
+              model_class.max_cursor_limit nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/kaminari-core/test/models/active_record/cursor_test.rb
+++ b/kaminari-core/test/models/active_record/cursor_test.rb
@@ -15,16 +15,13 @@ if defined? ActiveRecord
       assert_equal 0, relation.count
     end
 
-    sub_test_case "sequence backend" do
-
-
-
-      [User, Admin, GemDefinedModel, Device, Post].each do |model_class|
+    [User, Admin, GemDefinedModel, Device, Post].each do |model_class|
+      sub_test_case "for #{model_class}" do
         setup do
+          model_class.delete_all
           if model_class == Post
             1.upto(100) do |i|
-              post = Post.create! name: "user#{'%03d' % i}", age: (i / 10)
-              post.update(created_at: (100-i).days.ago)
+              post = Post.create! name: "user#{'%03d' % i}", age: (i / 10), created_at: (100-i).days.ago
             end
           else
             1.upto(100) {|i| model_class.create! name: "user#{'%03d' % i}", age: (i / 10)}
@@ -36,70 +33,69 @@ if defined? ActiveRecord
           model_class.delete_all
         end
 
-        sub_test_case "for #{model_class}" do
-          sub_test_case '#before' do
-            test 'cursor_page with before' do
-              record = model_class.find_by(name: 'user030')
-              relation = model_class.before(record.id)
-              assert_equal 25, relation.count
-              assert_equal 'user029', relation.first.name
-              assert_equal 'user005', relation.last.name
-            end
-
-            test 'cursor_page with before out of range' do
-              relation = model_class.before(0)
-              assert_blank_page(relation)
-            end
+        sub_test_case '#before' do
+          test 'cursor_page with before' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.before(record.id)
+            assert_equal 25, relation.count
+            assert_equal 'user029', relation.first.name
+            assert_equal 'user005', relation.last.name
           end
 
-          sub_test_case '#after' do
-            test 'cursor_page with after' do
-              record = model_class.find_by(name: 'user025')
-              relation = model_class.after(record.id)
-              assert_equal 25, relation.count
-              assert_equal 'user026', relation.first.name
-              assert_equal 'user050', relation.last.name
-            end
+          test 'cursor_page with before out of range' do
+            relation = model_class.before(0)
+            assert_blank_page(relation)
+          end
+        end
 
-            test 'cursor_page with after out of range' do
-              relation = model_class.after(10000)
-              assert_blank_page(relation)
-            end
+        sub_test_case '#after' do
+          test 'cursor_page with after' do
+            record = model_class.find_by!(name: 'user025')
+            relation = model_class.after(record.id)
+            assert_equal 25, relation.count
+            assert_equal 'user026', relation.first.name
+            assert_equal 'user050', relation.last.name
           end
 
-          sub_test_case '#cursor_limit' do
-            test 'before with cursor_limit 5' do
-              record = model_class.find_by(name: 'user030')
-              relation = model_class.before(record.id).cursor_limit(5)
-              assert_equal 5, relation.count
-              assert_equal 'user029', relation.first.name
-              assert_equal 'user025', relation.last.name
-            end
+          test 'cursor_page with after out of range' do
+            record = model_class.find_by!(name: 'user100')
+            relation = model_class.after(record.id)
+            assert_blank_page(relation)
+          end
+        end
 
-            test 'after with cursor_limit 5' do
+        sub_test_case '#cursor_limit' do
+          test 'before with cursor_limit 5' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.before(record.id).cursor_limit(5)
+            assert_equal 5, relation.count
+            assert_equal 'user029', relation.first.name
+            assert_equal 'user025', relation.last.name
+          end
+
+          test 'after with cursor_limit 5' do
+            record = model_class.find_by(name: 'user030')
+            relation = model_class.after(record.id).cursor_limit(5)
+            assert_equal 5, relation.count
+            assert_equal 'user031', relation.first.name
+            assert_equal 'user035', relation.last.name
+          end
+
+          test 'cursor_limit < 5' do
+            begin
+              model_class.max_cursor_limit 4
               record = model_class.find_by(name: 'user030')
               relation = model_class.after(record.id).cursor_limit(5)
-              assert_equal 5, relation.count
-              assert_equal 'user031', relation.first.name
-              assert_equal 'user035', relation.last.name
-            end
 
-            test 'cursor_limit < 5' do
-              begin
-                model_class.max_cursor_limit 4
-                record = model_class.find_by(name: 'user030')
-                relation = model_class.after(record.id).cursor_limit(5)
-
-                assert_equal 4, relation.count
-              ensure
-                model_class.max_cursor_limit nil
-              end
+              assert_equal 4, relation.count
+            ensure
+              model_class.max_cursor_limit nil
             end
           end
         end
       end
-
-
     end
+
+
   end
 end

--- a/kaminari-core/test/models/active_record/cursor_test.rb
+++ b/kaminari-core/test/models/active_record/cursor_test.rb
@@ -4,6 +4,8 @@ require 'test_helper'
 
 if defined? ActiveRecord
   class ActiveRecordExtensionTest < ActiveSupport::TestCase
+
+
     def assert_first_page(relation)
       assert_equal 25, relation.count
       assert_equal 'user001', relation.first.name
@@ -13,82 +15,91 @@ if defined? ActiveRecord
       assert_equal 0, relation.count
     end
 
-    class << self
-      def startup
-        [User, GemDefinedModel, Device].each do |m|
-          1.upto(100) {|i| m.create! name: "user#{'%03d' % i}", age: (i / 10)}
-        end
-        super
-      end
+    sub_test_case "sequence backend" do
 
-      def shutdown
-        [User, GemDefinedModel, Device].each(&:delete_all)
-        super
-      end
-    end
 
-    [User, Admin, GemDefinedModel, Device].each do |model_class|
-      sub_test_case "for #{model_class}" do
-        sub_test_case '#before' do
-          test 'cursor_page with before' do
-            record = model_class.find_by(name: 'user030')
-            relation = model_class.before(record.id)
-            assert_equal 25, relation.count
-            assert_equal 'user029', relation.first.name
-            assert_equal 'user005', relation.last.name
+
+      [User, Admin, GemDefinedModel, Device, Post].each do |model_class|
+        setup do
+          if model_class == Post
+            1.upto(100) do |i|
+              post = Post.create! name: "user#{'%03d' % i}", age: (i / 10)
+              post.update(created_at: (100-i).days.ago)
+            end
+          else
+            1.upto(100) {|i| model_class.create! name: "user#{'%03d' % i}", age: (i / 10)}
           end
 
-          test 'cursor_page with before out of range' do
-            relation = model_class.before(0)
-            assert_blank_page(relation)
-          end
         end
 
-        sub_test_case '#after' do
-          test 'cursor_page with after' do
-            record = model_class.find_by(name: 'user025')
-            relation = model_class.after(record.id)
-            assert_equal 25, relation.count
-            assert_equal 'user026', relation.first.name
-            assert_equal 'user050', relation.last.name
-          end
-
-          test 'cursor_page with after out of range' do
-            relation = model_class.after(10000)
-            assert_blank_page(relation)
-          end
+        teardown do
+          model_class.delete_all
         end
 
-        sub_test_case '#cursor_limit' do
-          test 'before with cursor_limit 5' do
-            record = model_class.find_by(name: 'user030')
-            relation = model_class.before(record.id).cursor_limit(5)
-            assert_equal 5, relation.count
-            assert_equal 'user029', relation.first.name
-            assert_equal 'user025', relation.last.name
+        sub_test_case "for #{model_class}" do
+          sub_test_case '#before' do
+            test 'cursor_page with before' do
+              record = model_class.find_by(name: 'user030')
+              relation = model_class.before(record.id)
+              assert_equal 25, relation.count
+              assert_equal 'user029', relation.first.name
+              assert_equal 'user005', relation.last.name
+            end
+
+            test 'cursor_page with before out of range' do
+              relation = model_class.before(0)
+              assert_blank_page(relation)
+            end
           end
 
-          test 'after with cursor_limit 5' do
-            record = model_class.find_by(name: 'user030')
-            relation = model_class.after(record.id).cursor_limit(5)
-            assert_equal 5, relation.count
-            assert_equal 'user031', relation.first.name
-            assert_equal 'user035', relation.last.name
+          sub_test_case '#after' do
+            test 'cursor_page with after' do
+              record = model_class.find_by(name: 'user025')
+              relation = model_class.after(record.id)
+              assert_equal 25, relation.count
+              assert_equal 'user026', relation.first.name
+              assert_equal 'user050', relation.last.name
+            end
+
+            test 'cursor_page with after out of range' do
+              relation = model_class.after(10000)
+              assert_blank_page(relation)
+            end
           end
 
-          test 'cursor_limit < 5' do
-            begin
-              model_class.max_cursor_limit 4
+          sub_test_case '#cursor_limit' do
+            test 'before with cursor_limit 5' do
+              record = model_class.find_by(name: 'user030')
+              relation = model_class.before(record.id).cursor_limit(5)
+              assert_equal 5, relation.count
+              assert_equal 'user029', relation.first.name
+              assert_equal 'user025', relation.last.name
+            end
+
+            test 'after with cursor_limit 5' do
               record = model_class.find_by(name: 'user030')
               relation = model_class.after(record.id).cursor_limit(5)
+              assert_equal 5, relation.count
+              assert_equal 'user031', relation.first.name
+              assert_equal 'user035', relation.last.name
+            end
 
-              assert_equal 4, relation.count
-            ensure
-              model_class.max_cursor_limit nil
+            test 'cursor_limit < 5' do
+              begin
+                model_class.max_cursor_limit 4
+                record = model_class.find_by(name: 'user030')
+                relation = model_class.after(record.id).cursor_limit(5)
+
+                assert_equal 4, relation.count
+              ensure
+                model_class.max_cursor_limit nil
+              end
             end
           end
         end
       end
+
+
     end
   end
 end

--- a/kaminari-core/test/models/active_record/inherited_test.rb
+++ b/kaminari-core/test/models/active_record/inherited_test.rb
@@ -4,8 +4,16 @@ require 'test_helper'
 
 if defined? ActiveRecord
   class ActiveRecordModelExtensionTest < ActiveSupport::TestCase
-    test 'An AR model responds to Kaminari defined methods' do
+    test 'An AR model responds to Kaminari defined methods page' do
       assert_respond_to Class.new(ActiveRecord::Base), :page
+    end
+
+    test 'An AR model responds to Kaminari defined methods before' do
+      assert_respond_to Class.new(ActiveRecord::Base), :cursor_page
+    end
+
+    test 'An AR model responds to Kaminari defined methods after' do
+      assert_respond_to Class.new(ActiveRecord::Base), :after
     end
 
     test "Kaminari doesn't prevent other AR extension gems to define a method" do

--- a/kaminari-core/test/models/active_record/inherited_test.rb
+++ b/kaminari-core/test/models/active_record/inherited_test.rb
@@ -9,7 +9,7 @@ if defined? ActiveRecord
     end
 
     test 'An AR model responds to Kaminari defined methods before' do
-      assert_respond_to Class.new(ActiveRecord::Base), :cursor_page
+      assert_respond_to Class.new(ActiveRecord::Base), :before
     end
 
     test 'An AR model responds to Kaminari defined methods after' do


### PR DESCRIPTION
Answer to request of #562  (more [read here](https://dev.to/jackmarchant/offset-and-cursor-pagination-explained-b89)) 
support: cursor_paginate for ['sequence', 'uuid'], has_more?

Just a kick start as I don't to wast much time if Kaminari won't accept this. 🤕🤕🤕
Also I can not work these big load at once.  🤯🤯🤯 

***Doc***: Coming 👨🏻‍💻 👨🏻‍💻 👨🏻‍💻 
***View***: Come when this idea likely to work. 👏👏👏
***Order***: static order (id for sequence)(created_at and id for uuid). Dynamic order is open for discussion. (Will come if this idea is likely to work)  💪🏻💪🏻💪🏻
***Code***: open for comment to refactor. 👍👍👍

Note: Open for any suggestion and correction 👨🏻‍🎓👨🏻‍🎓👨🏻‍🎓

### How to work with it
```
posts = Post.before(id)
posts = Post.after(id)
posts.has_more?
```
