### PR TITLE
Fix: total_count with GROUPED STI relation

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -34,7 +34,8 @@ module Kaminari
 
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
-        c.model.from(c.except(:select).select("1")).count
+        # STI can place a 'hard scope' on the model which doesn't work on the outer query here
+        c.model.unscope(where: :type).from(c.except(:select).select("1")).count
       else
         c.count(column_name)
       end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -35,7 +35,7 @@ module Kaminari
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
         # STI can place a 'hard scope' on the model which doesn't work on the outer query here
-        c.model.unscope(where: :type).from(c.except(:select).select("1")).count
+        c.model.unscoped.unscope(where: :type).from(c.except(:select).select("1")).count
       else
         c.count(column_name)
       end

--- a/kaminari-core/test/fake_app/active_record/models.rb
+++ b/kaminari-core/test/fake_app/active_record/models.rb
@@ -51,6 +51,20 @@ end
 class Device < Product
 end
 
+# STI table: animals
+class Animal < ActiveRecord::Base
+end
+class Mammal < Animal
+end
+class Dog < Mammal
+end
+class Cat < Mammal
+end
+class Insect < Animal
+end
+class Grasshopper < Insect
+end
+
 # migrations
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Tasks::DatabaseTasks.root = Dir.pwd
@@ -66,6 +80,7 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id }
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }
     create_table(:devices) {|t| t.string :name; t.integer :age}
+    create_table(:animals) {|t| t.string :type; t.string :name}
   end
 end
 CreateAllTables.up

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -14,6 +14,11 @@ if defined? ActiveRecord
         @books3 = 4.times.map {|i| @author3.books_authored.create!(title: "subject%03d" % i) }
         @readers = 4.times.map { User.create! name: 'reader' }
         @books.each {|book| book.readers << @readers }
+        [
+          ['Fenton', Dog], ['Bob', Dog],
+          ['Garfield', Cat], ['Bob', Cat],
+          ['Caine', Grasshopper]
+        ].each { |name, type| type.create! name: name }
       end
       teardown do
         Book.delete_all
@@ -98,6 +103,11 @@ if defined? ActiveRecord
 
       test 'calculating total_count with GROUP BY ... HAVING clause' do
         assert_equal 2, Authorship.group(:user_id).having("COUNT(book_id) >= 3").page(1).total_count
+      end
+
+      test 'calculating STI total_count with GROUP BY clause' do
+        # A type-based restriction places a scope on the model
+        assert_equal 3, Mammal.group(:name).page(1).total_count
       end
 
       test 'total_count with max_pages does not add LIMIT' do


### PR DESCRIPTION
When querying a subtype on a STI table, a 'hard scope' is applied that
is incompatible with the use of `model.from(subquery)`

This fix removes any type restriction from the _outer_ query (because
the subquery already has the restriction).

Introduced by #979