### PR TITLE
Add "entries_info" option to paginate helper

### DIFF
--- a/kaminari-core/app/views/kaminari/_paginator.html.erb
+++ b/kaminari-core/app/views/kaminari/_paginator.html.erb
@@ -2,7 +2,8 @@
   - available local variables
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
-    per_page:      number of items to fetch per page
+    per_page:      number of items to fetch per page 
+    entries_info:  display page entries info
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
@@ -21,5 +22,10 @@
       <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
     <% end %>
+    <% if entries_info -%>
+      <span class="entries-info">
+        <%= page_entries_info(scope) %>
+      </span>
+    <% end -%>
   </nav>
 <% end -%>

--- a/kaminari-core/app/views/kaminari/_paginator.html.haml
+++ b/kaminari-core/app/views/kaminari/_paginator.html.haml
@@ -3,6 +3,7 @@
 -#    current_page:  a page object for the currently displayed page
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
+-#    entries_info:  display page entries info
 -#    remote:        data-remote
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
@@ -16,3 +17,6 @@
         = gap_tag
     = next_page_tag unless current_page.last?
     = last_page_tag unless current_page.last?
+    - if entries_info
+      %span.entries-info
+        = page_entries_info(scope)

--- a/kaminari-core/app/views/kaminari/_paginator.html.slim
+++ b/kaminari-core/app/views/kaminari/_paginator.html.slim
@@ -3,8 +3,10 @@
     current_page : a page object for the currently displayed page
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
+    entries_info : display page entries info
     remote       : data-remote
     paginator    : the paginator that renders the pagination tags inside
+    scope        : a scope object for the paginator
 
 == paginator.render do
   nav.pagination
@@ -17,3 +19,6 @@
         == gap_tag
     == next_page_tag unless current_page.last?
     == last_page_tag unless current_page.last?
+    - if entries_info
+      span.entries-info
+        == page_entries_info(scope)

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -104,13 +104,15 @@ module Kaminari
       # * <tt>:right</tt> - The "right outer window" size (0 by default).
       # * <tt>:params</tt> - url_for parameters for the links (:controller, :action, etc.)
       # * <tt>:param_name</tt> - parameter name for page number in the links (:page by default)
+      # * <tt>:entries_info</tt> - Display page entries info? (false by default)
       # * <tt>:remote</tt> - Ajax? (false by default)
       # * <tt>:paginator_class</tt> - Specify a custom Paginator (Kaminari::Helpers::Paginator by default)
       # * <tt>:template</tt> - Specify a custom template renderer for rendering the Paginator (receiver by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, paginator_class: Kaminari::Helpers::Paginator, template: nil, **options)
+        options[:scope] ||= scope
         options[:total_pages] ||= scope.total_pages
-        options.reverse_merge! current_page: scope.current_page, per_page: scope.limit_value, remote: false
+        options.reverse_merge! current_page: scope.current_page, per_page: scope.limit_value, entries_info: false, remote: false
 
         paginator = paginator_class.new (template || self), options
         paginator.to_s

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -83,6 +83,22 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
         assert_not_match(/Last/, html)
         assert_not_match(/Next/, html)
       end
+
+      test 'entries_info: true' do
+        users = User.page(1)
+
+        html = view.paginate users, entries_info: true, params: {controller: 'users', action: 'index'}
+        assert_match(/<span class="entries-info">/, html)
+        assert_match(/#{view.page_entries_info(users)}/, html)
+      end
+
+      test 'entries_info: false (by default)' do
+        users = User.page(1)
+
+        html = view.paginate users, params: {controller: 'users', action: 'index'}
+        assert_not_match(/<span class="entries-info">/, html)
+        assert_not_match(/#{view.page_entries_info(users)}/, html)
+      end
     end
 
     sub_test_case '#link_to_previous_page' do


### PR DESCRIPTION
I usually use kaminari often. Thank you very much for your maintenance :)

When I use kaminari, I would like to display page entries info with pagination but I cannot call [page_entries_info](https://github.com/kaminari/kaminari/blob/master/kaminari-core/lib/kaminari/helpers/helper_methods.rb#L196) method inner [paginator view](https://github.com/kaminari/kaminari/blob/master/kaminari-core/app/views/kaminari/_paginator.html.erb). So I add `entries_info` option to paginate helper.

For example, following code outputs page entries info with pagination.

```erb
<%= paginate User.page(1), entries_info: true, params: {controller: 'users', action: 'index'} %>
```

output:

```html
<nav class="pagination" role="navigation" aria-label="pager">
  <span class="page current">
    1
  </span>
  <span class="page">
    <a rel="next" href="/users?page=2">2</a>
  </span>
  <span class="next">
    <a rel="next" href="/users?page=2">Next &rsaquo;</a>
  </span>
  <span class="last">
    <a href="/users?page=2">Last &raquo;</a>
  </span>
  <span class="entries-info">
    Displaying users <b>1&nbsp;-&nbsp;25</b> of <b>50</b> in total
  </span>
</nav>
```