### PR TITLE
Fix 'STI total_count with GROUP BY clause' test

### DIFF
--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -105,13 +105,13 @@ if defined? ActiveRecord
       end
 
       test 'calculating STI total_count with GROUP BY clause' do
-        {
-          'Fenton'   => Dog,
-          'Bob'      => Dog,
-          'Garfield' => Cat,
-          'Bob'      => Cat,
-          'Caine'    => Insect
-        }.each { |name, type| type.create!(name: name) }
+        [
+          ['Fenton',   Dog],
+          ['Bob',      Dog],
+          ['Garfield', Cat],
+          ['Bob',      Cat],
+          ['Caine', Insect]
+        ].each { |name, type| type.create!(name: name) }
 
         assert_equal 3, Mammal.group(:name).page(1).total_count
       end


### PR DESCRIPTION
This test's data was built using a hash keyed by a name which was
included twice, so it would always pass as long as total_count builds a
valid query. Fixed by using a 2D array instead.

I'm just raising this as a separate PR as I've no idea which - if any - of my other PRs might be merged.