### PR TITLE
Support Ruby 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The pagination helper outputs the HTML5 `<nav>` tag by default. Plus, the helper
 
 ## Supported Versions
 
-* Ruby 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2
+* Ruby 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3
 
 * Rails 4.1, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1
 


### PR DESCRIPTION
[this commit](https://github.com/kaminari/kaminari/commit/554f588cb54736d014099d2be60e6d41b3c93838) supports Ruby 3.3, so I update supported versions in README.