### PR TITLE
Add Safe HTML i18n Translations

### DIFF
--- a/kaminari-core/app/views/kaminari/_first_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_first_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="first">
-  <%= link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote %>
+  <%= link_to_unless current_page.first?, t('views.pagination.first_html'), url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_first_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_first_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.first
-  = link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.first_html'), url, remote: remote

--- a/kaminari-core/app/views/kaminari/_first_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_first_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.first
-  = link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  = link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote

--- a/kaminari-core/app/views/kaminari/_first_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_first_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.first
-  == link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote
+  == link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_first_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_first_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.first
-  == link_to_unless current_page.first?, sanitize(t('views.pagination.first')), url, remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.first_html'), url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_gap.html.erb
+++ b/kaminari-core/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= sanitize(t('views.pagination.truncate')) %></span>
+<span class="page gap"><%= t('views.pagination.truncate_html') %></span>

--- a/kaminari-core/app/views/kaminari/_gap.html.erb
+++ b/kaminari-core/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="page gap"><%= sanitize(t('views.pagination.truncate')) %></span>

--- a/kaminari-core/app/views/kaminari/_gap.html.haml
+++ b/kaminari-core/app/views/kaminari/_gap.html.haml
@@ -5,4 +5,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.page.gap
-  = t('views.pagination.truncate').html_safe
+  = sanitize(t('views.pagination.truncate'))

--- a/kaminari-core/app/views/kaminari/_gap.html.haml
+++ b/kaminari-core/app/views/kaminari/_gap.html.haml
@@ -5,4 +5,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.page.gap
-  = sanitize(t('views.pagination.truncate'))
+  = t('views.pagination.truncate_html')

--- a/kaminari-core/app/views/kaminari/_gap.html.slim
+++ b/kaminari-core/app/views/kaminari/_gap.html.slim
@@ -5,5 +5,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.page.gap
-  == t('views.pagination.truncate').html_safe
+  == sanitize(t('views.pagination.truncate'))
 '

--- a/kaminari-core/app/views/kaminari/_gap.html.slim
+++ b/kaminari-core/app/views/kaminari/_gap.html.slim
@@ -5,5 +5,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.page.gap
-  == sanitize(t('views.pagination.truncate'))
+  == t('views.pagination.truncate_html')
 '

--- a/kaminari-core/app/views/kaminari/_last_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.last_html'), url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_last_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+  <%= link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_last_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  = link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote

--- a/kaminari-core/app/views/kaminari/_last_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_last_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.last
-  = link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.last_html'), url, remote: remote

--- a/kaminari-core/app/views/kaminari/_last_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-  == link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.last_html'), url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_last_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_last_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.last
-  == link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote
+  == link_to_unless current_page.last?, sanitize(t('views.pagination.last')), url, remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_next_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next_html'), url, rel: 'next', remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_next_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+  <%= link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_next_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  = link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote

--- a/kaminari-core/app/views/kaminari/_next_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote
+  = link_to_unless current_page.last?, t('views.pagination.next_html'), url, rel: 'next', remote: remote

--- a/kaminari-core/app/views/kaminari/_next_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_next_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.next
-  == link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote
+  == link_to_unless current_page.last?, t('views.pagination.next_html'), url, rel: 'next', remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_next_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_next_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.next
-  == link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote
+  == link_to_unless current_page.last?, sanitize(t('views.pagination.next')), url, rel: 'next', remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_prev_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?,t('views.pagination.previous_html'), url, rel: 'prev', remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_prev_page.html.erb
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+  <%= link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote %>
 </span>

--- a/kaminari-core/app/views/kaminari/_prev_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.prev
-  = link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote
+  = link_to_unless current_page.first?, t('views.pagination.previous_html'), url, rel: 'prev', remote: remote

--- a/kaminari-core/app/views/kaminari/_prev_page.html.haml
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.prev
-  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  = link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote

--- a/kaminari-core/app/views/kaminari/_prev_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.prev
-  == link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote
+  == link_to_unless current_page.first?, t('views.pagination.previous_html'), url, rel: 'prev', remote: remote
 '

