### PR TITLE
Default branch for Rails is now main instead of master

### DIFF
--- a/gemfiles/active_record_edge.gemfile
+++ b/gemfiles/active_record_edge.gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-github 'rails/rails' do
+github 'rails/rails', branch: 'main' do
   gem 'railties'
   gem 'activerecord', require: 'active_record'
   gem 'actionview', require: 'action_view'


### PR DESCRIPTION
The default branch for Rails has been changed to `main` since January 15, 2021. [DHH's tweet](https://twitter.com/dhh/status/1350091751789375490)
So I specified `main` branch for `active_record_edge.gemfile`.