### PR TITLE
Do not deduce the total count if 'load' and 'padding' methods are called

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -19,7 +19,7 @@ module Kaminari
 
       # There are some cases that total count can be deduced from loaded records
       # If `padding` method is called, this deduction is wrong
-      if loaded? && !@_padding
+      if loaded? && !defined?(@_padding)
         # Total count has to be 0 if loaded records are 0
         return @total_count = 0 if (current_page == 1) && @records.empty?
         # Total count is calculable at the last page

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -18,7 +18,8 @@ module Kaminari
       return @total_count if defined?(@total_count) && @total_count
 
       # There are some cases that total count can be deduced from loaded records
-      if loaded?
+      # If `padding` method is called, this deduction is wrong
+      if loaded? && !@_padding
         # Total count has to be 0 if loaded records are 0
         return @total_count = 0 if (current_page == 1) && @records.empty?
         # Total count is calculable at the last page

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -39,6 +39,7 @@ if defined? ActiveRecord
         assert_equal 7, User.page(2).load.total_count
         assert_equal 7, User.page(2).per(10).load.total_count
         assert_equal 7, User.page(2).per(2).load.total_count
+        assert_equal 7, User.page(1).padding(7).load.total_count
 
         old_max_per_page = User.max_per_page
         User.max_paginates_per(5)


### PR DESCRIPTION
## Issue
https://github.com/kaminari/kaminari/issues/1055

## What
If `total_count` is called with `padding` and `load`, `total_count` deduction is wrong.
So, when `padding` is called with `load`, `total_count`'s deduction should not be implemented.

## Examples
### Example1
```ruby
irb(main):001:0> User.count
   (1.8ms)  SELECT sqlite_version(*)
   (1.0ms)  SELECT COUNT(*) FROM "users"
=> 5
irb(main):002:0> User.page(1).padding(5).load.total_count
  User Load (1.0ms)  SELECT "users".* FROM "users" LIMIT ? OFFSET ?  [["LIMIT", 25], ["OFFSET", 5]]
=> 0
```

In this case, below code is implemented.

https://github.com/kaminari/kaminari/blob/master/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L23

```ruby
return @total_count = 0 if (current_page == 1) && @records.empty?
```

### Example2
```ruby
irb(main):003:0> User.count
   (0.3ms)  SELECT COUNT(*) FROM "users"
=> 5
irb(main):004:0> User.page(1).padding(1).load.total_count
  User Load (0.2ms)  SELECT "users".* FROM "users" LIMIT ? OFFSET ?  [["LIMIT", 25], ["OFFSET", 1]]
=> 4
```

In this case, below code is implemented.

https://github.com/kaminari/kaminari/blob/master/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L25

```ruby
return @total_count = (current_page - 1) * limit_value + @records.length if @records.any? && (@records.length < limit_value)
```

`current_page` is 1 and `@records.length` is 4 and `limit_value` is 25(default number), so `total_count` is 4.