### PR TITLE
Test improvements

### DIFF
--- a/kaminari-core/test/helpers/paginator_tags_test.rb
+++ b/kaminari-core/test/helpers/paginator_tags_test.rb
@@ -2,73 +2,71 @@
 
 require 'test_helper'
 
-if defined? ::Kaminari::ActionView
-  class PaginatorTagsTest < ActionView::TestCase
-    # A test paginator that can detect instantiated tags inside
-    class TagSpy < Kaminari::Helpers::Paginator
-      def initialize(*)
-        super
-        @tags = []
-      end
-
-      def page_tag(page)
-        @tags << page.to_i
-        super
-      end
-
-      %w[first_page prev_page next_page last_page gap].each do |tag|
-        eval <<-DEF, nil, __FILE__, __LINE__ + 1
-          def #{tag}_tag
-            @tags << :#{tag}
-            super
-          end
-        DEF
-      end
-
-      def partial_path
-        'kaminari/paginator'
-      end
-
-      def to_s
-        super
-        @tags
-      end
+class PaginatorTagsTest < ActionView::TestCase
+  # A test paginator that can detect instantiated tags inside
+  class TagSpy < Kaminari::Helpers::Paginator
+    def initialize(*)
+      super
+      @tags = []
     end
 
-    def tags_for(collection, window: 4, outer_window: 0)
-      view.paginate(collection, paginator_class: TagSpy, window: window, outer_window: outer_window, params: {controller: 'users', action: 'index'})
+    def page_tag(page)
+      @tags << page.to_i
+      super
     end
 
-    teardown do
-      User.delete_all
+    %w[first_page prev_page next_page last_page gap].each do |tag|
+      eval <<-DEF, nil, __FILE__, __LINE__ + 1
+        def #{tag}_tag
+          @tags << :#{tag}
+          super
+        end
+      DEF
     end
 
-    test '1 page in total' do
-      3.times {|i| User.create! name: "user#{i}"}
-      assert_empty tags_for(User.page(1).per(3))
+    def partial_path
+      'kaminari/paginator'
     end
 
-    sub_test_case 'when having 1 outer_window (and 1 inner window)' do
-      def tags_for(collection, window: 1, outer_window: 1)
-        super
-      end
+    def to_s
+      super
+      @tags
+    end
+  end
 
-      test '10 pages in total' do
-        20.times {|i| User.create! name: "user#{i}"}
+  def tags_for(collection, window: 4, outer_window: 0)
+    view.paginate(collection, paginator_class: TagSpy, window: window, outer_window: outer_window, params: {controller: 'users', action: 'index'})
+  end
 
-        assert_equal [1, 2, :gap, 10, :next_page, :last_page], tags_for(User.page(1).per(2))
-        assert_equal [:first_page, :prev_page, 1, 2, 3, :gap, 10, :next_page, :last_page], tags_for(User.page(2).per(2))
-        assert_equal [:first_page, :prev_page, 1, 2, 3, 4, :gap, 10, :next_page, :last_page], tags_for(User.page(3).per(2))
-        # the 3rd page doesn't become a gap because it's a single gap
-        assert_equal [:first_page, :prev_page, 1, 2, 3, 4, 5, :gap, 10, :next_page, :last_page], tags_for(User.page(4).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 4, 5, 6, :gap, 10, :next_page, :last_page], tags_for(User.page(5).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 5, 6, 7, :gap, 10, :next_page, :last_page], tags_for(User.page(6).per(2))
-        # the 9th page doesn't become a gap because it's a single gap
-        assert_equal [:first_page, :prev_page, 1, :gap, 6, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(7).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(8).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 8, 9, 10, :next_page, :last_page], tags_for(User.page(9).per(2))
-        assert_equal [:first_page, :prev_page, 1, :gap, 9, 10], tags_for(User.page(10).per(2))
-      end
+  teardown do
+    User.delete_all
+  end
+
+  test '1 page in total' do
+    3.times {|i| User.create! name: "user#{i}"}
+    assert_empty tags_for(User.page(1).per(3))
+  end
+
+  sub_test_case 'when having 1 outer_window (and 1 inner window)' do
+    def tags_for(collection, window: 1, outer_window: 1)
+      super
+    end
+
+    test '10 pages in total' do
+      20.times {|i| User.create! name: "user#{i}"}
+
+      assert_equal [1, 2, :gap, 10, :next_page, :last_page], tags_for(User.page(1).per(2))
+      assert_equal [:first_page, :prev_page, 1, 2, 3, :gap, 10, :next_page, :last_page], tags_for(User.page(2).per(2))
+      assert_equal [:first_page, :prev_page, 1, 2, 3, 4, :gap, 10, :next_page, :last_page], tags_for(User.page(3).per(2))
+      # the 3rd page doesn't become a gap because it's a single gap
+      assert_equal [:first_page, :prev_page, 1, 2, 3, 4, 5, :gap, 10, :next_page, :last_page], tags_for(User.page(4).per(2))
+      assert_equal [:first_page, :prev_page, 1, :gap, 4, 5, 6, :gap, 10, :next_page, :last_page], tags_for(User.page(5).per(2))
+      assert_equal [:first_page, :prev_page, 1, :gap, 5, 6, 7, :gap, 10, :next_page, :last_page], tags_for(User.page(6).per(2))
+      # the 9th page doesn't become a gap because it's a single gap
+      assert_equal [:first_page, :prev_page, 1, :gap, 6, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(7).per(2))
+      assert_equal [:first_page, :prev_page, 1, :gap, 7, 8, 9, 10, :next_page, :last_page], tags_for(User.page(8).per(2))
+      assert_equal [:first_page, :prev_page, 1, :gap, 8, 9, 10, :next_page, :last_page], tags_for(User.page(9).per(2))
+      assert_equal [:first_page, :prev_page, 1, :gap, 9, 10], tags_for(User.page(10).per(2))
     end
   end
 end

--- a/kaminari-core/test/helpers/paginator_tags_test.rb
+++ b/kaminari-core/test/helpers/paginator_tags_test.rb
@@ -5,8 +5,8 @@ require 'test_helper'
 class PaginatorTagsTest < ActionView::TestCase
   # A test paginator that can detect instantiated tags inside
   class TagSpy < Kaminari::Helpers::Paginator
-    def initialize(*)
-      super
+    def initialize(template, **options)
+      super(template, **options)
       @tags = []
     end
 


### PR DESCRIPTION
This PR will fix some problems on test codes.

* It seems that PaginatorTagsTest is not executed all the time, so I removed `if defined? ::Kaminari::ActionView`.
Then the warning about keyword args on Ruby 2.7 came up, so I handled it and confirmed all tests passed.

  * Before change:
    ```
    Started
    ................................................................................
    ................................................................................
    ................................................................................
    ................................................................................
    ................................................................................
    ................
    Finished in 75.099708361 seconds.
    --------------------------------------------------------------------------------
    416 tests, 562 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    --------------------------------------------------------------------------------
    5.54 tests/s, 7.48 assertions/s
    ```


  * After change:
    ```
    Started
    ................................................................................
    ................................................................................
    ................................................................................
    ................................................................................
    ................................................................................
    ..................
    Finished in 68.046275066 seconds.
    --------------------------------------------------------------------------------
    418 tests, 573 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed
    --------------------------------------------------------------------------------
    6.14 tests/s, 8.42 assertions/s
    ```