### PR TITLE
Cursor pagination

### DIFF
--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -45,9 +45,10 @@ module Kaminari
           per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
 
           # Decode cursor for `before` or `after` query
-          after_h = JSON.parse(Base64.decode64(after), object_class: OpenStruct) if after
-          before_h = JSON.parse(Base64.decode64(before), object_class: OpenStruct) if before
-          cursor = before_h || after_h
+          after_h = JSON.parse(Base64.decode64(after)) if after
+          before_h = JSON.parse(Base64.decode64(before)) if before
+          cursor_h = before_h || after_h
+          cursor = cursor_h ? JSON.parse({columns: cursor_h.each_pair.map{|name,value|{name: name.to_s, value: value&.to_s}}}.to_json, object_class:OpenStruct) : nil
           querying_before_cursor = before.present?
 
           if cursor

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -55,7 +55,7 @@ module Kaminari
           # Convert cursor to OpenStruct with .columns, each having .name and .value
           cursor = decode_cursor(directed_cursor) || {}
           querying_before_cursor = (cursor.delete(:#{Kaminari.config.page_direction_attr_name}) || cursor.delete('#{Kaminari.config.page_direction_attr_name}'))&.to_sym == :before && cursor.any?
-          cursor = cursor.empty? ? nil : JSON.parse({columns: cursor.each_pair.map{|name,value|{name: name.to_s, value: value&.to_s}}}.to_json, object_class:OpenStruct)
+          cursor = cursor.empty? ? nil : JSON.parse({columns: cursor.each_pair.map{|name,value|{name: name.to_s, full_name: table_name + '.' + name.to_s, value: value&.to_s}}}.to_json, object_class:OpenStruct)
 
           if cursor
             # Validate cursor columns against model
@@ -96,7 +96,7 @@ module Kaminari
             values = querying_before_cursor ? before_values : after_values
 
             # Peek back to detect any result in opposite direction
-            peekback_condition = (querying_before_cursor ? after_condition : before_condition) + ' or (' + (cursor.columns.map {|c| c.value.nil? ? (c.name + ' is null ') : (c.name + ' = ? ')}).join(' and ') + ')'
+            peekback_condition = (querying_before_cursor ? after_condition : before_condition) + ' or (' + (cursor.columns.map {|c| c.value.nil? ? (c.full_name + ' is null ') : (c.full_name + ' = ? ')}).join(' and ') + ')'
             peekback_values = (querying_before_cursor ? after_values : before_values) + cursor.columns.map{|c| c.value}.compact
             peekback_relation = relation.where(peekback_condition, *peekback_values).limit(1)
             peekback_relation.reverse_order!

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -49,8 +49,8 @@ module Kaminari
           per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
 
           # Convert cursor to OpenStruct with .columns, each having .name and .value
-          cursor = decode_cursor(directed_cursor)
-          querying_before_cursor = cursor.delete(:#{Kaminari.config.page_direction_attr_name})&.to_sym == :before && cursor.any?
+          cursor = decode_cursor(directed_cursor) || {}
+          querying_before_cursor = (cursor.delete(:#{Kaminari.config.page_direction_attr_name}) || cursor.delete('#{Kaminari.config.page_direction_attr_name}'))&.to_sym == :before && cursor.any?
           cursor = cursor.empty? ? nil : JSON.parse({columns: cursor.each_pair.map{|name,value|{name: name.to_s, value: value&.to_s}}}.to_json, object_class:OpenStruct)
 
           if cursor

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -20,6 +20,56 @@ module Kaminari
           end
         end
       RUBY
+
+      # Fetch the values after cursor
+      #   Model.page_after(cursor: cursor)
+      eval <<-RUBY, nil, __FILE__, __LINE__ + 1
+        def self.#{Kaminari.config.page_after_method_name}(cursor = nil)
+          self.#{Kaminari.config.page_by_cursor_method_name}(after: cursor)
+        end
+      RUBY
+
+      # Fetch the values before cursor
+      #   Model.page_before(cursor: cursor)
+      eval <<-RUBY, nil, __FILE__, __LINE__ + 1
+        def self.#{Kaminari.config.page_before_method_name}(cursor = nil)
+          self.#{Kaminari.config.page_by_cursor_method_name}(before: cursor)
+        end
+      RUBY
+
+      # Fetch the values after or before cursor
+      # If both after and before are provided, use before.
+      #   Model.page_by_cursor(after: cursor)
+      eval <<-RUBY, nil, __FILE__, __LINE__ + 1
+        def self.#{Kaminari.config.page_by_cursor_method_name}(after: nil, before: nil)
+          per_page = max_per_page && (default_per_page > max_per_page) ? max_per_page : default_per_page
+
+          # Decode cursor for `before` or `after` query
+          after_h = JSON.parse(Base64.decode64(after), object_class: OpenStruct) if after
+          before_h = JSON.parse(Base64.decode64(before), object_class: OpenStruct) if before
+          cursor = before_h || after_h
+          querying_before_cursor = before.present?
+
+          if cursor
+            # Validate cursor columns against model
+            cursor_columns = cursor.columns.map { |c| c.name }
+            model_columns = columns.map { |c| c.name }
+            raise 'Cursor has columns that are not on model.' if (cursor_columns - model_columns).any?
+
+            # TODO Assert that cursor is unique, e.g. any column is unique or any subset of columns is unique.
+          end
+          
+          limit(per_page).extending do
+            include Kaminari::ActiveRecordRelationMethods
+            include Kaminari::CursorPageScopeMethods
+            include  Kaminari::CursorPaginatable
+          end
+          .tap do |relation|
+            relation.instance_variable_set('@_cursor', cursor)
+            relation.instance_variable_set('@_querying_before_cursor', querying_before_cursor)
+          end
+        end
+      RUBY
     end
   end
 end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -45,7 +45,7 @@ module Kaminari
         end
       RUBY
 
-      # Fetch the values after or before cursor, depending on included page_direction.
+      # Fetch the values after or before cursor, depending on page direction embedded in cursor.
       # Direction defaults to after if direction is not provided or cursor values are not provided.
       #   Model.page_by_cursor(cursor)
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
@@ -54,8 +54,8 @@ module Kaminari
 
           # Convert cursor to OpenStruct with .columns, each having .name and .value
           cursor = decode_cursor(directed_cursor) || {}
-          querying_before_cursor = (cursor.delete(:#{Kaminari.config.page_direction_attr_name}) || cursor.delete('#{Kaminari.config.page_direction_attr_name}'))&.to_sym == :before && cursor.any?
-          cursor = cursor.empty? ? nil : JSON.parse({columns: cursor.each_pair.map{|name,value|{name: name.to_s, full_name: table_name + '.' + name.to_s, value: value&.to_s}}}.to_json, object_class:OpenStruct)
+          querying_before_cursor = (cursor.delete(:#{Kaminari.config.page_direction_attr_name}) || cursor.delete('#{Kaminari.config.page_direction_attr_name}')).try(:to_sym) == :before && cursor.any?
+          cursor = cursor.empty? ? nil : JSON.parse({columns: cursor.each_pair.map{|name,value|{name: name.to_s, full_name: table_name + '.' + name.to_s, value: value.try(:to_s)}}}.to_json, object_class:OpenStruct)
 
           if cursor
             # Validate cursor columns against model

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -61,7 +61,7 @@ module Kaminari
             # Validate cursor columns against model
             cursor_columns = cursor.columns.map { |c| c.name }
             model_columns = columns.map { |c| c.name }
-            raise 'Cursor has columns that are not on model.' if (cursor_columns - model_columns).any?
+            raise "Cursor has columns that are not on model: \#{cursor_columns - model_columns}" if (cursor_columns - model_columns).any?
           end
           
           relation = limit(per_page).extending do

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -55,8 +55,6 @@ module Kaminari
             cursor_columns = cursor.columns.map { |c| c.name }
             model_columns = columns.map { |c| c.name }
             raise 'Cursor has columns that are not on model.' if (cursor_columns - model_columns).any?
-
-            # TODO Assert that cursor is unique, e.g. any column is unique or any subset of columns is unique.
           end
           
           limit(per_page).extending do

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -58,15 +58,53 @@ module Kaminari
             raise 'Cursor has columns that are not on model.' if (cursor_columns - model_columns).any?
           end
           
-          limit(per_page).extending do
+          relation = limit(per_page).extending do
             include Kaminari::ActiveRecordRelationMethods
             include Kaminari::CursorPageScopeMethods
-            include  Kaminari::CursorPaginatable
+            include Kaminari::CursorPaginatable
           end
-          .tap do |relation|
-            relation.instance_variable_set('@_cursor', cursor)
-            relation.instance_variable_set('@_querying_before_cursor', querying_before_cursor)
+          relation.instance_variable_set('@_cursor', cursor)
+          relation.instance_variable_set('@_querying_before_cursor', querying_before_cursor)
+
+          # Assert that ActiveRecord order columns come directly from model. (ordering by association columns not supported)
+          raise "Cursor pagination does not support ordering by associated columns" if relation.ordered_by_unsupported_columns
+
+          # Ensure that primary key is part of ordering
+          relation = relation.order(primary_key + ' asc') unless relation.normalized_order_info[:columns].include? primary_key
+
+          order_columns = relation.normalized_order_info[:columns]
+
+          if !cursor
+            condition = nil
+            values = []
+            peekback_relation = nil
+          else
+            # Coerce cursor column order into agreement with ActiveRecord order
+            cursor.columns.filter! { |c| order_columns.include? c.name }
+            cursor.columns.sort_by! { |c| order_columns.index(c.name) }
+
+            # Generate condition to query `after`
+            after_condition, after_values = relation.build_cursor_condition(:after)
+            before_condition, before_values = relation.build_cursor_condition(:before)
+
+            # Reverse inequality signs if querying `before`
+            condition = querying_before_cursor ? before_condition : after_condition
+            values = querying_before_cursor ? before_values : after_values
+
+            # Peek back to detect any result in opposite direction
+            peekback_condition = (querying_before_cursor ? after_condition : before_condition) + ' or (' + (cursor.columns.map {|c| c.value.nil? ? (c.name + ' is null ') : (c.name + ' = ? ')}).join(' and ') + ')'
+            peekback_values = (querying_before_cursor ? after_values : before_values) + cursor.columns.map{|c| c.value}.compact
+            peekback_relation = relation.where(peekback_condition, *peekback_values).limit(1)
+            peekback_relation.reverse_order!
           end
+
+          relation = relation.where(condition, *values) if condition
+          relation = relation.reverse_order if querying_before_cursor
+
+          relation.instance_variable_set('@_peekback_relation', peekback_relation)
+          relation.instance_variable_set('@_order_columns', order_columns)
+
+          relation
         end
       RUBY
     end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -26,6 +26,8 @@ module Kaminari
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
         def self.#{Kaminari.config.page_after_method_name}(cursor = {})
           cursor = decode_cursor(cursor) || {}
+          cursor.delete(:#{Kaminari.config.page_direction_attr_name})
+          cursor.delete('#{Kaminari.config.page_direction_attr_name}')
           cursor[:#{Kaminari.config.page_direction_attr_name}] = :after
           self.#{Kaminari.config.page_by_cursor_method_name}(cursor)
         end
@@ -36,6 +38,8 @@ module Kaminari
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1
         def self.#{Kaminari.config.page_before_method_name}(cursor = {})
           cursor = decode_cursor(cursor) || {}
+          cursor.delete(:#{Kaminari.config.page_direction_attr_name})
+          cursor.delete('#{Kaminari.config.page_direction_attr_name}')
           cursor[:#{Kaminari.config.page_direction_attr_name}] = :before
           self.#{Kaminari.config.page_by_cursor_method_name}(cursor)
         end

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -86,7 +86,7 @@ module Kaminari
             peekback_relation = nil
           else
             # Coerce cursor column order into agreement with ActiveRecord order
-            cursor.columns.filter! { |c| order_columns.include? c.name }
+            cursor.columns.keep_if { |c| order_columns.include? c.name }
             cursor.columns.sort_by! { |c| order_columns.index(c.name) }
 
             # Generate condition for cursor-based filter

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -204,12 +204,12 @@ module Kaminari
                           .map { |column, preceding_columns, dir, nulls_after|
                           nulls_last = (nulls_after and search_direction == :after) || (!nulls_after and search_direction == :before)
                           if column.value.nil?
-                            inequality = nulls_last ? nil : "#{column.name} is not null"
+                            inequality = nulls_last ? nil : "#{column.full_name} is not null"
                           else
-                            inequality = {asc: "#{column.name} #{asc_operator} ?", desc: "#{column.name} #{desc_operator} ?"}.fetch(dir)
-                            inequality += " or #{column.name} is null" if nulls_last
+                            inequality = {asc: "#{column.full_name} #{asc_operator} ?", desc: "#{column.full_name} #{desc_operator} ?"}.fetch(dir)
+                            inequality += " or #{column.full_name} is null" if nulls_last
                           end
-                          inequality.nil? ? nil : (preceding_columns.pluck(:name, :value).map {|c, v| v.nil? ? "#{c} is null" : "#{c} = ?" } + ['(' + inequality + ')']).join(' and ')
+                          inequality.nil? ? nil : (preceding_columns.pluck(:full_name, :value).map {|c, v| v.nil? ? "#{c} is null" : "#{c} = ?" } + ['(' + inequality + ')']).join(' and ')
                         }
                         .compact
                         .map {|c| '(' + c + ')'}

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -152,12 +152,20 @@ module Kaminari
           # Generate start/end cursors for further paging
           start_cursor_values = @_order_columns.map { |c| @records.first.send(c) }
           end_cursor_values = @_order_columns.map { |c| @records.last.send(c) }
-          @_page_start_cursor = Base64.strict_encode64(Hash[@_order_columns.zip(start_cursor_values)].to_json)
-          @_page_end_cursor = Base64.strict_encode64(Hash[@_order_columns.zip(end_cursor_values)].to_json)
+          @_start_cursor = Hash[@_order_columns.zip(start_cursor_values)]
+          @_start_cursor[Kaminari.config.page_direction_attr_name] = 'before'
+          @_end_cursor = Hash[@_order_columns.zip(end_cursor_values)]
+          @_end_cursor[Kaminari.config.page_direction_attr_name] = 'after'
         end
 
         self
       end
+    end
+
+    # Force to raise an exception if #total_count is called explicitly.
+    def total_count
+      raise "This scope is marked as a cursor paginable scope and can't be used in combination " \
+            "with `#paginate' or `#page_entries_info'. Use #link_to_page_after or #link_to_page_before instead."
     end
 
     def build_cursor_condition(search_direction)

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -173,13 +173,11 @@ module Kaminari
       # In case of Postgresql connection, read_attribute_before_type_cast returns a Time instead
       # of the native database String, so the cursor time precision must meet or exceed the database precision.
       # At present, Postgresql and Mysql smallest time unit is microseconds, so '6' fractional digits suffice.
-      cursor_values.each do |value|
+      cursor_values = cursor_values.map do |value|
         if [ActiveSupport::TimeWithZone, Time, DateTime].any? {|klass| value.is_a? klass }
-          class << value
-            def as_json(options = nil)
-              xmlschema(6)
-            end
-          end
+          value.xmlschema(6)
+        else
+          value
         end
       end
 

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -226,7 +226,7 @@ module Kaminari
         .map { |o| o.split(',') }.flatten
         .map { |o| o.downcase.strip }
         .map { |o| o.gsub(/(?<!")"(([^"]|"")+)"(?!")/, '\1') }
-        .map { |o| o.match?(/\s+(asc|desc)(\s+nulls\s+(first|last))?/) ? o : o.sub(/(\s+nulls\s+(first|last))?$/, ' asc\0') }
+        .map { |o| o.match(/\s+(asc|desc)(\s+nulls\s+(first|last))?/) ? o : o.sub(/(\s+nulls\s+(first|last))?$/, ' asc\0') }
       return {
         columns: order_strings.map(&:split).map(&:first).map{|o| o.split('.').last},
         dirs: order_strings.map{|o| o.match(/\s+(asc|desc)(\s+nulls\s+(first|last))?/)}.map{|o| o[1].to_sym},

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -204,7 +204,7 @@ module Kaminari
                             inequality = {asc: "#{column.full_name} #{asc_operator} ?", desc: "#{column.full_name} #{desc_operator} ?"}.fetch(dir)
                             inequality += " or #{column.full_name} is null" if nulls_last
                           end
-                          inequality.nil? ? nil : (preceding_columns.pluck(:full_name, :value).map {|c, v| v.nil? ? "#{c} is null" : "#{c} = ?" } + ['(' + inequality + ')']).join(' and ')
+                          inequality.nil? ? nil : (preceding_columns.map{|c| [c.full_name, c.value]} .map {|c, v| v.nil? ? "#{c} is null" : "#{c} = ?" } + ['(' + inequality + ')']).join(' and ')
                         }
                         .compact
                         .map {|c| '(' + c + ')'}
@@ -212,7 +212,7 @@ module Kaminari
       values = @_cursor.columns.zip(preceding_columns_per_column, nulls_after_per_column)
                        .map { |column, preceding_columns, nulls_after|
                          nulls_last = (nulls_after and search_direction == :after) || (!nulls_after and search_direction == :before)
-                         (column.value.nil? and nulls_last) ? nil : (preceding_columns.pluck(:value) + [column.value])
+                         (column.value.nil? and nulls_last) ? nil : (preceding_columns.map{|c| c.value} + [column.value])
                        }
                        .flatten
                        .compact

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb
@@ -211,10 +211,10 @@ module Kaminari
     def normalized_order_info
       # Normalize order to strings formatted as '(table.)?<column_name> (asc|desc)( nulls (first|last))?'
       order_strings = order_values
-        .map { |o| o.is_a?(Arel::Nodes::Ascending) ? "#{o.expr.relation.name}.#{o.expr.name} asc" : o }
-        .map { |o| o.is_a?(Arel::Nodes::Descending) ? "#{o.expr.relation.name}.#{o.expr.name} desc" : o }
+        .map { |o| o.is_a?(Arel::Nodes::Ordering) ? o.to_sql : o }
         .map { |o| o.split(',') }.flatten
         .map { |o| o.downcase.strip }
+        .map { |o| o.gsub(/(?<!")"(([^"]|"")+)"(?!")/, '\1') }
         .map { |o| o.match?(/\s+(asc|desc)(\s+nulls\s+(first|last))?/) ? o : o.sub(/(\s+nulls\s+(first|last))?$/, ' asc\0') }
       return {
         columns: order_strings.map(&:split).map(&:first).map{|o| o.split('.').last},

--- a/kaminari-core/app/views/kaminari/_page_after.html.erb
+++ b/kaminari-core/app/views/kaminari/_page_after.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page for cursor-based pagination
+  - available local variables
+    url:           url to the previous page
+    first_page?:   indicates there are no earlier results
+    last_page?:    indicates there are no later results
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless last_page?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/kaminari-core/app/views/kaminari/_page_after.html.haml
+++ b/kaminari-core/app/views/kaminari/_page_after.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Next" page for cursor-based pagination
+-#  available local variables
+-#    url:           url to the previous page
+-#    first_page?:   indicates there are no earlier results
+-#    last_page?:    indicates there are no later results
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.next
+  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote

--- a/kaminari-core/app/views/kaminari/_page_after.html.slim
+++ b/kaminari-core/app/views/kaminari/_page_after.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Next" page for cursor-based pagination
+  - available local variables
+    url          : url to the previous page
+    first_page?:   indicates there are no earlier results
+    last_page?:    indicates there are no later results
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.next
+  == link_to_unless last_page?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+'

--- a/kaminari-core/app/views/kaminari/_page_before.html.erb
+++ b/kaminari-core/app/views/kaminari/_page_before.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page for cursor-based pagination
+  - available local variables
+    url:           url to the previous page
+    first_page?:   indicates there are no earlier results
+    last_page?:    indicates there are no later results
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless first_page?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/kaminari-core/app/views/kaminari/_page_before.html.haml
+++ b/kaminari-core/app/views/kaminari/_page_before.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Previous" page for cursor-based pagination
+-#  available local variables
+-#    url:           url to the previous page
+-#    first_page?:   indicates there are no earlier results
+-#    last_page?:    indicates there are no later results
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.prev
+  = link_to_unless first_page?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote

--- a/kaminari-core/app/views/kaminari/_page_before.html.slim
+++ b/kaminari-core/app/views/kaminari/_page_before.html.slim
@@ -1,0 +1,10 @@
+/ Link to the "Previous" page for cursor-based pagination
+  - available local variables
+    url          : url to the previous page
+    first_page?:   indicates there are no earlier results
+    last_page?:    indicates there are no later results
+    per_page     : number of items to fetch per page
+    remote       : data-remote
+span.prev
+  == link_to_unless first_page?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+'

--- a/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
+++ b/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
@@ -8,6 +8,11 @@ Kaminari.configure do |config|
   # config.left = 0
   # config.right = 0
   # config.page_method_name = :page
+  # config.page_by_cursor_method_name = :page_by_cursor
+  # config.page_before_method_name = :page_before
+  # config.page_after_method_name = :page_after
+  # config.before_cursor_param_name = :before_cursor
+  # config.after_cursor_param_name = :after_cursor
   # config.param_name = :page
   # config.max_pages = nil
   # config.params_on_first_page = false

--- a/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
+++ b/kaminari-core/lib/generators/kaminari/templates/kaminari_config.rb
@@ -11,8 +11,7 @@ Kaminari.configure do |config|
   # config.page_by_cursor_method_name = :page_by_cursor
   # config.page_before_method_name = :page_before
   # config.page_after_method_name = :page_after
-  # config.before_cursor_param_name = :before_cursor
-  # config.after_cursor_param_name = :after_cursor
+  # config.cursor_param_name = :cursor
   # config.param_name = :page
   # config.max_pages = nil
   # config.params_on_first_page = false

--- a/kaminari-core/lib/kaminari/config.rb
+++ b/kaminari-core/lib/kaminari/config.rb
@@ -17,7 +17,9 @@ module Kaminari
 
   class Config
     attr_accessor :default_per_page, :max_per_page, :window, :outer_window, :left, :right, :page_method_name, :max_pages, :params_on_first_page
+    attr_accessor :page_by_cursor_method_name, :page_before_method_name, :page_after_method_name, :page_start_cursor_attr_name, :page_end_cursor_attr_name
     attr_writer :param_name
+    attr_accessor :before_cursor_param_name, :after_cursor_param_name
 
     def initialize
       @default_per_page = 25
@@ -27,7 +29,12 @@ module Kaminari
       @left = 0
       @right = 0
       @page_method_name = :page
+      @page_by_cursor_method_name = :page_by_cursor
+      @page_before_method_name = :page_before
+      @page_after_method_name = :page_after
       @param_name = :page
+      @before_cursor_param_name = :before_cursor
+      @after_cursor_param_name = :after_cursor
       @max_pages = nil
       @params_on_first_page = false
     end

--- a/kaminari-core/lib/kaminari/config.rb
+++ b/kaminari-core/lib/kaminari/config.rb
@@ -17,7 +17,7 @@ module Kaminari
 
   class Config
     attr_accessor :default_per_page, :max_per_page, :window, :outer_window, :left, :right, :page_method_name, :max_pages, :params_on_first_page
-    attr_accessor :page_by_cursor_method_name, :page_before_method_name, :page_after_method_name, :page_start_cursor_attr_name, :page_end_cursor_attr_name
+    attr_accessor :page_by_cursor_method_name, :page_before_method_name, :page_after_method_name, :cursor_param_name, :page_direction_attr_name
     attr_writer :param_name
     attr_accessor :before_cursor_param_name, :after_cursor_param_name
 
@@ -33,8 +33,8 @@ module Kaminari
       @page_before_method_name = :page_before
       @page_after_method_name = :page_after
       @param_name = :page
-      @before_cursor_param_name = :before_cursor
-      @after_cursor_param_name = :after_cursor
+      @cursor_param_name = :cursor
+      @page_direction_attr_name = :page_direction
       @max_pages = nil
       @params_on_first_page = false
     end

--- a/kaminari-core/lib/kaminari/core.rb
+++ b/kaminari-core/lib/kaminari/core.rb
@@ -15,6 +15,7 @@ require 'kaminari/config'
 require 'kaminari/exceptions'
 require 'kaminari/helpers/paginator'
 require 'kaminari/models/page_scope_methods'
+require 'kaminari/models/cursor_page_scope_methods'
 require 'kaminari/models/configuration_methods'
 require 'kaminari/models/array_extension'
 

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -64,6 +64,14 @@ module Kaminari
       alias url_to_prev_page      prev_page_url
       alias url_to_previous_page  prev_page_url
 
+      def page_before_url(scope, options = {})
+        "#{request.base_url}#{page_before_path(scope, options)}" if !scope.first_page?
+      end
+
+      def page_after_url(scope, options = {})
+        "#{request.base_url}#{page_after_path(scope, options)}" if !scope.last_page?
+      end
+
       # A helper that calculates the path to the next page.
       #
       # ==== Examples
@@ -93,6 +101,16 @@ module Kaminari
       alias previous_page_path     prev_page_path
       alias path_to_previous_page  prev_page_path
       alias path_to_prev_page      prev_page_path
+
+      def page_before_path(scope, options = {})
+        Kaminari::Helpers::PageBefore.new(self, **options.reverse_merge(before_cursor: scope.page_start_cursor)).url if !scope.first_page?
+      end
+      alias path_to_page_before page_before_path
+
+      def page_after_path(scope, options = {})
+        Kaminari::Helpers::PageAfter.new(self, **options.reverse_merge(after_cursor: scope.page_end_cursor)).url if !scope.last_page?
+      end
+      alias path_to_page_after page_after_path
     end
 
     module HelperMethods
@@ -177,6 +195,32 @@ module Kaminari
 
         if next_page
           link_to name, next_page, options
+        elsif block_given?
+          yield
+        end
+      end
+
+      def link_to_page_before(scope, name, **options)
+        page_before = path_to_page_before(scope, options)
+
+        options.except! :params, :param_name
+        options[:rel] ||= 'prev'
+
+        if page_before
+          link_to name, page_before, options
+        elsif block_given?
+          yield
+        end
+      end
+
+      def link_to_page_after(scope, name, **options)
+        page_after = path_to_page_after(scope, options)
+
+        options.except! :params, :param_name
+        options[:rel] ||= 'next'
+
+        if page_after
+          link_to name, page_after, options
         elsif block_given?
           yield
         end

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -103,12 +103,12 @@ module Kaminari
       alias path_to_prev_page      prev_page_path
 
       def page_before_path(scope, options = {})
-        Kaminari::Helpers::PageBefore.new(self, **options.reverse_merge(before_cursor: scope.page_start_cursor)).url if !scope.first_page?
+        Kaminari::Helpers::PageBefore.new(self, **options.reverse_merge(cursor: scope.start_cursor)).url if !scope.first_page?
       end
       alias path_to_page_before page_before_path
 
       def page_after_path(scope, options = {})
-        Kaminari::Helpers::PageAfter.new(self, **options.reverse_merge(after_cursor: scope.page_end_cursor)).url if !scope.last_page?
+        Kaminari::Helpers::PageAfter.new(self, **options.reverse_merge(cursor: scope.end_cursor)).url if !scope.last_page?
       end
       alias path_to_page_after page_after_path
     end

--- a/kaminari-core/lib/kaminari/helpers/paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/paginator.rb
@@ -62,7 +62,7 @@ module Kaminari
         @last = Page.new @template, **@options.merge(page: page)
       end
 
-      %w[first_page prev_page next_page last_page gap].each do |tag|
+      %w[first_page prev_page next_page last_page gap page_after page_before].each do |tag|
         eval <<-DEF, nil, __FILE__, __LINE__ + 1
           def #{tag}_tag
             @last = #{tag.classify}.new @template, **@options

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -168,7 +168,7 @@ module Kaminari
       private
 
       def params_for(cursor)
-        if (@param_name == :before_cursor) || (@param_name == :after_cursor) || !@param_name.include?('[')
+        if (@param_name == :cursor) || !@param_name.include?('[')
           @params.merge(@param_name => cursor)
         else
           page_params = Rack::Utils.parse_nested_query("#{@param_name}=#{cursor}")
@@ -192,7 +192,7 @@ module Kaminari
 
     end
 
-    class PageBefore < Tag
+    class PageByCursor < Tag
       include CursorLink
 
       def initialize(template, params: {}, param_name: nil, theme: nil, views_prefix: nil, **options) #:nodoc:
@@ -205,33 +205,18 @@ module Kaminari
 
         super(template, params: params, param_name: param_name, theme: theme, views_prefix: views_prefix, **options)
 
-        @param_name = param_name || Kaminari.config.before_cursor_param_name
+        @param_name = param_name || Kaminari.config.cursor_param_name
       end
 
       def cursor
-        @options[:before_cursor]
+        @options[:cursor]
       end
     end
 
-    class PageAfter < Tag
-      include CursorLink
+    class PageBefore < PageByCursor
+    end
 
-      def initialize(template, params: {}, param_name: nil, theme: nil, views_prefix: nil, **options) #:nodoc:
-        # params in Rails 5 may not be a Hash either,
-        # so it must be converted to a Hash to be merged into @params
-        if params && params.respond_to?(:to_unsafe_h)
-          ActiveSupport::Deprecation.warn 'Explicitly passing params to helpers could be omitted.'
-          params = params.to_unsafe_h
-        end
-
-        super(template, params: params, param_name: param_name, theme: theme, views_prefix: views_prefix, **options)
-
-        @param_name = param_name || Kaminari.config.after_cursor_param_name
-      end
-
-      def cursor
-        @options[:after_cursor]
-      end
+    class PageAfter < PageByCursor
     end
 
     # Non-link tag that stands for skipped pages...

--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -55,6 +55,12 @@ module Kaminari
         ActiveSupport::Deprecation.warn 'max_pages_per is deprecated. Use max_pages instead.'
         max_pages val
       end
+
+      private
+
+      def decode_cursor(cursor)
+        cursor.is_a?(String) ? JSON.parse(Base64.decode64(cursor)) : cursor.clone
+      end
     end
   end
 end

--- a/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
@@ -28,28 +28,22 @@ module Kaminari
     #def padding(num)
     #end
 
-    # Total number of pages
-    def total_pages
-      count_without_padding = total_count
-      count_without_padding -= @_padding if defined?(@_padding) && @_padding
-      count_without_padding = 0 if count_without_padding < 0
-
-      total_pages_count = (count_without_padding.to_f / limit_value).ceil
-      max_pages && (max_pages < total_pages_count) ? max_pages : total_pages_count
-    rescue FloatDomainError
-      raise ZeroPerPageOperation, "The number of total pages was incalculable. Perhaps you called .per(0)?"
-    end
+    # Intentionally undefined
+    #def total_pages
+    #end
 
     # Intentionally undefined
     #def current_page
     #end
 
-    def page_start_cursor
-      @_page_start_cursor
+    def start_cursor
+      load unless loaded?
+      Base64.strict_encode64(@_start_cursor.to_json)
     end
 
-    def page_end_cursor
-      @_page_end_cursor
+    def end_cursor
+      load unless loaded?
+      Base64.strict_encode64(@_end_cursor.to_json)
     end
 
     # Intentionally undefined

--- a/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/cursor_page_scope_methods.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Kaminari
+  module CursorPageScopeMethods
+    # Specify the <tt>per_page</tt> value for the preceding <tt>page</tt> scope
+    #   Model.page(3).per(10)
+    def per(num, max_per_page: nil)
+      max_per_page ||= ((defined?(@_max_per_page) && @_max_per_page) || self.max_per_page)
+      @_per = (num || default_per_page).to_i
+      if (n = num.to_i) < 0 || !(/^\d/ =~ num.to_s)
+        self
+      elsif n.zero?
+        limit(n)
+      elsif max_per_page && (max_per_page < n)
+        limit(max_per_page)
+      else
+        limit(n)
+      end
+    end
+
+    def max_paginates_per(new_max_per_page)
+      @_max_per_page = new_max_per_page
+
+      per (defined?(@_per) && @_per) || default_per_page, max_per_page: new_max_per_page
+    end
+
+    # Intentionally undefined
+    #def padding(num)
+    #end
+
+    # Total number of pages
+    def total_pages
+      count_without_padding = total_count
+      count_without_padding -= @_padding if defined?(@_padding) && @_padding
+      count_without_padding = 0 if count_without_padding < 0
+
+      total_pages_count = (count_without_padding.to_f / limit_value).ceil
+      max_pages && (max_pages < total_pages_count) ? max_pages : total_pages_count
+    rescue FloatDomainError
+      raise ZeroPerPageOperation, "The number of total pages was incalculable. Perhaps you called .per(0)?"
+    end
+
+    # Intentionally undefined
+    #def current_page
+    #end
+
+    def page_start_cursor
+      @_page_start_cursor
+    end
+
+    def page_end_cursor
+      @_page_end_cursor
+    end
+
+    # Intentionally undefined
+    #def next_page
+    #end
+
+    # Intentionally undefined
+    #def prev_page
+    #end
+
+    # Intentionally undefined
+    #def first_page?
+    #end
+
+    # The page wouldn't be the last page if there's "limit + 1" record
+    def first_page?
+      !out_of_range? && !@_has_prev
+    end
+
+    def last_page?
+      !out_of_range? && !@_has_next
+    end
+
+    # Empty relation needs no pagination
+    def out_of_range?
+      load unless loaded?
+      @records.empty?
+    end
+  end
+end

--- a/kaminari-core/test/fake_app/active_record/models.rb
+++ b/kaminari-core/test/fake_app/active_record/models.rb
@@ -62,6 +62,9 @@ end
 class Device < Product
 end
 
+class Event < ActiveRecord::Base
+end
+
 # migrations
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Tasks::DatabaseTasks.root = Dir.pwd
@@ -78,6 +81,7 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }
     create_table(:devices) {|t| t.string :name; t.integer :age}
     create_table(:animals) {|t| t.string :type; t.string :name}
+    create_table(:events) {|t| t.datetime :time}
   end
 end
 CreateAllTables.up

--- a/kaminari-core/test/fake_app/active_record/models.rb
+++ b/kaminari-core/test/fake_app/active_record/models.rb
@@ -74,8 +74,8 @@ ActiveRecord::Tasks::DatabaseTasks.create_current 'test'
 class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
   def self.up
     create_table(:gem_defined_models) { |t| t.string :name; t.integer :age }
-    create_table(:users) {|t| t.string :name; t.integer :age}
-    create_table(:books) {|t| t.string :title}
+    create_table(:users) {|t| t.string :name; t.integer :age; t.timestamps}
+    create_table(:books) {|t| t.string :title; t.timestamps}
     create_table(:readerships) {|t| t.integer :user_id; t.integer :book_id }
     create_table(:authorships) {|t| t.integer :user_id; t.integer :book_id; t.datetime :deleted_at }
     create_table(:user_addresses) {|t| t.string :street; t.integer :user_id }

--- a/kaminari-core/test/fake_app/rails_app.rb
+++ b/kaminari-core/test/fake_app/rails_app.rb
@@ -23,6 +23,7 @@ Rails.application.initialize!
 Rails.application.routes.draw do
   resources :users do
     get 'index_text(.:format)', action: :index_text, on: :collection
+    get 'by_cursor', action: :index_by_cursor, on: :collection
   end
   resources :addresses do
     get 'page/:page', action: :index, on: :collection
@@ -48,6 +49,15 @@ ERB
 
   def index_text
     @users = User.page params[:page]
+  end
+
+  def index_by_cursor
+    @users = User.page_by_cursor params[:cursor]
+    render inline: <<-ERB
+<%= @users.map(&:name).join("\n") %>
+<%= link_to_page_before @users, '‹ Prev' %>
+<%= link_to_page_after @users, 'Next ›' %>
+ERB
   end
 end
 

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -228,6 +228,10 @@ if defined? ActiveRecord
         assert [@books.first, @books.second, @books.third] == Book.page_before({id: @books.fourth.id}).per(5).to_a
       end
 
+      test 'page by cursor does not change explicit descending id' do
+        assert [@another_vampire, @vampire] == User.order(:age).order(id: :desc).page_after({age: @werewolf.age, id: @werewolf.id}).per(2).to_a
+      end
+
       if (Rails.version >= '6.1.0' && ENV['DB'] == 'postgresql') || (Rails.version >= '7.0.0' && ENV['DB'] == 'sqlite3')
         test 'page after cursor works with nulls first (ascending)' do
           users = User.order(User.arel_table[:name].asc.nulls_first).page_after

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -185,17 +185,17 @@ if defined? ActiveRecord
       end
 
       test 'page after cursor with null valued column should give next results' do
-        cursor = Base64.encode64({name: @newborn.name, age: @newborn.age, id: @newborn.id}.to_json)
+        cursor = Base64.strict_encode64({name: @newborn.name, age: @newborn.age, id: @newborn.id}.to_json)
         assert [@werewolf] == User.order('name, age').page_after(cursor).per(1).to_a
       end
 
       test 'page after should resolve ambiguity with primary key' do
-        cursor = Base64.encode64({name: @vampire.name, age: @vampire.age, id: @vampire.id}.to_json)
+        cursor = Base64.strict_encode64({name: @vampire.name, age: @vampire.age, id: @vampire.id}.to_json)
         assert [@another_vampire] == User.order('name, age').page_after(cursor).per(1).to_a
       end
 
       test 'cursor paging should include remaining records with null values' do
-        cursor = Base64.encode64({name: @baby.name, age: @baby.age, id: @baby.id}.to_json)
+        cursor = Base64.strict_encode64({name: @baby.name, age: @baby.age, id: @baby.id}.to_json)
         page_method = @large_nulls ? :page_after : :page_before
         results = User.order('name').send(page_method, cursor).per(100)
         assert results.include? @werewolf
@@ -203,7 +203,7 @@ if defined? ActiveRecord
       end
 
       test 'cursor paging should exclude prior records with null values' do
-        cursor = Base64.encode64({name: @baby.name, age: @baby.age, id: @baby.id}.to_json)
+        cursor = Base64.strict_encode64({name: @baby.name, age: @baby.age, id: @baby.id}.to_json)
         page_method = @large_nulls ? :page_before : :page_after
         results = User.order('name').send(page_method, cursor).per(100)
         assert !results.include?(@werewolf)
@@ -211,13 +211,11 @@ if defined? ActiveRecord
       end
 
       test 'page after cursor works based on primary key alone' do
-        cursor = Base64.encode64({id: @books.second.id}.to_json)
-        assert [@books.third, @books.fourth, @books.fifth] == Book.page_after(cursor).per(5).to_a
+        assert [@books.third, @books.fourth, @books.fifth] == Book.page_after({id: @books.second.id}).per(5).to_a
       end
 
       test 'page before cursor works based on primary key alone' do
-        cursor = Base64.encode64({id: @books.fourth.id}.to_json)
-        assert [@books.first, @books.second, @books.third] == Book.page_before(cursor).per(5).to_a
+        assert [@books.first, @books.second, @books.third] == Book.page_before({id: @books.fourth.id}).per(5).to_a
       end
     end
   end

--- a/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
+++ b/kaminari-core/test/models/active_record/active_record_relation_methods_test.rb
@@ -246,6 +246,12 @@ if defined? ActiveRecord
         assert [@events.third, @events.fourth, @events.fifth] == events.page_after(cursor).per(5).to_a
       end
 
+      test 'page by cursor works despite same-named columns on joined relations' do
+        books = Book.joins(:authors).order("#{Book.table_name}.created_at")
+        cursor = books.page_by_cursor.per(3).end_cursor
+        assert [@books.fourth, @books.fifth] == books.page_by_cursor(cursor).per(3).to_a
+      end
+
       if (Rails.version >= '6.1.0' && ENV['DB'] == 'postgresql') || (Rails.version >= '7.0.0' && ENV['DB'] == 'sqlite3')
         test 'page after cursor works with nulls first (ascending)' do
           users = User.order(User.arel_table[:name].asc.nulls_first).page_after

--- a/kaminari-core/test/models/active_record/inherited_test.rb
+++ b/kaminari-core/test/models/active_record/inherited_test.rb
@@ -6,6 +6,7 @@ if defined? ActiveRecord
   class ActiveRecordModelExtensionTest < ActiveSupport::TestCase
     test 'An AR model responds to Kaminari defined methods' do
       assert_respond_to Class.new(ActiveRecord::Base), :page
+      assert_respond_to Class.new(ActiveRecord::Base), :page_by_cursor
     end
 
     test "Kaminari doesn't prevent other AR extension gems to define a method" do

--- a/kaminari-core/test/models/active_record/paginable_without_count_test.rb
+++ b/kaminari-core/test/models/active_record/paginable_without_count_test.rb
@@ -26,15 +26,17 @@ if defined? ActiveRecord
       end
     end
 
-    test 'it does not make count queries after calling #each (page_after)' do
-      @scope = User.page_after(nil).without_count
-      @scope.each
+    [:page_after, :page_before].each do|method|
+      test "it does not make count queries after calling #each (#{method})" do
+        @scope = User.send(method).without_count
+        @scope.each
 
-      assert_no_queries do
-        assert_not @scope.last_page?
-      end
-      assert_no_queries do
-        assert_not @scope.out_of_range?
+        assert_no_queries do
+          assert_not @scope.last_page?
+        end
+        assert_no_queries do
+          assert_not @scope.out_of_range?
+        end
       end
     end
 
@@ -46,12 +48,14 @@ if defined? ActiveRecord
       assert_no_queries { @scope.each }
     end
 
-    test 'it does not make count queries after calling #last_page? or #out_of_range? _page_aafter' do
-      @scope = User.page_after(nil).without_count
+    [:page_after, :page_before].each do |method|
+      test "it does not make count queries after calling #last_page? or #out_of_range? (#{method})" do
+        @scope = User.send(method).without_count
 
-      assert_not @scope.last_page?
-      assert_not @scope.out_of_range?
-      assert_no_queries { @scope.each }
+        assert_not @scope.last_page?
+        assert_not @scope.out_of_range?
+        assert_no_queries { @scope.each }
+      end
     end
 
     test '#last_page? returns false when total count == 26 and page size == 25' do
@@ -63,13 +67,15 @@ if defined? ActiveRecord
       assert_not @users.out_of_range?
     end
 
-    test '#last_page? returns false when total count == 26 and page size == 25 (page_after)' do
-      @users = User.page_after(nil).without_count
+    [:page_after, :page_before].each do |method|
+      test "#last_page? returns false when total count == 26 and page size == 25 (#{method})" do
+        @users = User.send(method).without_count
 
-      assert_equal 25, @users.size
-      assert_equal 25, @users.each.size
-      assert_not @users.last_page?
-      assert_not @users.out_of_range?
+        assert_equal 25, @users.size
+        assert_equal 25, @users.each.size
+        assert_not @users.last_page?
+        assert_not @users.out_of_range?
+      end
     end
 
     test '#last_page? returns true when total count == page size' do
@@ -118,18 +124,13 @@ if defined? ActiveRecord
       assert_equal false, @users.last_page?
     end
 
-    test 'regression: call arel first (page_after)' do
-      @users = User.page_after(nil).without_count
-      @users.arel
+    [:page_after, :page_before].each do |method|
+      test "regression: call arel first (#{method})" do
+        @users = User.send(method).without_count
+        @users.arel
 
-      assert_equal false, @users.last_page?
-    end
-
-    test 'regression: call arel first (page_before)' do
-      @users = User.page_before(nil).without_count
-      @users.arel
-
-      assert_equal false, @users.last_page?
+        assert_equal false, @users.last_page?
+      end
     end
 
     test 'regression: call last page first' do
@@ -141,22 +142,15 @@ if defined? ActiveRecord
       assert_equal false, @users.last_page?
     end
 
-    test 'regression: call last page first (page_after)' do
-      @users = User.page_after(nil).without_count
+    [:page_after, :page_before].each do |method|
+      test "regression: call last page first (#{method})" do
+        @users = User.send(method).without_count
 
-      @users.last_page?
-      @users.arel
+        @users.last_page?
+        @users.arel
 
-      assert_equal false, @users.last_page?
-    end
-
-    test 'regression: call last page first (page_before)' do
-      @users = User.page_before(nil).without_count
-
-      @users.last_page?
-      @users.arel
-
-      assert_equal false, @users.last_page?
+        assert_equal false, @users.last_page?
+      end
     end
 
     def assert_no_queries

--- a/kaminari-core/test/models/active_record/paginable_without_count_test.rb
+++ b/kaminari-core/test/models/active_record/paginable_without_count_test.rb
@@ -26,6 +26,18 @@ if defined? ActiveRecord
       end
     end
 
+    test 'it does not make count queries after calling #each (page_after)' do
+      @scope = User.page_after(nil).without_count
+      @scope.each
+
+      assert_no_queries do
+        assert_not @scope.last_page?
+      end
+      assert_no_queries do
+        assert_not @scope.out_of_range?
+      end
+    end
+
     test 'it does not make count queries after calling #last_page? or #out_of_range?' do
       @scope = User.page(1).without_count
 
@@ -34,8 +46,25 @@ if defined? ActiveRecord
       assert_no_queries { @scope.each }
     end
 
+    test 'it does not make count queries after calling #last_page? or #out_of_range? _page_aafter' do
+      @scope = User.page_after(nil).without_count
+
+      assert_not @scope.last_page?
+      assert_not @scope.out_of_range?
+      assert_no_queries { @scope.each }
+    end
+
     test '#last_page? returns false when total count == 26 and page size == 25' do
       @users = User.page(1).without_count
+
+      assert_equal 25, @users.size
+      assert_equal 25, @users.each.size
+      assert_not @users.last_page?
+      assert_not @users.out_of_range?
+    end
+
+    test '#last_page? returns false when total count == 26 and page size == 25 (page_after)' do
+      @users = User.page_after(nil).without_count
 
       assert_equal 25, @users.size
       assert_equal 25, @users.each.size
@@ -89,8 +118,40 @@ if defined? ActiveRecord
       assert_equal false, @users.last_page?
     end
 
+    test 'regression: call arel first (page_after)' do
+      @users = User.page_after(nil).without_count
+      @users.arel
+
+      assert_equal false, @users.last_page?
+    end
+
+    test 'regression: call arel first (page_before)' do
+      @users = User.page_before(nil).without_count
+      @users.arel
+
+      assert_equal false, @users.last_page?
+    end
+
     test 'regression: call last page first' do
       @users = User.page(1).without_count
+
+      @users.last_page?
+      @users.arel
+
+      assert_equal false, @users.last_page?
+    end
+
+    test 'regression: call last page first (page_after)' do
+      @users = User.page_after(nil).without_count
+
+      @users.last_page?
+      @users.arel
+
+      assert_equal false, @users.last_page?
+    end
+
+    test 'regression: call last page first (page_before)' do
+      @users = User.page_before(nil).without_count
 
       @users.last_page?
       @users.arel

--- a/kaminari-core/test/requests/navigation_test.rb
+++ b/kaminari-core/test/requests/navigation_test.rb
@@ -77,4 +77,26 @@ class NavigationTest < Test::Unit::TestCase
       assert page.has_text? 'Displaying users 1'
     end
   end
+
+  test 'navigating by cursor pagination links' do
+    visit '/users/by_cursor'
+
+    assert page.has_no_content? '‹ Prev'
+    assert page.has_content? 'Next ›'
+
+    click_link 'Next ›'
+
+    assert page.has_content? '‹ Prev'
+    assert page.has_content? 'Next ›'
+
+    click_link 'Next ›'
+
+    assert page.has_content? '‹ Prev'
+    assert page.has_content? 'Next ›'
+
+    click_link 'Next ›'
+
+    assert page.has_content? '‹ Prev'
+    assert page.has_no_content? 'Next ›'
+  end
 end


### PR DESCRIPTION
This draft PR describes a sort of minimum viable contribution to add cursor-based pagination to Kaminari.

At present, it does satisfy a particular use case with cursor-based pagination of a sorted relation. Under the heading **Shortcomings/Opportunities** below, you will find some shortcomings that would need to be addressed before it satisfies a wider range of use cases. I welcome any feedback and guidance to make this a useful and maintainable addition to Kaminari.

## Example usage

```
users = User.order(:id)

# Get cursor at end of first page
#   [ 1 2 3 4 5 ] 6 7 8 ...
next = users.page_by_cursor.end_cursor

# Get next page
#   1 2 3 4 5 [ 6 7 8 ...
next_page = users.page_by_cursor(next)
prev = next_page.start_cursor

# Destroy 3 users from first page
#         4 5 [ 6 7 8 ...
User.destroy(1)
User.destroy(2)
User.destroy(3)

# Get previous page (now with fewer records)
#   [      4 5 ] 6 7 8 ...
users.page_by_cursor(prev)
```

## Shortcomings/Opportunities

### Relation must ordered by columns of `.model`.

Cursor pagination is only supported when the relation is ordered by columns of `.model`. For example, ordering by an association's columns is not presently supported.

### Views that support results whose bounds may frequently change are not well supported.

The primary use case has *Next* and *Prev* buttons that appear only if there are results in that direction. For example, the *Prev* button does not appear on the first page.

A contrary case would be a log viewer where logs are ordered by descending timestamp. In this case the *Next* button might be labeled "Load Newer", and the user would want the ability to click "Load Newer" even if there might not be any newer results now.

### Paging by cursor can result in a non-full page at the beginning of results.

It is not surprising when the last page of search results is not full. However, it can be surprising to leave the first page, return to it, and find a page that is not full. Strictly only showing records _before_ or _after_ a cursor can result in a non-full page. It is possible when bumping up against the ends of the recordset in one direction to requery in the other direction to produce a full page. However, this is not presently supported. 

## Design decisions

### The model's primary key is used as tie-breaker.

The cursor must be unique per record. To ensure this, the model's primary key is appended to the ordering columns.

### When added by Kaminari, the primary key order is always ascending.

For example, `Book.order(title: :asc)` and `Book.order(title: :desc)`will result in `title asc, id asc` and `title desc, id asc`, respectively. The latter results are not exactly the reverse of the former results in cases where some books have the same title.

If the primary key is explicitly included in the order, then the order will not be changed, e.g.

`Book.order(title: :asc, id: :asc)` --> `title asc, id asc`
`Book.order(title: :asc, id: :desc)` --> `title asc, id desc`

### Cursor pagination only works on relations which are ordered by the columns of `.model`.

To generate a cursor from results, the values used to order the relation must be available. In principle, any column used to order the relation can be included in the select statement. However, this implementation challenge was left for a later time.

### Page direction is embedded in the cursor.

To allow applications to page forward and backward through records using a single method and a single cursor value, I embed the page direction in the cursor, as a property named `page_direction` by default.

### The cursor is encoded json.

I initially considered the following:

```
{
    "columns": [
        {
            "name": <column name>,
            "value": <column value>,
            "dir": <asc|desc>
        }
    ],
    "page_direction": "after"
}
```

The use of a columns property allows for collision-free addition of more properties later. Using an array type captures the ordering of columns. The inclusion of the `dir` attribute allows Kaminari to enforce that a cursor used in one sort direction is only used for that sort direction.

I decided that enforcing a cursor is only used in a particular sort direction was needless rigor. I decided that the columns property also did not need to be an array to capture column order. This led me to fall back on a simple object whose keys and values are the column names and column values, respectively, e.g.

```
{
    "title": "clean code",
    "id": 9102,
    "page_direction": "after"
}
```

The exception is `page_direction`, an attribute whose name can be reconfigured if the name is already taken by a column.

### The cursor uses base64 encoding.

This provides nominal obfuscation of the cursor. **Any data used to sort the records will be present in the easily-decoded cursor.** It would be possible for an application to encrypt cursors if needed.

### Differentiated methods are available to explicitly page before or after.

Methods `page_before` and `page_after` are provided to page in a particular direction.

### The database-defined ordering of null-valued records is respected.

Null values do not have a natural ordering in SQL. RDBMS differ in whether they treat null as low or high in comparison. SQL of course also defines any comparison involving a null value as false. A simple cursor-based filter for non-nullable values could work merely by using `=`, `<`, and `>` operators to compare columns with cursor values. However, such a cursor pagination would omit records with a null value used for ordering.

For this reason, null values have to be handled specially with `is null` and `is not null` applied according to whether nulls are treated as small or large in the database. Additionally, the Postgresql order by clause optionally includes `nulls first` or `nulls last` which overrides the default ordering. This too is handled.

### An extra 'peekback' relation is created and queried to support the `first_page?` and `last_page?` properties.

When paging forward through results, the visibility of the 'next' button is determined by peeking an extra record ahead. If paging backward through results, this extra record would inform the visibility of the 'previous' button. To know whether both 'next' and 'previous' should be visible, it is required to peek in the opposite direction starting at the cursor.

This 'peekback' relation is queried at the when the cursor-paginated relation is loaded.

### The `total_count` method is not supported.

## Usage of Rails methods not part of the public API

### `order_values`

Cursor-based pagination requires filtering based on the relation's ordering. Introspection of the relation's ordering is required. I used the `order_values` attribute to get this ordering. The values in `order_values` include Arel nodes and strings, so interpretation of these into columns creates a dependency on Arel.

### Awareness of database for timestamp serialization

Serialized times in the cursor must be comparable with time-valued columns in the database query. The simplest solution would be to use the public API method `read_attribute_before_type_cast` to get the raw value directly from the database, which we would expect to include the correct precision. This works for SQLite, for which `read_attribute_before_type_cast` returns a String. However, for Postgresql, `read_attribute_before_type_cast` returns a `Time` object which is already deserialized.

Postgresql and Mysql at present support up to microsecond precision in times. We serialize times with nanosecond precision using iso8601 format.

### Awareness of database for null value ordering

As described above ("The database-defined ordering of null-valued records is respected."), Kaminari is aware of the database used for purpose of knowing whether null values are treated as low or high in ordering.