### PR TITLE
Add support for `format` option in `next_page_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ This option makes it easier to do things like A/B testing pagination templates/t
 
 This simply renders a link to the next page. This would be helpful for creating a Twitter-like pagination feature.
 
+The helper methods support a `params` option to further specify the link. If `format` needs to be set, inlude it in the `params` hash.
+
+```erb
+<%= link_to_next_page @items, 'Next Page', params: {controller: 'foo', action: 'bar', format: :turbo_stream} %>
+```
+
 ### The `page_entries_info` Helper Method
 
 ```erb

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ This would modify the query parameter name on each links.
 ### Extra Parameters (`:params`) for the Links
 
 ```erb
-<%= paginate @users, params: {controller: 'foo', action: 'bar'} %>
+<%= paginate @users, params: {controller: 'foo', action: 'bar', format: :turbo_stream} %>
 ```
 
 This would modify each link's `url_option`. :`controller` and :`action` might be the keys in common.

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -526,6 +526,11 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
         users = User.page(2).per(1)
         assert_nil view.path_to_next_page(users, params: {controller: 'users', action: 'index'})
       end
+
+      test 'format option' do
+        users = User.page(1).per(1)
+        assert_equal '/users.turbo_stream?page=2', view.path_to_next_page(users, params: {controller: 'users', action: 'index', format: :turbo_stream})
+      end
     end
 
     sub_test_case '#path_to_prev_page' do


### PR DESCRIPTION
## Current situation

The `next_page_path` method currently ignores any passed `format` options.

Example:

```ruby
next_page_path(@posts, format: :turbo_stream)
```

Results in:

```
/posts?page=2
```

## Expected behavior

I would expect that the `format` option is represented in the path:

```
/posts.turbo_stream?page=2
```

## Use Case

I have a list, paginated with kaminari. However, there is no shown pagination. At the bottom of the list there is a "load more" button, which loads the next page and appends it to the current list. Hotwire/Turbo is used for this, with the following view code for the button:

```ruby
= button_to 'Load more', next_page_path(@posts, format: :turbo_stream), method: :get
```

Turbo requires the link/button to be a form (if it's a link, Turbo will request HTML instead of `turbo_stream`). As we display a list of items, this should be a `get` request (and we can reuse the usual `index` action for it). However, Turbo does not add the required headers in `get` requests. So `format: :turbo_stream` needs to be explicitly set.

I'm aware that this requirement might be a bit stretched. However, I believe because `next_page_path` uses the Rails naming convention for `path` methods, it is suprising if the same options are simply ignored.

## Proposed change

This simply adds any `format` option to the path, if one is provided.