### PR TITLE
Remove deprecated usage of ActiveSupport::Deprecation singleton

### DIFF
--- a/kaminari-core/lib/generators/kaminari/views_generator.rb
+++ b/kaminari-core/lib/generators/kaminari/views_generator.rb
@@ -74,8 +74,8 @@ BANNER
         engine = options[:template_engine].try(:to_s).try(:downcase)
 
         if engine == 'haml' || engine == 'slim'
-          ActiveSupport::Deprecation.warn 'The -e option is deprecated and will be removed in the near future. Please use the html2slim gem or the html2haml gem ' \
-                                          'to convert erb templates manually.'
+          Kaminari.deprecator.warn 'The -e option is deprecated and will be removed in the near future. Please use the html2slim gem or the html2haml gem ' \
+            'to convert erb templates manually.'
         end
 
         engine || 'erb'

--- a/kaminari-core/lib/kaminari/core.rb
+++ b/kaminari-core/lib/kaminari/core.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Kaminari
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("2.0", "kaminari-core")
+  end
 end
 
 # load Rails/Railtie

--- a/kaminari-core/lib/kaminari/engine.rb
+++ b/kaminari-core/lib/kaminari/engine.rb
@@ -2,5 +2,8 @@
 
 module Kaminari #:nodoc:
   class Engine < ::Rails::Engine #:nodoc:
+    initializer :deprecator do |app|
+      app.deprecators[:kaminari] = Kaminari.deprecator if app.respond_to?(:deprecators)
+    end
   end
 end

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -44,7 +44,7 @@ module Kaminari
       alias url_to_next_page next_page_url
 
       def path_to_next_url(scope, options = {})
-        ActiveSupport::Deprecation.warn 'path_to_next_url is deprecated. Use next_page_url or url_to_next_page instead.'
+        Kaminari.deprecator.warn 'path_to_next_url is deprecated. Use next_page_url or url_to_next_page instead.'
         next_page_url(scope, options)
       end
 

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -134,7 +134,7 @@ module Kaminari
         # params in Rails 5 may not be a Hash either,
         # so it must be converted to a Hash to be merged into @params
         if params && params.respond_to?(:to_unsafe_h)
-          ActiveSupport::Deprecation.warn 'Explicitly passing params to helpers could be omitted.'
+          Kaminari.deprecator.warn 'Explicitly passing params to helpers could be omitted.'
           params = params.to_unsafe_h
         end
 
@@ -155,7 +155,7 @@ module Kaminari
         # params in Rails 5 may not be a Hash either,
         # so it must be converted to a Hash to be merged into @params
         if params && params.respond_to?(:to_unsafe_h)
-          ActiveSupport::Deprecation.warn 'Explicitly passing params to helpers could be omitted.'
+          Kaminari.deprecator.warn 'Explicitly passing params to helpers could be omitted.'
           params = params.to_unsafe_h
         end
 

--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -52,7 +52,7 @@ module Kaminari
       end
 
       def max_pages_per(val)
-        ActiveSupport::Deprecation.warn 'max_pages_per is deprecated. Use max_pages instead.'
+        Kaminari.deprecator.warn 'max_pages_per is deprecated. Use max_pages instead.'
         max_pages val
       end
     end

--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -56,8 +56,8 @@ module Kaminari
 
     # Current per-page number
     def current_per_page
-      ActiveSupport::Deprecation.warn '#current_per_page is deprecated and will be removed in the next major ' \
-                                      'version. Please use #limit_value instead.'
+      Kaminari.deprecator.warn '#current_per_page is deprecated and will be removed in the next major ' \
+        'version. Please use #limit_value instead.'
 
       limit_value
       # (defined?(@_per) && @_per) || default_per_page


### PR DESCRIPTION
Rails 7.1 will deprecate usage of the ActiveSupport::Deprecation singleton (calling `warn`, `silence`, etc. directly on it) (see https://github.com/rails/rails/pull/47354).

This PR defines an instance of `ActiveSupport::Deprecation` for the gem and uses it.

It's also added to the application's set of deprecators, allowing it to be configured along all the other deprecators.