### PR TITLE
Remove unused `sudo: false` in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ env:
   - DB=postgresql
   - DB=mysql
 
-sudo: false
-
 before_install:
   - gem i rubygems-update -v '<3' && update_rubygems
   - gem i bundler -v '<2'


### PR DESCRIPTION
`sudo: false` has been deprecated.
Now the virtual-machine-based Linux is always used.

See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration