### PR TITLE
Fix alias name of next_page_url

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -41,7 +41,7 @@ module Kaminari
       def next_page_url(scope, options = {})
         "#{request.base_url}#{next_page_path(scope, options)}" if scope.next_page
       end
-      alias path_to_next_url next_page_url
+      alias url_to_next_page next_page_url
 
       # A helper that calculates the url to the previous page.
       #

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -43,6 +43,11 @@ module Kaminari
       end
       alias url_to_next_page next_page_url
 
+      def path_to_next_url(scope, options = {})
+        ActiveSupport::Deprecation.warn 'path_to_next_url is deprecated. Use next_page_url or url_to_next_page instead.'
+        next_page_url(scope, options)
+      end
+
       # A helper that calculates the url to the previous page.
       #
       # ==== Examples


### PR DESCRIPTION
The alias of `next_page_url` should be `url_to_next_page`, shouldn't it?
(It was defined at 38e95a262a210548c4f892aaa69d09ca8ecdce7f)