### PR TITLE
Warn when no ordering is in place

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -14,10 +14,17 @@ module Kaminari
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
         def self.#{Kaminari.config.page_method_name}(num = nil)
           per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
-          limit(per_page).offset(per_page * ((num = num.to_i - 1) < 0 ? 0 : num)).extending do
+          scope = limit(per_page).offset(per_page * ((num = num.to_i - 1) < 0 ? 0 : num)).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::PageScopeMethods
           end
+          # Using limit and offset is unreliable without ordering
+          # Warn the developers using paginatin wihout the order clause
+          if scope.order_values.empty?
+            warn "WARNING: It seems you're using pagination without an ORDER BY clause."
+            warn "This might result in unexpected or random records on paginated results."
+          end
+          scope
         end
       RUBY
     end

--- a/kaminari-core/test/models/active_record/scopes_test.rb
+++ b/kaminari-core/test/models/active_record/scopes_test.rb
@@ -16,6 +16,23 @@ if defined? ActiveRecord
         Kaminari.configure {|config| config.page_method_name = :page }
       end
     end
+    
+    test 'Show warning when using scope without ordering' do
+      expected_err = "WARNING: It seems you're using pagination without an ORDER BY clause.\nThis might result in unexpected or random records on paginated results.\n"
+      log, err = capture_output do
+        User.page(1)
+      end
+
+      assert_equal(err, expected_err)
+    end
+
+    test "Don't whow warning when scope is used with order" do
+      log, err = capture_output do
+        User.order(User.primary_key).page(1)
+      end
+      
+      assert_equal(err,'')
+    end
   end
 
   class ActiveRecordExtensionTest < ActiveSupport::TestCase


### PR DESCRIPTION
Hey, I'm submitting the PR that adds a warning when no ordering is in place. 

This code is connected to the following:
https://github.com/kaminari/kaminari/pull/1042 and
https://github.com/kaminari/kaminari/issues/1040 (I think this one explains the issue well enough)

This code will for sure screw the test output quite a bit but for a good reason. 
I mean, for sure the correct ordering is the responsibility of the developer who uses this gem, however, I believe in this case it is easily missed, especially because there is (still) no warning in the documentation, also the existing tests don't offer a good practice example. (I am prepared to fix existing tests as well, please let me know if this PR is acceptable. )

Not using ordering, can lead to some nasty consequences especially when Kaminari is used in an API.

There is also another option to resolve this issue (albeit more intrusive):
The default order by column could be added to the config and then prepend it to the 'page' scope. 
(Another variant would be to use the primary key of the model if exists)
