### PR TITLE
Grouped query performance of total_count using SQL

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -37,7 +37,7 @@ module Kaminari
         # Only count non-null values of column_name if supplied
         c = c.where.not column_name => nil unless column_name.nil? || column_name == :all
 
-        c.connection.select_value <<-SQL.strip!
+        c.connection.select_value(<<-SQL.strip).to_i
           SELECT count(*) FROM (#{c.except(:select).select(1).to_sql}) subquery
         SQL
       else

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -38,7 +38,7 @@ module Kaminari
         c = c.where.not column_name => nil unless column_name.nil? || column_name == :all
 
         c.connection.select_value(<<-SQL.strip).to_i
-          SELECT count(*) FROM (#{c.except(:select).select(1).to_sql}) subquery
+          SELECT count(*) FROM (#{c.except(:select).select("1").to_sql}) subquery
         SQL
       else
         c.count(column_name)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -32,15 +32,14 @@ module Kaminari
 
       c = c.limit(max_pages * limit_value) if max_pages && max_pages.respond_to?(:*)
 
-      # .group returns an OrderedHash that responds to #count
-      c = c.count(column_name)
-      @total_count = if c.is_a?(Hash) || c.is_a?(ActiveSupport::OrderedHash)
-                       c.count
-                     elsif c.respond_to? :count
-                       c.count(column_name)
-                     else
-                       c
-                     end
+      # Handle grouping with a subquery
+      @total_count = if c.group_values.any?
+        c.model.connection.select_value <<~SQL
+          SELECT count(*) FROM (#{c.except(:select).select("1").to_sql}) subquery
+        SQL
+      else
+        c.count(column_name)
+      end
     end
 
     # Turn this Relation to a "without count mode" Relation.

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -34,8 +34,11 @@ module Kaminari
 
       # Handle grouping with a subquery
       @total_count = if c.group_values.any?
-        c.model.connection.select_value <<~SQL
-          SELECT count(*) FROM (#{c.except(:select).select("1").to_sql}) subquery
+        # Only count non-null values of column_name if supplied
+        c = c.where.not column_name => nil unless column_name.nil? || column_name == :all
+
+        c.connection.select_value <<-SQL.strip!
+          SELECT count(*) FROM (#{c.except(:select).select(1).to_sql}) subquery
         SQL
       else
         c.count(column_name)

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -105,13 +105,13 @@ if defined? ActiveRecord
       end
 
       test 'calculating STI total_count with GROUP BY clause' do
-        {
-          'Fenton'   => Dog,
-          'Bob'      => Dog,
-          'Garfield' => Cat,
-          'Bob'      => Cat,
-          'Caine'    => Insect
-        }.each { |name, type| type.create!(name: name) }
+        [
+          ['Fenton',   Dog],
+          ['Bob',      Dog],
+          ['Garfield', Cat],
+          ['Bob',      Cat],
+          ['Caine', Insect]
+        ].each { |name, type| type.create!(name: name) }
 
         assert_equal 3, Mammal.group(:name).page(1).total_count
       end


### PR DESCRIPTION
Improved performance for total_count on grouped ActiveRecord::Relation.

This re-implements #979 using plain SQL to avoid issues #1012 and #1015

This is an alternative solution to #1022