### PR TITLE
Optimize page_entries_info a bit by reusing local variables

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -199,17 +199,18 @@ module Kaminari
       #   <%= page_entries_info @posts, entry_name: 'item' %>
       #   #-> Displaying items 6 - 10 of 26 in total
       def page_entries_info(collection, entry_name: nil)
+        page_size = (collection.respond_to?(:records) ? collection.records : collection.to_a).size
         entry_name = if entry_name
-                       entry_name.pluralize(collection.size, I18n.locale)
+                       entry_name.pluralize(page_size, I18n.locale)
                      else
-                       collection.entry_name(count: collection.size).downcase
+                       collection.entry_name(count: page_size).downcase
                      end
 
         if collection.total_pages < 2
           t('helpers.page_entries_info.one_page.display_entries', entry_name: entry_name, count: collection.total_count)
         else
           from = collection.offset_value + 1
-          to   = collection.offset_value + (collection.respond_to?(:records) ? collection.records : collection.to_a).size
+          to   = collection.offset_value + page_size
 
           t('helpers.page_entries_info.more_pages.display_entries', entry_name: entry_name, first: from, last: to, total: collection.total_count)
         end.html_safe


### PR DESCRIPTION
The entry_name local variable uses collection.size to pluralize the name. This value is calculated in all cases. The size of the collection is reused later to calculate the `to` local variable (the final entry on the page).

By reusing this calculated value, we cut down on database round trips. When the collection query is very expensive, running it twice can cause a large page slowdown.