--- a/kaminari-core/app/views/kaminari/_prev_page.html.slim
+++ b/kaminari-core/app/views/kaminari/_prev_page.html.slim
@@ -6,5 +6,5 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 span.prev
-  == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote
+  == link_to_unless current_page.first?, sanitize(t('views.pagination.previous')), url, rel: 'prev', remote: remote
 '

--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -3,11 +3,11 @@
 en:
   views:
     pagination:
-      first: "&laquo; First"
-      last: "Last &raquo;"
-      previous: "&lsaquo; Prev"
-      next: "Next &rsaquo;"
-      truncate: "&hellip;"
+      first_html: "&laquo; First"
+      last_html: "Last &raquo;"
+      previous_html: "&lsaquo; Prev"
+      next_html: "Next &rsaquo;"
+      truncate_html: "&hellip;"
   helpers:
     page_entries_info:
       entry:
@@ -17,7 +17,7 @@ en:
       one_page:
         display_entries:
           zero: "No %{entry_name} found"
-          one: "Displaying <b>1</b> %{entry_name}"
-          other: "Displaying <b>all %{count}</b> %{entry_name}"
+          one_html: "Displaying <b>1</b> %{entry_name}"
+          other_html: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
-        display_entries: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
+        display_entries_html: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"

--- a/kaminari-core/config/locales/kaminari.yml
+++ b/kaminari-core/config/locales/kaminari.yml
@@ -17,7 +17,7 @@ en:
       one_page:
         display_entries:
           zero: "No %{entry_name} found"
-          one_html: "Displaying <b>1</b> %{entry_name}"
-          other_html: "Displaying <b>all %{count}</b> %{entry_name}"
+          one: "Displaying <b>1</b> %{entry_name}"
+          other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
         display_entries_html: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -208,7 +208,7 @@ module Kaminari
                      end
 
         if collection.total_pages < 2
-          t('helpers.page_entries_info.one_page.display_entries_html', entry_name: entry_name, count: collection.total_count)
+          t('helpers.page_entries_info.one_page.display_entries', entry_name: entry_name, count: collection.total_count)
         else
           from = collection.offset_value + 1
           to =

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -208,7 +208,7 @@ module Kaminari
                      end
 
         if collection.total_pages < 2
-          t('helpers.page_entries_info.one_page.display_entries', entry_name: entry_name, count: collection.total_count)
+          t('helpers.page_entries_info.one_page.display_entries_html', entry_name: entry_name, count: collection.total_count)
         else
           from = collection.offset_value + 1
           to =
@@ -218,8 +218,8 @@ module Kaminari
               collection.offset_value + page_size
             end
 
-          t('helpers.page_entries_info.more_pages.display_entries', entry_name: entry_name, first: from, last: to, total: collection.total_count)
-        end.html_safe
+          t('helpers.page_entries_info.more_pages.display_entries_html', entry_name: entry_name, first: from, last: to, total: collection.total_count)
+        end
       end
 
       # Renders rel="next" and rel="prev" links to be used in the head.

--- a/kaminari-core/test/helpers/action_view_extension_test.rb
+++ b/kaminari-core/test/helpers/action_view_extension_test.rb
@@ -333,7 +333,7 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
                       }
                     },
                     more_pages: {
-                      display_entries: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
+                      display_entries_html: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
                     }
                   }
                 }
@@ -369,7 +369,7 @@ if defined?(::Rails::Railtie) && defined?(::ActionView)
                     }
                   },
                   more_pages: {
-                    display_entries: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
+                    display_entries_html: "Displaying %{entry_name} <b>%{first}–%{last}</b> of <b>%{total}</b> in total"
                   }
                 }
               }


### PR DESCRIPTION
I was in the middle of doing a Rails project and overriding the default template. I did some ERB linting and the suite told me the following message:

```
erb interpolation with '<%= (...).html_safe %>' in this context is never safe
In file: app/views/kaminari/_first_page.html.erb:10
```

My original expectation for this request was to be sanitized, but it isn't. I ended up by fixing the view code to use the `sanitize(...)` method to prevent potential XSS attacks. It allows the method to properly read the characters in a sanitized context.

Let me know if you have any questions for me.