### PR TITLE
Add max_pages documentation to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ class User < ActiveRecord::Base
 end
 ```
 
+### Configuring max_pages Value for Each Model by `max_pages`
+
+You can specify `max_pages` value per each model using the following declarative DSL.
+This value restricts the total number of pages that can be returned.  Useful for setting limits on large collections.
+
+```ruby
+class User < ActiveRecord::Base
+  max_pages 100
+end
+```
+
 ### Configuring params_on_first_page when using ransack_memory
 
 If you are using [the `ransack_memory` gem](https://github.com/richardrails/ransack_memory) and experience problems navigating back to the previous or first page, set the `params_on_first_page` setting to `true`.


### PR DESCRIPTION
Recently ran into an issue where determining total_count for a collection created from a complex query was taking too long and timing out our server.  We didn't need to return all the records however, just a recent subset, so this method works perfectly and greatly reduces query time.  However we found no real documentation for this method and google searches proved mostly fruitless--wasn't until looking into the Kaminari codebase that I discovered this method could be applied per model.  I'd recommend adding some form of documentation to the readme to save future users the headache--feel free to use what I've provided here or substitute something else.  Thanks!