### PR TITLE
Grouped query performance of total_count using Arel

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -32,15 +32,13 @@ module Kaminari
 
       c = c.limit(max_pages * limit_value) if max_pages && max_pages.respond_to?(:*)
 
-      # .group returns an OrderedHash that responds to #count
-      c = c.count(column_name)
-      @total_count = if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-                       c.count
-                     elsif c.respond_to? :count
-                       c.count(column_name)
-                     else
-                       c
-                     end
+      # Handle grouping with a subquery
+      @total_count = if c.group_values.any?
+        sq = c.except(:select).select("1 AS record").arel.as("subquery")
+        c.model.connection.select_value Arel::SelectManager.new.from(sq).project(sq[:record].count)
+      else
+        c.count(column_name)
+      end
     end
 
     # Turn this Relation to a "without count mode" Relation.

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -34,6 +34,9 @@ module Kaminari
 
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
+        # Only count non-null values of column_name if supplied
+        c = c.where.not column_name => nil unless column_name.nil? || column_name == :all
+
         sq = c.except(:select).select(1).arel.as("subquery")
         c.connection.select_value Arel::SelectManager.new.from(sq).project(Arel.star.count)
       else

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -34,8 +34,8 @@ module Kaminari
 
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
-        sq = c.except(:select).select("1 AS record").arel.as("subquery")
-        c.model.connection.select_value Arel::SelectManager.new.from(sq).project(sq[:record].count)
+        sq = c.except(:select).select(1).arel.as("subquery")
+        c.connection.select_value Arel::SelectManager.new.from(sq).project(Arel.star.count)
       else
         c.count(column_name)
       end

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -105,13 +105,13 @@ if defined? ActiveRecord
       end
 
       test 'calculating STI total_count with GROUP BY clause' do
-        {
-          'Fenton'   => Dog,
-          'Bob'      => Dog,
-          'Garfield' => Cat,
-          'Bob'      => Cat,
-          'Caine'    => Insect
-        }.each { |name, type| type.create!(name: name) }
+        [
+          ['Fenton',   Dog],
+          ['Bob',      Dog],
+          ['Garfield', Cat],
+          ['Bob',      Cat],
+          ['Caine', Insect]
+        ].each { |name, type| type.create!(name: name) }
 
         assert_equal 3, Mammal.group(:name).page(1).total_count
       end


### PR DESCRIPTION
Improved performance for total_count on grouped ActiveRecord::Relation.

This re-implements #979 using Arel to avoid issues #1012 and #1015

After implementing it this way, it became obvious that Arel really wasn't doing anything special that couldn't safely be achieved with plain SQL, so I'm opening a 2nd PR to proffer the choice...