### PR TITLE
Add clarifying example for external API usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,13 @@ You can specify the `total_count` value through options Hash. This would be help
 @paginatable_array = Kaminari.paginate_array([], total_count: 145).page(params[:page]).per(10)
 ```
 
+or, in the case of using an external API to source the page of data:
+```ruby
+page_size = 10
+one_page = get_page_of_data params[:page], page_size
+@paginatable_array = Kaminari.paginate_array(one_page.data, total_count: one_page.total_count).page(params[:page]).per(page_size)
+```
+
 
 ## Creating Friendly URLs and Caching
 


### PR DESCRIPTION
I recently chose to use Kaminari to help with my pagination needs (great success!), but I found the docs a bit lacking for my specific use-case. This PR extends the Readme with the example I wish had been there when I first read through them.