### PR TITLE
limit-unzero-bugfix

### DIFF
--- a/kaminari-core/lib/kaminari/models/page_scope_methods.rb
+++ b/kaminari-core/lib/kaminari/models/page_scope_methods.rb
@@ -11,10 +11,16 @@ module Kaminari
         self
       elsif n.zero?
         limit(n)
-      elsif max_per_page && (max_per_page < n)
-        limit(max_per_page).offset(offset_value / limit_value * max_per_page)
       else
-        limit(n).offset(offset_value / limit_value * n)
+        if max_per_page && (max_per_page < n)
+          n = max_per_page
+        end
+
+        if limit_value.zero?
+          limit(n).offset(0)
+        else
+          limit(n).offset(offset_value / limit_value * n)
+        end
       end
     end
 

--- a/kaminari-core/test/models/array_test.rb
+++ b/kaminari-core/test/models/array_test.rb
@@ -197,4 +197,13 @@ class PaginatableArrayTest < ActiveSupport::TestCase
       assert_equal 15, arr.total_count
     end
   end
+
+  test 'limit un-zeroed' do
+    arr = Kaminari::PaginatableArray.new([]).page(1).per(0).per(10)
+
+    assert_equal 0, arr.count
+    assert_equal 0, arr.total_count
+    assert_equal 1, arr.current_page
+    assert_equal 0, arr.total_pages
+  end
 end


### PR DESCRIPTION
I stumbled upon a corner case where Kaminari explodes with a `divided by 0` error and wanted to offer a fix.  The usage is a little contrived / self inflicted, but kaminari should probably be more resilient to user silliness.

Repro:
```ruby
Kaminari::PaginatableArray.new([]).page(n).per(0).per(3)
# kaminari-core/lib/kaminari/models/page_scope_methods.rb:17:in `/': divided by 0 (ZeroDivisionError)

# or

Model.page(n).per(0).per(3)
# kaminari-core/lib/kaminari/models/page_scope_methods.rb:17:in `/': divided by 0 (ZeroDivisionError)
```

the issue arises because in `.per`, this library uses `limit_value` to recalculate the new offset value.  but if `limit_value` is 0, it explodes.  It's unclear what the offset should be set to (since we don't store page number, only offset), but resetting to 0 seemed sane.

Open to a bugfix?