### PR TITLE
Add Jets Support

### DIFF
--- a/kaminari-core/lib/kaminari/core.rb
+++ b/kaminari-core/lib/kaminari/core.rb
@@ -11,7 +11,7 @@ begin
   require 'rails'
 rescue LoadError
   #do nothing
-end
+end unless defined?(::Jets::Turbine)
 
 # load Kaminari components
 require 'kaminari/config'
@@ -25,4 +25,9 @@ require 'kaminari/models/array_extension'
 if defined? ::Rails::Railtie
   require 'kaminari/railtie'
   require 'kaminari/engine'
+end
+
+if defined? ::Jets::Turbine
+  require 'kaminari/jets/turbine'
+  require 'kaminari/jets/engine'
 end

--- a/kaminari-core/lib/kaminari/jets/engine.rb
+++ b/kaminari-core/lib/kaminari/jets/engine.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Kaminari #:nodoc:
+  class Engine < ::Jets::Engine #:nodoc:
+  end
+end

--- a/kaminari-core/lib/kaminari/jets/turbine.rb
+++ b/kaminari-core/lib/kaminari/jets/turbine.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Kaminari
+  class Turbine < ::Jets::Turbine #:nodoc:
+    # Doesn't actually do anything. Just keeping this hook point, mainly for compatibility
+    initializer 'kaminari' do
+    end
+  end
+end


### PR DESCRIPTION
Intro: [Ruby on Jets](https://rubyonjets.com/) is a Serverless Framework. 

This PR adds Jets support to kaminari.

Note, when the Rails constant is defined, it prevents the library from being used with Jets.  TLDR: When the Rails constant is defined it loads rails specific code in gem libraries and plugins, which makes it not possible to then use the gem also be used by Jets. Here's a longer explanation: https://community.boltops.com/t/why-does-jets-define-rails-module/29/5

This PR:

* Won't try to require rails when the Jets constant is defined
* Adds a Jets Turbine, which is like a Railtie, that registers the plugin with the Jets Framework.

This would spare the need for this forked gem [kaminari-jets](https://github.com/rubyonjets/kaminari-jets)

Thanks for considering this PR. No sweat either way of course. 👍
