### PR TITLE
fixes without_count last_page? behaviour

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -59,11 +59,11 @@ module Kaminari
       else
         @values[:limit] = limit_value + 1
         # FIXME: this could be removed when we're dropping AR 4 support
-        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit.class)
+        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit)
         super
         @values[:limit] = limit_value - 1
         # FIXME: this could be removed when we're dropping AR 4 support
-        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit.class)
+        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit)
 
         if @records.any?
           @records = @records.dup if (frozen = @records.frozen?)
@@ -76,15 +76,16 @@ module Kaminari
     end
 
     def adjustable?(obj)
-      return true if obj === Integer
-      return true if obj === Arel::Nodes::BindParam && obj.respond_to?(:value)
+      return true if obj.class == Integer
+      return true if obj.class == Arel::Nodes::BindParam && obj.respond_to?(:value)
       false
     end
 
     def adjusted_limit(limit)
-      if Integer === @arel.limit
+      case @arel.limit.class
+      when Integer
         limit
-      elsif Arel::Nodes::BindParam === @arel.limit
+      when Arel::Nodes::BindParam
         Arel::Nodes::BindParam.new(@arel.limit.value.with_cast_value(limit))
       end
     end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -76,9 +76,7 @@ module Kaminari
     end
 
     def adjustable?(obj)
-      return true if obj.class == Integer || obj.class == Fixnum
-      return true if obj.class == Arel::Nodes::BindParam && obj.respond_to?(:value)
-      false
+      obj.class == Integer || obj.class == Fixnum || (obj.class == Arel::Nodes::BindParam && obj.respond_to?(:value))
     end
 
     def adjusted_limit(limit)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -63,7 +63,7 @@ module Kaminari
         super
         @values[:limit] = limit_value - 1
         # FIXME: this could be removed when we're dropping AR 4 support
-        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit)
+        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit.class)
 
         if @records.any?
           @records = @records.dup if (frozen = @records.frozen?)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -63,7 +63,7 @@ module Kaminari
         super
         @values[:limit] = limit_value - 1
         # FIXME: this could be removed when we're dropping AR 4 support
-        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit.class)
+        @arel.limit = adjusted_limit(@values[:limit]) if @arel && adjustable?(@arel.limit)
 
         if @records.any?
           @records = @records.dup if (frozen = @records.frozen?)
@@ -75,8 +75,10 @@ module Kaminari
       end
     end
 
-    def adjustable?(type)
-      [Integer, Arel::Nodes::BindParam].include?(type)
+    def adjustable?(obj)
+      return true if obj === Integer
+      return true obj === Arel::Nodes::BindParam && obj.respond_to?(:value)
+      false
     end
 
     def adjusted_limit(limit)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -77,7 +77,7 @@ module Kaminari
 
     def adjustable?(obj)
       return true if obj === Integer
-      return true obj === Arel::Nodes::BindParam && obj.respond_to?(:value)
+      return true if obj === Arel::Nodes::BindParam && obj.respond_to?(:value)
       false
     end
 

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -76,14 +76,14 @@ module Kaminari
     end
 
     def adjustable?(obj)
-      return true if obj.class == Integer
+      return true if obj.class == Integer || obj.class == Fixnum
       return true if obj.class == Arel::Nodes::BindParam && obj.respond_to?(:value)
       false
     end
 
     def adjusted_limit(limit)
       case @arel.limit.class
-      when Integer
+      when Integer, Fixnum
         limit
       when Arel::Nodes::BindParam
         Arel::Nodes::BindParam.new(@arel.limit.value.with_cast_value(limit))

--- a/kaminari-core/test/models/active_record/paginable_without_count_test.rb
+++ b/kaminari-core/test/models/active_record/paginable_without_count_test.rb
@@ -70,6 +70,22 @@ if defined? ActiveRecord
       assert @users.out_of_range?
     end
 
+    test 'regression: call arel first' do
+      @user = User.page(1).without_count
+      @user.arel
+
+      assert_equal false, @user.last_page?
+    end
+
+    test 'regression: call last page first' do
+      @user = User.page(1).without_count
+
+      @user.last_page?
+      @user.arel
+
+      assert_equal false, @user.last_page?
+    end
+
     def assert_no_queries
       subscriber = ActiveSupport::Notifications.subscribe 'sql.active_record' do
         raise 'A SQL query is being made to the db:'


### PR DESCRIPTION
I believe this will fix [this bug](https://github.com/kaminari/kaminari/issues/975).

After some experimentation I noted that `@arel.limit` is not always an `Integer`. In the cases this code fails to perform as expected this type is `Arel::Nodes::BindParam`. After some inspection of the various types it appears to me this additional type can also be cloned and modified to behave as expected.