### PR TITLE
Stop displaying first page link on second page pagination and last page link on penultimate page pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Add `#url_to_next_page` and `#url_to_prev_page` helper methods: [38e95a2](https://github.com/kaminari/kaminari/commit/38e95a262a210548c4f892aaa69d09ca8ecdce7f)
 * Extract url helper methods and pack them in `Kaminari::Helpers::UrlHelper`: [ff38bee](https://github.com/kaminari/kaminari/commit/ff38bee54b5be1a948f1118c0bfd829a72a1a502)
+* Stop displaying first page link on second page pagination and last page link on penultimate page pagination: [@tiagotex]
 
 ### Bug Fixes:
 

--- a/kaminari-core/app/views/kaminari/_first_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.first? || current_page.second?, t('views.pagination.first').html_safe, url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_first_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_first_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.first
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  = link_to_unless current_page.first? || current_page.second?, t('views.pagination.first').html_safe, url, remote: remote

--- a/kaminari-core/app/views/kaminari/_first_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_first_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  == link_to_unless current_page.first? || current_page.second?, t('views.pagination.first').html_safe, url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_last_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.last? || current_page.penultimate?, t('views.pagination.last').html_safe, url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_last_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  = link_to_unless current_page.last? || current_page.penultimate?, t('views.pagination.last').html_safe, url, remote: remote

--- a/kaminari-core/app/views/kaminari/_last_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  == link_to_unless current_page.last? || current_page.penultimate?, t('views.pagination.last').html_safe, url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_paginator.html.erb
+++ b/kaminari-core/app/views/kaminari/_paginator.html.erb
@@ -8,7 +8,7 @@
 -%>
 <%= paginator.render do -%>
   <nav class="pagination" role="navigation" aria-label="pager">
-    <%= first_page_tag unless current_page.first? %>
+    <%= first_page_tag unless current_page.first? || current_page.second? %>
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>
@@ -19,7 +19,7 @@
     <% end -%>
     <% unless current_page.out_of_range? %>
       <%= next_page_tag unless current_page.last? %>
-      <%= last_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? || current_page.penultimate? %>
     <% end %>
   </nav>
 <% end -%>

--- a/kaminari-core/app/views/kaminari/_paginator.html.haml
+++ b/kaminari-core/app/views/kaminari/_paginator.html.haml
@@ -7,7 +7,7 @@
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav.pagination
-    = first_page_tag unless current_page.first?
+    = first_page_tag unless current_page.first? || current_page.second?
     = prev_page_tag unless current_page.first?
     - each_page do |page|
       - if page.display_tag?
@@ -15,4 +15,4 @@
       - elsif !page.was_truncated?
         = gap_tag
     = next_page_tag unless current_page.last?
-    = last_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last? || current_page.penultimate?

--- a/kaminari-core/app/views/kaminari/_paginator.html.slim
+++ b/kaminari-core/app/views/kaminari/_paginator.html.slim
@@ -8,7 +8,7 @@
 
 == paginator.render do
   nav.pagination
-    == first_page_tag unless current_page.first?
+    == first_page_tag unless current_page.first? || current_page.second?
     == prev_page_tag unless current_page.first?
     - each_page do |page|
       - if page.display_tag?
@@ -16,4 +16,4 @@
       - elsif !page.was_truncated?
         == gap_tag
     == next_page_tag unless current_page.last?
-    == last_page_tag unless current_page.last?
+    == last_page_tag unless current_page.last? || current_page.penultimate?

--- a/kaminari-core/lib/kaminari/helpers/paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/paginator.rb
@@ -106,9 +106,19 @@ module Kaminari
           @page == 1
         end
 
+        # the second page or not
+        def second?
+          @page == 2
+        end
+
         # the last page or not
         def last?
           @page == @options[:total_pages]
+        end
+
+        # the page before the last or not
+        def penultimate?
+          @page + 1 == @options[:total_pages]
         end
 
         # the previous page or not

--- a/kaminari-core/test/helpers/paginator_tags_test.rb
+++ b/kaminari-core/test/helpers/paginator_tags_test.rb
@@ -57,7 +57,7 @@ if defined? ::Kaminari::ActionView
         20.times {|i| User.create! name: "user#{i}"}
 
         assert_equal [1, 2, :gap, 10, :next_page, :last_page], tags_for(User.page(1).per(2))
-        assert_equal [:first_page, :prev_page, 1, 2, 3, :gap, 10, :next_page, :last_page], tags_for(User.page(2).per(2))
+        assert_equal [:prev_page, 1, 2, 3, :gap, 10, :next_page, :last_page], tags_for(User.page(2).per(2))
         assert_equal [:first_page, :prev_page, 1, 2, 3, 4, :gap, 10, :next_page, :last_page], tags_for(User.page(3).per(2))
         # the 3rd page doesn't become a gap because it's a single gap
         assert_equal [:first_page, :prev_page, 1, 2, 3, 4, 5, :gap, 10, :next_page, :last_page], tags_for(User.page(4).per(2))
@@ -66,7 +66,7 @@ if defined? ::Kaminari::ActionView
         # the 9th page doesn't become a gap because it's a single gap
         assert_equal [:first_page, :prev_page, 1, :gap, 6, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(7).per(2))
         assert_equal [:first_page, :prev_page, 1, :gap, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(8).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 8, 9, 10, :next_page, :last_page], tags_for(User.page(9).per(2))
+        assert_equal [:first_page, :prev_page, 1, :gap, 8, 9, 10, :next_page], tags_for(User.page(9).per(2))
         assert_equal [:first_page, :prev_page, 1, :gap, 9, 10], tags_for(User.page(10).per(2))
       end
     end


### PR DESCRIPTION
While debugging a problem in ActiveAdmin pagination I found this unexpected behaviour.

I expected the first page link to not be shown in the second page pagination because it does exactly the same as the previous page link. I'm not sure if this link duplication is on purpose or not. 

I've created a quick spike with a possible alternative, let me know if any other work needs to be done. If you decide that the current behaviour is the correct, feel free to close this PR.

Thank you for the nice work maintaining this gem 💚