### PR TITLE
support data html options

### DIFF
--- a/kaminari-core/app/views/kaminari/_first_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_first_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, data: data %>
 </span>

--- a/kaminari-core/app/views/kaminari/_first_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_first_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 %span.first
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, data: data

--- a/kaminari-core/app/views/kaminari/_first_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_first_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options
 span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, data: data
 '

--- a/kaminari-core/app/views/kaminari/_last_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_last_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, data: data %>
 </span>

--- a/kaminari-core/app/views/kaminari/_last_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_last_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, data: data

--- a/kaminari-core/app/views/kaminari/_last_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_last_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options
 span.last
-  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, data: data
 '

--- a/kaminari-core/app/views/kaminari/_next_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_next_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, data: data %>
 </span>

--- a/kaminari-core/app/views/kaminari/_next_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_next_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 %span.next
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, data: data

--- a/kaminari-core/app/views/kaminari/_next_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_next_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options
 span.next
-  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, data: data
 '

--- a/kaminari-core/app/views/kaminari/_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_page.html.erb
@@ -6,7 +6,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+  <%= link_to_unless page.current?, page, url, {remote: remote, data: data, rel: page.rel} %>
 </span>

--- a/kaminari-core/app/views/kaminari/_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_page.html.haml
@@ -6,5 +6,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 %span{class: "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+  = link_to_unless page.current?, page, url, {remote: remote, data: data, rel: page.rel}

--- a/kaminari-core/app/views/kaminari/_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_page.html.slim
@@ -6,6 +6,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+  == link_to_unless page.current?, page, url, {remote: remote, data: data, rel: page.rel}
 '

--- a/kaminari-core/app/views/kaminari/_paginator.html.erb
+++ b/kaminari-core/app/views/kaminari/_paginator.html.erb
@@ -4,6 +4,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>

--- a/kaminari-core/app/views/kaminari/_paginator.html.haml
+++ b/kaminari-core/app/views/kaminari/_paginator.html.haml
@@ -4,6 +4,7 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav.pagination

--- a/kaminari-core/app/views/kaminari/_paginator.html.slim
+++ b/kaminari-core/app/views/kaminari/_paginator.html.slim
@@ -4,6 +4,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options 
     paginator    : the paginator that renders the pagination tags inside
 
 == paginator.render do

--- a/kaminari-core/app/views/kaminari/_prev_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.erb
@@ -5,7 +5,8 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
+    data:          data html options
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, data: data %>
 </span>

--- a/kaminari-core/app/views/kaminari/_prev_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.haml
@@ -5,5 +5,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
+-#    data:          data html options
 %span.prev
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, data: data

--- a/kaminari-core/app/views/kaminari/_prev_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.slim
@@ -5,6 +5,7 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
+    data         : data html options
 span.prev
-  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, data: data
 '

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -114,6 +114,7 @@ module Kaminari
       # * <tt>:template</tt> - Specify a custom template renderer for rendering the Paginator (receiver by default)
       # * <tt>:ANY_OTHER_VALUES</tt> - Any other hash key & values would be directly passed into each tag as :locals value.
       def paginate(scope, paginator_class: Kaminari::Helpers::Paginator, template: nil, **options)
+        options[:data] ||= {}
         options[:total_pages] ||= scope.total_pages
         options.reverse_merge! current_page: scope.current_page, per_page: scope.limit_value, remote: false
 


### PR DESCRIPTION
Rails 7 Hotwire requires many `data html-options` such as `data-turbo-frame`, `data-controller` (stimulus.js), ...
But it looks like `Kaminari` only support the `data-remote` option. So i think it's better to support other data html-options, too.

For example:

`turbo_frame`
```ruby
  <%= turbo_frame_tag "tasks" do %>
    <div class="min-w-full">
      <%= render @tasks %>
    </div>
  <% end %>
  <%= paginate @tasks, data: {turbo_frame: :tasks} %>
```

`stimulus controller`
```ruby
<%= paginate @tasks, data: {controller: "task", action: "click->log"} %>
```