### PR TITLE
Renames `zero` key to `"0"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ en:
     page_entries_info:
       one_page:
         display_entries:
-          zero: "No %{entry_name} found"
+          "0": "No %{entry_name} found"
           one: "Displaying <b>1</b> %{entry_name}"
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:

--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -11,12 +11,12 @@ en:
   helpers:
     page_entries_info:
       entry:
-        zero: "entries"
+        "0": "entries"
         one: "entry"
         other: "entries"
       one_page:
         display_entries:
-          zero: "No %{entry_name} found"
+          "0": "No %{entry_name} found"
           one: "Displaying <b>1</b> %{entry_name}"
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:


### PR DESCRIPTION
Linked to [this issue](https://github.com/kaminari/kaminari/issues/1090)
[Breaking change in a minor version update, thanks i18n](https://github.com/ruby-i18n/i18n/commit/a7b92a10b79910b7c15a3c993110809d24d41cd8)

> This is a breaking change. Anyone using the `zero` key in locales that don't require the `zero` key will have to change the key to use the explicit "0" key.


This commits updates `zero` keys

_Sorry I could not run the thest_