### PR TITLE
'data-turbo-action': 'advance' 

### DIFF
--- a/kaminari-core/app/views/kaminari/_first_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, 'data-turbo-action': 'advance' %>
 </span>

--- a/kaminari-core/app/views/kaminari/_first_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_first_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.first
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, 'data-turbo-action': 'advance'

--- a/kaminari-core/app/views/kaminari/_first_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_first_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, 'data-turbo-action': 'advance'
 '

--- a/kaminari-core/app/views/kaminari/_last_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, 'data-turbo-action': 'advance' %>
 </span>

--- a/kaminari-core/app/views/kaminari/_last_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, 'data-turbo-action': 'advance'

--- a/kaminari-core/app/views/kaminari/_last_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, 'data-turbo-action': 'advance'
 '

--- a/kaminari-core/app/views/kaminari/_next_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, 'data-turbo-action': 'advance' %>
 </span>

--- a/kaminari-core/app/views/kaminari/_next_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, 'data-turbo-action': 'advance'

--- a/kaminari-core/app/views/kaminari/_next_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_next_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.next
-  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, 'data-turbo-action': 'advance'
 '

--- a/kaminari-core/app/views/kaminari/_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_page.html.erb
@@ -8,5 +8,5 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}, 'data-turbo-action': 'advance' %>
 </span>

--- a/kaminari-core/app/views/kaminari/_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_page.html.haml
@@ -7,4 +7,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span{class: "page#{' current' if page.current?}"}
-  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}, 'data-turbo-action': 'advance'

--- a/kaminari-core/app/views/kaminari/_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_page.html.slim
@@ -7,5 +7,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span class="page#{' current' if page.current?}"
-  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}
+  == link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}, 'data-turbo-action': 'advance'
 '

--- a/kaminari-core/app/views/kaminari/_prev_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, 'data-turbo-action': 'advance' %>
 </span>

--- a/kaminari-core/app/views/kaminari/_prev_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.prev
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, 'data-turbo-action': 'advance'

--- a/kaminari-core/app/views/kaminari/_prev_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.prev
-  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, 'data-turbo-action': 'advance'
 '

--- a/kaminari-core/lib/kaminari/helpers/paginator.rb
+++ b/kaminari-core/lib/kaminari/helpers/paginator.rb
@@ -74,7 +74,7 @@ module Kaminari
 
       def to_s #:nodoc:
         Thread.current[:kaminari_rendering] = true
-        super @window_options.merge paginator: self
+        super @window_options.merge(paginator: self)
       ensure
         Thread.current[:kaminari_rendering] = false
       end

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -20,7 +20,6 @@ module Kaminari
       def initialize(template, params: nil, param_name: nil, theme: nil, views_prefix: nil, internal_params: nil, **options) #:nodoc:
         @template, @theme, @views_prefix, @options = template, theme, views_prefix, options
         @param_name = param_name || Kaminari.config.param_name
-
         if internal_params
           @params = internal_params
         else


### PR DESCRIPTION
fixes all templates to include  'data-turbo-action': 'advance' for all links

this fixes the browser history behavior when using Turbo (Rails 7) with kaminari pagination