### PR TITLE
fix: Handle allowed engines

### DIFF
--- a/kaminari-core/lib/generators/kaminari/views_generator.rb
+++ b/kaminari-core/lib/generators/kaminari/views_generator.rb
@@ -80,7 +80,7 @@ BANNER
             'to convert erb templates manually.'
         end
 
-        engine || 'erb'
+        %w[erb haml slim].include?(engine) ? engine : 'erb'
       end
     end
 


### PR DESCRIPTION
## Overview

Closes #1071 

Currently if you're using tailwindcss with rails, it will bypass this field as `tailwindcss`.

Adding a small validation to ensure only allowed engines can be handled.

## Fixed behaviour

```bash
# in rails project with tailwindcss
$ rails g kaminari:views default

      create  app/views/kaminari/_first_page.html.erb
      create  app/views/kaminari/_gap.html.erb
      create  app/views/kaminari/_last_page.html.erb
      create  app/views/kaminari/_next_page.html.erb
      create  app/views/kaminari/_page.html.erb
      create  app/views/kaminari/_paginator.html.erb
      create  app/views/kaminari/_prev_page.html.erb

$ rails d kaminari:views default

      remove  app/views/kaminari/_first_page.html.erb
      remove  app/views/kaminari/_gap.html.erb
      remove  app/views/kaminari/_last_page.html.erb
      remove  app/views/kaminari/_next_page.html.erb
      remove  app/views/kaminari/_page.html.erb
      remove  app/views/kaminari/_paginator.html.erb
      remove  app/views/kaminari/_prev_page.html.erb


```