### PR TITLE
Fix total_count when grouping model has default scope

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -34,7 +34,7 @@ module Kaminari
 
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
-        c.model.from(c.except(:select).select("1")).count
+        c.model.unscoped.from(c.except(:select).select("1")).count
       else
         c.count(column_name)
       end

--- a/kaminari-core/test/fake_app/active_record/models.rb
+++ b/kaminari-core/test/fake_app/active_record/models.rb
@@ -26,6 +26,12 @@ class Authorship < ActiveRecord::Base
   belongs_to :user
   belongs_to :book
 end
+class CurrentAuthorship < ActiveRecord::Base
+  self.table_name = 'authorships'
+  belongs_to :user
+  belongs_to :book
+  default_scope -> { where(deleted_at: nil) }
+end
 class Readership < ActiveRecord::Base
   belongs_to :user
   belongs_to :book
@@ -63,7 +69,7 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:users) {|t| t.string :name; t.integer :age}
     create_table(:books) {|t| t.string :title}
     create_table(:readerships) {|t| t.integer :user_id; t.integer :book_id }
-    create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id }
+    create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id; t.datetime :deleted_at }
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }
     create_table(:devices) {|t| t.string :name; t.integer :age}
   end

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -100,6 +100,10 @@ if defined? ActiveRecord
         assert_equal 2, Authorship.group(:user_id).having("COUNT(book_id) >= 3").page(1).total_count
       end
 
+      test 'calculating total_count with GROUP BY ... HAVING clause with model that has default scope' do
+        assert_equal 2, CurrentAuthorship.group(:user_id).having("COUNT(book_id) >= 3").page(1).total_count
+      end
+
       test 'total_count with max_pages does not add LIMIT' do
         begin
           subscriber = ActiveSupport::Notifications.subscribe 'sql.active_record' do |_, __, ___, ____, payload|


### PR DESCRIPTION
This PR should fix `#total_count` when grouping model has `default_scope`.

Currently, if you have model like:

```ruby
class User < ApplicationRecord
  default_scope -> { where(deleted_at: nil) }
end
```

and have statement like `User.group(:email).having("COUNT(name) >= 3").page(1).total_count`,  you will get error like "Mysql2::Error: Unknown column 'users.deleted_at' in 'where clause'".

`#total_count` in 1.2.0 uses subquery ([here](https://github.com/kaminari/kaminari/commit/642b535ffa96931e2815ac542eca8bef5ea8cc11#diff-5c0fa2b503b79b941e406eaae810e204R32-R36)). This remove table reference from `FROM` clause,  and `WHERE` clause created by `default_scope` loses table to reference.

This PR removes `default_scope` by calling `unscoped` to solve this issue.