### PR TITLE
Adding paginated? helper to active record extensions and page scope methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ User.page(2).prev_page         #=> 1
 User.page(1).first_page?       #=> true
 User.page(50).last_page?       #=> true
 User.page(100).out_of_range?   #=> true
+User.all.paginated?            #=> false
+User.page(1).paginated?        #=> true
 ```
 
 ### The `per` Scope

--- a/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
+++ b/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb
@@ -9,6 +9,10 @@ module Kaminari
     included do
       include Kaminari::ConfigurationMethods
 
+      def self.paginated?
+        false
+      end
+
       # Fetch the values at the specified page number
       #   Model.page(5)
       eval <<-RUBY, nil, __FILE__, __LINE__ + 1

--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -87,5 +87,9 @@ module Kaminari
     def out_of_range?
       current_page > total_pages
     end
+
+    def paginated?
+      limit_value.present?
+    end
   end
 end

--- a/kaminari-core/test/models/active_record/scopes_test.rb
+++ b/kaminari-core/test/models/active_record/scopes_test.rb
@@ -378,6 +378,20 @@ if defined? ActiveRecord
           end
         end
 
+        sub_test_case '#paginated?' do
+          test 'before calling page' do
+            assert_false model_class.paginated?
+          end
+
+          test 'after calling page' do
+            assert_true model_class.page(1).paginated?
+          end
+
+          test 'after calling page and unscoping limit' do
+            assert_false model_class.page(1).unscope(:limit).paginated?
+          end
+        end
+
         sub_test_case '#count' do
           test 'page 1' do
             assert_equal 25, model_class.page.count


### PR DESCRIPTION
# Main Purpose
Adding a `paginated?` helper to PageScopeMethods and AR extensions.

# Context
Lately I found myself implementing a `See All` option in a few pages. As expected I had to find a way to conditionally render `paginate` section leading to conditions on views as `relation.respond_to?(:total_pages)` or `relation.limit_value.present?`.
That was the moment when the `paginated?` helper came to my mind, a simple and clean method to achieve this check.

# Changes
- adding `paginated?` with default value false to AR relations to have it available even if pagination method wasn't called
- defining `paginated?` on PageScopeMethods relying on `limit_value` (this way we ensure the helper being true just when the pagination method is called and include support to possible `unscope` calls too)
- added tests ✅ 
- updated README


On a separated note: contributions section on README should be updated, current lines described there to run specs are relying on removed `gemfiles/*`