### PR TITLE
Fix: code quality issues

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,9 @@
+version = 1
+
+test_patterns = ["**/*_test.rb"]
+
+exclude_patterns = ["gemfiles/**"]
+
+[[analyzers]]
+name = "ruby"
+enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,0 @@
-version = 1
-
-test_patterns = ["**/*_test.rb"]
-
-exclude_patterns = ["gemfiles/**"]
-
-[[analyzers]]
-name = "ruby"
-enabled = true

--- a/kaminari-actionview/lib/kaminari/actionview.rb
+++ b/kaminari-actionview/lib/kaminari/actionview.rb
@@ -5,7 +5,7 @@ require 'active_support/lazy_load_hooks'
 
 ActiveSupport.on_load :action_view do
   require 'kaminari/helpers/helper_methods'
-  ::ActionView::Base.send :include, Kaminari::Helpers::HelperMethods
+  ::ActionView::Base.include Kaminari::Helpers::HelperMethods
 
   require 'kaminari/actionview/action_view_extension'
 end

--- a/kaminari-actionview/lib/kaminari/actionview/action_view_extension.rb
+++ b/kaminari-actionview/lib/kaminari/actionview/action_view_extension.rb
@@ -18,6 +18,6 @@ module Kaminari
 end
 
 # so that this instance can actually "render"
-::Kaminari::Helpers::Paginator.send :include, ::ActionView::Context
+::Kaminari::Helpers::Paginator.include ::ActionView::Context
 
-ActionView::LogSubscriber.send :prepend, Kaminari::ActionViewExtension::LogSubscriberSilencer
+ActionView::LogSubscriber.prepend Kaminari::ActionViewExtension::LogSubscriberSilencer

--- a/kaminari-activerecord/lib/kaminari/activerecord.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord.rb
@@ -6,5 +6,5 @@ require 'active_support/lazy_load_hooks'
 ActiveSupport.on_load :active_record do
   require 'kaminari/core'
   require 'kaminari/activerecord/active_record_extension'
-  ::ActiveRecord::Base.send :include, Kaminari::ActiveRecordExtension
+  ::ActiveRecord::Base.include Kaminari::ActiveRecordExtension
 end

--- a/kaminari-core/lib/generators/kaminari/views_generator.rb
+++ b/kaminari-core/lib/generators/kaminari/views_generator.rb
@@ -4,7 +4,7 @@ module Kaminari
   module Generators
     # rails g kaminari:views THEME
     class ViewsGenerator < Rails::Generators::NamedBase # :nodoc:
-      source_root File.expand_path('../../../../app/views/kaminari', __FILE__)
+      source_root File.expand_path('../../../app/views/kaminari', __dir__)
 
       class_option :template_engine, type: :string, aliases: '-e', desc: 'Template engine for the views. Available options are "erb", "haml", and "slim".'
       class_option :views_prefix, type: :string, desc: 'Prefix for path to put views in.'

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -238,8 +238,8 @@ module Kaminari
         prev_page = path_to_prev_page(scope, options)
 
         output = String.new
-        output << %Q|<link rel="next" href="#{next_page}">| if next_page
-        output << %Q|<link rel="prev" href="#{prev_page}">| if prev_page
+        output << %|<link rel="next" href="#{next_page}">| if next_page
+        output << %|<link rel="prev" href="#{prev_page}">| if prev_page
         output.html_safe
       end
     end

--- a/kaminari-core/test/fake_gem.rb
+++ b/kaminari-core/test/fake_gem.rb
@@ -14,7 +14,7 @@ module Kaminari
 end
 
 ActiveSupport.on_load :active_record do
-  ActiveRecord::Base.send :include, Kaminari::FakeGem
+  ActiveRecord::Base.include Kaminari::FakeGem
 
   # Simulate a gem providing a subclass of ActiveRecord::Base before the Railtie is loaded.
   class GemDefinedModel < ActiveRecord::Base

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -119,14 +119,14 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
         users = User.page(1)
 
         assert_nil view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'})
-        assert_equal 'At the Beginning', (view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'}) do 'At the Beginning' end)
+        assert_equal 'At the Beginning', (view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'}) { 'At the Beginning' })
       end
 
       test 'out of range' do
         users = User.page(5)
 
         assert_nil view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'})
-        assert_equal 'At the Beginning', (view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'}) do 'At the Beginning' end)
+        assert_equal 'At the Beginning', (view.link_to_previous_page(users, 'Previous', params: {controller: 'users', action: 'index'}) { 'At the Beginning' })
       end
 
       test '#link_to_previous_page accepts ActionController::Parameters' do


### PR DESCRIPTION
#### Description
This PR fixes a few issues that were affecting the code quality.

#### Summary of changes

- Remove improper use of `%q()` or `%()`
- Fix improper use of block delimiter
- Remove `send` methods with mixin
- Fix parameters being passed to `expand_path