### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,105 @@
+name: Ruby
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    services:
+      postgresql:
+        image: postgres:9.6
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby_version:
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+          - 'jruby-9.2.9.0'
+        gemfile:
+          - gemfiles/active_record_60.gemfile
+          - gemfiles/active_record_52.gemfile
+          - gemfiles/active_record_51.gemfile
+          - gemfiles/active_record_50.gemfile
+          - gemfiles/active_record_42.gemfile
+          - gemfiles/active_record_41.gemfile
+          - gemfiles/active_record_edge.gemfile
+        db:
+          - sqlite3
+          - postgresql
+          - mysql
+        exclude:
+          - ruby_version: '2.7'
+            gemfile: gemfiles/active_record_52.gemfile
+          - ruby_version: '2.7'
+            gemfile: gemfiles/active_record_51.gemfile
+          - ruby_version: '2.7'
+            gemfile: gemfiles/active_record_50.gemfile
+          - ruby_version: '2.7'
+            gemfile: gemfiles/active_record_42.gemfile
+          - ruby_version: '2.7'
+            gemfile: gemfiles/active_record_41.gemfile
+          - ruby_version: '2.6'
+            gemfile: gemfiles/active_record_edge.gemfile
+          - ruby_version: '2.6'
+            gemfile: gemfiles/active_record_42.gemfile
+          - ruby_version: '2.6'
+            gemfile: gemfiles/active_record_41.gemfile
+          - ruby_version: '2.5'
+            gemfile: gemfiles/active_record_edge.gemfile
+          - ruby_version: '2.5'
+            gemfile: gemfiles/active_record_42.gemfile
+          - ruby_version: '2.5'
+            gemfile: gemfiles/active_record_41.gemfile
+          - ruby_version: '2.4'
+            gemfile: gemfiles/active_record_edge.gemfile
+          - ruby_version: '2.4'
+            gemfile: gemfiles/active_record_60.gemfile
+          - ruby_version: '2.4'
+            gemfile: gemfiles/active_record_42.gemfile
+          - ruby_version: '2.4'
+            gemfile: gemfiles/active_record_41.gemfile
+          - ruby_version: '2.3'
+            gemfile: gemfiles/active_record_edge.gemfile
+          - ruby_version: '2.3'
+            gemfile: gemfiles/active_record_60.gemfile
+          - ruby_version: 'jruby-9.2.9.0'
+            gemfile: gemfiles/active_record_42.gemfile
+          - ruby_version: 'jruby-9.2.9.0'
+            gemfile: gemfiles/active_record_41.gemfile
+          - ruby_version: 'jruby-9.2.9.0'
+            gemfile: gemfiles/active_record_edge.gemfile 
+        include:
+          - ruby_version: 'ruby-head'
+            gemfile: gemfiles/active_record_edge.gemfile
+            db: sqlite3
+          - ruby_version: '2.2'
+            gemfile: gemfiles/active_record_51.gemfile
+            db: sqlite3
+          - ruby_version: '2.1'
+            gemfile: gemfiles/active_record_42.gemfile
+            db: sqlite3
+    runs-on: ubuntu-16.04
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      DB: ${{ matrix.db }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start local MySQL
+        run: sudo /etc/init.d/mysql start
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+        continue-on-error: ${{ matrix.ruby_version == 'ruby-head' || matrix.ruby_version == 'jruby-9.2.9.0' || matrix.gemfile == 'gemfiles/active_record_edge.gemfile' }}
+      - run: mv kaminari-core/test/fake_app/config/database_gha.yml kaminari-core/test/fake_app/config/database.yml
+      - run: bundle exec rake test
+        continue-on-error: ${{ matrix.ruby_version == 'ruby-head' || matrix.ruby_version == 'jruby-9.2.9.0' || matrix.gemfile == 'gemfiles/active_record_edge.gemfile' }}

--- a/kaminari-core/test/fake_app/config/database_gha.yml
+++ b/kaminari-core/test/fake_app/config/database_gha.yml
@@ -1,0 +1,22 @@
+sqlite3: &sqlite3
+  adapter: sqlite3
+  database: <%= File.expand_path '../test/fake_app/kaminari_test.sqlite3', __FILE__ %>
+  pool: 5
+  timeout: 5000
+
+postgresql: &postgresql
+  adapter: postgresql
+  host: localhost
+  username: postgres
+  password: postgres
+  database: kaminari_test
+
+mysql: &mysql
+  adapter: mysql2
+  host: localhost
+  username: root
+  password: root
+  database: kaminari_test
+
+test:
+  <<: *<%= ENV['DB'] %>


### PR DESCRIPTION
It seems that CI with Travis CI is taking a very long time, at least 3 hours or more...
To save time, I created this PR that migrate CI to GitHub Actions.
CI with GitHub Actions will take less than 15 minutes.

Let me explain a few things:

* The database password seems to be required by default, so I set passwords.
We can choose not to set passwords, but I think it's better to have them.
* Rails edge now [requires Ruby 2.7 and above](https://github.com/rails/rails/commit/6487836af8f50648a9b30ce61864c827132e5592). So I excluded combinations of 2.6, 2.5, jruby and Rails edge. 
* GitHub Actions does not have Travis CI's `allow_failures`, so I used `continue-on-error` instead.
* Tests against rbx seems to have not been run for a long time, so I ignored it.
(and [ruby/setup-ruby@v1](https://github.com/ruby/setup-ruby) does not support rbx)
* [ruby/setup-ruby@v1](https://github.com/ruby/setup-ruby) does not support Ruby 2.0 either.
That's why I'm still using Travis CI just for testing ruby 2.0.
If we can drop support for Ruby 2.0, we can completely migrate to GitHub Actions!