### PR TITLE
Exclude path_params from page_url_for params keys

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -2,7 +2,7 @@
 
 module Kaminari
   module Helpers
-    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name].freeze
+    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name, :path_params].freeze
 
     # A tag stands for an HTML tag inside the paginator.
     # Basically, a tag has its own partial template file, so every tag can be

--- a/kaminari-core/test/helpers/helpers_test.rb
+++ b/kaminari-core/test/helpers/helpers_test.rb
@@ -44,6 +44,14 @@ class PaginatorHelperTest < ActiveSupport::TestCase
 
       assert_equal({'controller' => 'foo', 'action' => 'bar'}, @paginator.page_tag(template).instance_variable_get('@params'))
     end
+
+    test 'when params has special path_params key' do
+      stub(template).params do
+        {path_params: 'exclude'}
+      end
+
+      assert_equal({'controller' => 'foo', 'action' => 'bar'}, @paginator.page_tag(template).instance_variable_get('@params'))
+    end
   end
 
   test '#param_name' do


### PR DESCRIPTION
It is possible to add `path_params=val` to the url and cause 500 errors when [this code is invoked by kaminari](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/journey/formatter.rb#L62-L66). Exclude it from params to avoid this problem.

I thought about trying to patch this in rails, but I think passing all of `@params` to url_for is not happening regularly. Let me know if you disagree.

EDIT: It would seem it is not currently possible to control the params that are passed to `url_for`. Passing `params:` to paginate only adds to the params instead of replacing them. This means the solution requires altering the global `params` as in https://github.com/rubygems/rubygems.org/pull/4580.