### PR TITLE
change calls to deprecator.warn to notify

### DIFF
--- a/kaminari-core/lib/generators/kaminari/views_generator.rb
+++ b/kaminari-core/lib/generators/kaminari/views_generator.rb
@@ -76,7 +76,7 @@ BANNER
         engine = options[:template_engine].try(:to_s).try(:downcase)
 
         if engine == 'haml' || engine == 'slim'
-          Kaminari.deprecator.warn 'The -e option is deprecated and will be removed in the near future. Please use the html2slim gem or the html2haml gem ' \
+          Kaminari.deprecator.notify 'The -e option is deprecated and will be removed in the near future. Please use the html2slim gem or the html2haml gem ' \
             'to convert erb templates manually.'
         end
 

--- a/kaminari-core/lib/kaminari/helpers/helper_methods.rb
+++ b/kaminari-core/lib/kaminari/helpers/helper_methods.rb
@@ -44,7 +44,7 @@ module Kaminari
       alias url_to_next_page next_page_url
 
       def path_to_next_url(scope, options = {})
-        Kaminari.deprecator.warn 'path_to_next_url is deprecated. Use next_page_url or url_to_next_page instead.'
+        Kaminari.deprecator.notify 'path_to_next_url is deprecated. Use next_page_url or url_to_next_page instead.'
         next_page_url(scope, options)
       end
 

--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -134,7 +134,7 @@ module Kaminari
         # params in Rails 5 may not be a Hash either,
         # so it must be converted to a Hash to be merged into @params
         if params && params.respond_to?(:to_unsafe_h)
-          Kaminari.deprecator.warn 'Explicitly passing params to helpers could be omitted.'
+          Kaminari.deprecator.notify 'Explicitly passing params to helpers could be omitted.'
           params = params.to_unsafe_h
         end
 

--- a/kaminari-core/lib/kaminari/models/configuration_methods.rb
+++ b/kaminari-core/lib/kaminari/models/configuration_methods.rb
@@ -52,7 +52,7 @@ module Kaminari
       end
 
       def max_pages_per(val)
-        Kaminari.deprecator.warn 'max_pages_per is deprecated. Use max_pages instead.'
+        Kaminari.deprecator.notify 'max_pages_per is deprecated. Use max_pages instead.'
         max_pages val
       end
     end

--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -56,7 +56,7 @@ module Kaminari
 
     # Current per-page number
     def current_per_page
-      Kaminari.deprecator.warn '#current_per_page is deprecated and will be removed in the next major ' \
+      Kaminari.deprecator.notify '#current_per_page is deprecated and will be removed in the next major ' \
         'version. Please use #limit_value instead.'
 
       limit_value


### PR DESCRIPTION
Rails 7.2 has removed ActiveSupport::Deprecator.warn