### PR TITLE
expose version number automatically instead of explicitly requiring it

### DIFF
--- a/lib/kaminari.rb
+++ b/lib/kaminari.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require 'kaminari/core'
+require 'kaminari/version'
 require 'kaminari/actionview'
 require 'kaminari/activerecord'


### PR DESCRIPTION
# Problem
When developing with my organization we needed to `raise` if someone tries to update Kaminari past a certain version. 
It was discovered that `Kaminari::VERSION` was not automatically exposed without explicitly requiring it via `require 'kaminari/version'`

# Solution
Explicitly expose the version to gem consumers. 

Any and all feedback is definitely welcome--including on ideas of how to test this.