### PR TITLE
Blacklist "original_script_name" get param

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -2,7 +2,7 @@
 
 module Kaminari
   module Helpers
-    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name].freeze
+    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name].freeze
 
     # A tag stands for an HTML tag inside the paginator.
     # Basically, a tag has its own partial template file, so every tag can be


### PR DESCRIPTION
I was looking over the source code, and I noticed that the get param black list was incomplete. Passing the `original_script_name` param will redirect to other domains.