### PR TITLE
Use Ubuntu 24.04 LTS for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
       POSTGRES_PASSWORD: postgres  # for passing the password to the Rails process
       MYSQL_PASSWORD: root  # for passing the password to the Rails process
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub has retired 20.04 LTS in the hosted Actions runner. This change will allow to continue running CI tests for few more years.

Closes #1142