### PR TITLE
Use valid link tags in rel_next_prev_link_tags

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -231,15 +231,15 @@ module Kaminari
       #     <%= rel_next_prev_link_tags @items %>
       #   <% end %>
       #
-      #   #-> <link rel="next" href="/items/page/3" /><link rel="prev" href="/items/page/1" />
+      #   #-> <link rel="next" href="/items/page/3"><link rel="prev" href="/items/page/1">
       #
       def rel_next_prev_link_tags(scope, options = {})
         next_page = path_to_next_page(scope, options)
         prev_page = path_to_prev_page(scope, options)
 
         output = String.new
-        output << %Q|<link rel="next" href="#{next_page}"></link>| if next_page
-        output << %Q|<link rel="prev" href="#{prev_page}"></link>| if prev_page
+        output << %Q|<link rel="next" href="#{next_page}">| if next_page
+        output << %Q|<link rel="prev" href="#{prev_page}">| if prev_page
         output.html_safe
       end
     end


### PR DESCRIPTION
Currently `rel_next_prev_link_tags` generates `link` tags as `<link ...></link>`, which triggers warning in [W3C's HTML validator](https://validator.w3.org/nu/).

According to [HTML4](https://www.w3.org/TR/html401/struct/links.html#h-12.3) & [HTML5](https://www.w3.org/TR/html52/document-metadata.html#the-link-element) standards, the correct format is actually just `<link ..>`.

P.S. `<link .../>` (aka self-closing) used to be the allowed in XHTML, and our current implementation `<link ..></link>` has never been in the standard.