### PR TITLE
Update documentation around ajax links

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ This would modify the query parameter name on each links.
 
 This would modify each link's `url_option`. `:controller` and `:action` might be the keys in common.
 
-### Ajax Links (crazy simple, but works perfectly!)
+### Ajax Links (via rails-ujs, works with Rails < 7.2)
 
 ```erb
 <%= paginate @users, remote: true %>


### PR DESCRIPTION
Explain that it's related to rails-ujs and not available in Rails 7.2+

See #1129 