### PR TITLE
Fix UrlGenerationError with route constraints on Rails 8+

### DIFF
--- a/kaminari-core/lib/kaminari/helpers/tags.rb
+++ b/kaminari-core/lib/kaminari/helpers/tags.rb
@@ -2,7 +2,8 @@
 
 module Kaminari
   module Helpers
-    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name].freeze
+    PARAM_KEY_EXCEPT_LIST = [:authenticity_token, :commit, :utf8, :_method, :script_name, :original_script_name,
+                             :subdomain, :domain, :host, :port, :protocol, :anchor, :trailing_slash, :path_params].freeze
 
     # A tag stands for an HTML tag inside the paginator.
     # Basically, a tag has its own partial template file, so every tag can be

--- a/kaminari-core/test/helpers/helpers_test.rb
+++ b/kaminari-core/test/helpers/helpers_test.rb
@@ -44,6 +44,19 @@ class PaginatorHelperTest < ActiveSupport::TestCase
 
       assert_equal({'controller' => 'foo', 'action' => 'bar'}, @paginator.page_tag(template).instance_variable_get('@params'))
     end
+
+    test 'page_url_for excludes route constraint params' do
+      tmpl = template
+      stub(tmpl).params { {controller: 'foo', action: 'bar', subdomain: 'admin', domain: 'example.com'} }
+      stub(tmpl).url_for {|h| h.to_query }
+
+      paginator = Paginator.new(tmpl, params: {})
+      url = paginator.page_tag(tmpl).page_url_for(2)
+
+      assert_match(/page=2/, url)
+      assert_no_match(/subdomain/, url)
+      assert_no_match(/domain/, url)
+    end
   end
 
   test '#param_name' do


### PR DESCRIPTION
Strip route-constraint keys (`subdomain`, `domain`, `host`, `port`, `protocol`, `anchor`, `trailing_slash`, `path_params`) and nil values from the params hash in `page_url_for` so they don't leak into `url_for` and trigger `ActionController::UrlGenerationError` on Rails 8+.

Related: #1123